### PR TITLE
Add mi-extraction identity yamls for test and stg

### DIFF
--- a/k8s/stg/releases/mi/mi-extraction-service-identity.yaml
+++ b/k8s/stg/releases/mi/mi-extraction-service-identity.yaml
@@ -1,0 +1,20 @@
+apiVersion: "aadpodidentity.k8s.io/v1"
+kind: AzureIdentity
+metadata:
+ name: mi-extraction-service
+ namespace: mi
+spec:
+ type: 0
+ ResourceID: /subscriptions/74dacd4f-a248-45bb-a2f0-af700dc4cf68/resourceGroups/mi-stg-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-extraction-service-stg-mi
+ ClientID: 88d54b96-2be6-4fb5-b966-7d98111152d8
+
+---
+
+apiVersion: "aadpodidentity.k8s.io/v1"
+kind: AzureIdentityBinding
+metadata:
+  name: mi-extraction-service
+  namespace: mi
+spec:
+  AzureIdentity: mi-extraction-service
+  Selector: mi-extraction-service

--- a/k8s/test/releases/mi/mi-extraction-service-identity.yaml
+++ b/k8s/test/releases/mi/mi-extraction-service-identity.yaml
@@ -1,0 +1,20 @@
+apiVersion: "aadpodidentity.k8s.io/v1"
+kind: AzureIdentity
+metadata:
+ name: mi-extraction-service
+ namespace: mi
+spec:
+ type: 0
+ ResourceID: /subscriptions/3eec5bde-7feb-4566-bfb6-805df6e10b90/resourceGroups/mi-test-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-extraction-service-test-mi
+ ClientID: 58ed3fc0-18be-4a6f-8ceb-14768c8e796a
+
+---
+
+apiVersion: "aadpodidentity.k8s.io/v1"
+kind: AzureIdentityBinding
+metadata:
+  name: mi-extraction-service
+  namespace: mi
+spec:
+  AzureIdentity: mi-extraction-service
+  Selector: mi-extraction-service


### PR DESCRIPTION
### JIRA link (if applicable) ###



### Change description ###

Add pod identity binding yamls for mi-extraction service on test and stg.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
