### PR TITLE
Patch - correct AZDO url

### DIFF
--- a/k8s/environments/sbox/common/hmi/az-devops-agent.yaml
+++ b/k8s/environments/sbox/common/hmi/az-devops-agent.yaml
@@ -15,6 +15,6 @@ spec:
     ref: master
   values:
     env:
-      AZP_URL: "https://dev.azure.com/hmcts/Shared%20Services"
+      AZP_URL: "https://dev.azure.com/hmcts"
       AZP_POOL: "hmi-pool"
       AZP_WORK: "_work"


### PR DESCRIPTION
### Change description ###
removed project from azure devops url, as it only needs to point to organisation and pool, not project