### PR TITLE
rollout CSI driver to all non prod AKS cluster

### DIFF
--- a/k8s/environments/dev/cluster-00-overlay/kustomization.yaml
+++ b/k8s/environments/dev/cluster-00-overlay/kustomization.yaml
@@ -4,6 +4,7 @@ bases:
 - ../../../release/admin/kube-slack
 - ../../../release/admin/traefik
 - ../../../release/admin/kured
+- ../../../release/admin/secrets-csi-driver
 # - ../../../release/admin/env-injector
 # - ../../../release/kube-system/nodelocaldns
 
@@ -17,6 +18,9 @@ patchesStrategicMerge:
 
 #kured patch
 - ../../../release/admin/kured/patches/dev/cluster-00/kured.yaml
+
+#secrets-csi-driver patch
+- ../../../release/admin/secrets-csi-driver/patches/dev/cluster-00/secrets-csi-driver.yaml
 
 # env-injector
 # - ../../../release/admin/env-injector/patches/dev/cluster-00/env-injector.yaml

--- a/k8s/environments/ithc/cluster-00-overlay/kustomization.yaml
+++ b/k8s/environments/ithc/cluster-00-overlay/kustomization.yaml
@@ -4,6 +4,7 @@ bases:
 - ../../../release/admin/kube-slack
 - ../../../release/admin/traefik
 - ../../../release/admin/kured
+- ../../../release/admin/secrets-csi-driver
 # - ../../../release/admin/env-injector
 # - ../../../release/kube-system/nodelocaldns
 
@@ -17,6 +18,9 @@ patchesStrategicMerge:
 
 #kured patch
 - ../../../release/admin/kured/patches/ithc/cluster-00/kured.yaml
+
+#secrets-csi-driver patch
+- ../../../release/admin/secrets-csi-driver/patches/ithc/cluster-00/secrets-csi-driver.yaml
 
 # env-injector
 # - ../../../release/admin/env-injector/patches/ithc/cluster-00/env-injector.yaml

--- a/k8s/environments/test/cluster-00-overlay/kustomization.yaml
+++ b/k8s/environments/test/cluster-00-overlay/kustomization.yaml
@@ -5,6 +5,7 @@ bases:
 - ../../../release/admin/traefik
 - ../../../release/admin/kured
 - ../../../release/admin/keyvault-flexvol
+- ../../../release/admin/secrets-csi-driver
 # - ../../../release/admin/env-injector
 # - ../../../release/kube-system/nodelocaldns
 
@@ -18,6 +19,9 @@ patchesStrategicMerge:
 
 #kured patch
 - ../../../release/admin/kured/patches/test/cluster-00/kured.yaml
+
+#secrets-csi-driver patch
+- ../../../release/admin/secrets-csi-driver/patches/test/cluster-00/secrets-csi-driver.yaml
 
 # env-injector
 # - ../../../release/admin/env-injector/patches/test/cluster-00/env-injector.yaml

--- a/k8s/release/admin/secrets-csi-driver/patches/dev/cluster-00/secrets-csi-driver.yaml
+++ b/k8s/release/admin/secrets-csi-driver/patches/dev/cluster-00/secrets-csi-driver.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: csi-secrets-store-provider-azure
+  namespace: admin
+spec:
+  values:
+    secrets-store-csi-driver:
+      linux:
+        metricsAddr: ":8090"

--- a/k8s/release/admin/secrets-csi-driver/patches/ithc/cluster-00/secrets-csi-driver.yaml
+++ b/k8s/release/admin/secrets-csi-driver/patches/ithc/cluster-00/secrets-csi-driver.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: csi-secrets-store-provider-azure
+  namespace: admin
+spec:
+  values:
+    secrets-store-csi-driver:
+      linux:
+        metricsAddr: ":8090"

--- a/k8s/release/admin/secrets-csi-driver/patches/test/cluster-00/secrets-csi-driver.yaml
+++ b/k8s/release/admin/secrets-csi-driver/patches/test/cluster-00/secrets-csi-driver.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: csi-secrets-store-provider-azure
+  namespace: admin
+spec:
+  values:
+    secrets-store-csi-driver:
+      linux:
+        metricsAddr: ":8090"


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/RDO-9323

This change has already been tested in sbox cluster and rollsout AKS CSI Driver for mounting vault secrets in AKs across all non production AKS clusters 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
