### PR TITLE
updated the configs for traefik prometheus metrics

### DIFF
--- a/k8s/release/admin/traefik/patches/dev/cluster-00/traefik.yaml
+++ b/k8s/release/admin/traefik/patches/dev/cluster-00/traefik.yaml
@@ -16,4 +16,20 @@ spec:
     ssl:
       generateTLS: true
       defaultCN: "*.ss-service.core-compute-dev.internal"
+    metrics:
+      prometheus:
+        enabled: true
+        buckets: [0.1,0.3,1.2,5]
+        service:
+          # Set a custom service name
+          name:
+            traefik-metrics
+          annotations:
+            prometheus.io/scrape: "true"
+          port: 9100
+          type: ClusterIP
+    deployment:
+      podAnnotations:
+        prometheus.io/port: "9100"
+        prometheus.io/scrape: "true"
 

--- a/k8s/release/admin/traefik/patches/dev/cluster-01/traefik.yaml
+++ b/k8s/release/admin/traefik/patches/dev/cluster-01/traefik.yaml
@@ -18,4 +18,20 @@ spec:
     ssl:
       generateTLS: true
       defaultCN: "*.ss-service.core-compute-dev.internal"
+    metrics:
+      prometheus:
+        enabled: true
+        buckets: [0.1,0.3,1.2,5]
+        service:
+          # Set a custom service name
+          name:
+            traefik-metrics
+          annotations:
+            prometheus.io/scrape: "true"
+          port: 9100
+          type: ClusterIP
+    deployment:
+      podAnnotations:
+        prometheus.io/port: "9100"
+        prometheus.io/scrape: "true"
 

--- a/k8s/release/admin/traefik/patches/ithc/cluster-00/traefik.yaml
+++ b/k8s/release/admin/traefik/patches/ithc/cluster-00/traefik.yaml
@@ -16,3 +16,19 @@ spec:
     ssl:
       generateTLS: true
       defaultCN: "*.ss-service.core-compute-ithc.internal"
+    metrics:
+      prometheus:
+        enabled: true
+        buckets: [0.1,0.3,1.2,5]
+        service:
+          # Set a custom service name
+          name:
+            traefik-metrics
+          annotations:
+            prometheus.io/scrape: "true"
+          port: 9100
+          type: ClusterIP
+    deployment:
+      podAnnotations:
+        prometheus.io/port: "9100"
+        prometheus.io/scrape: "true"

--- a/k8s/release/admin/traefik/patches/ithc/cluster-01/traefik.yaml
+++ b/k8s/release/admin/traefik/patches/ithc/cluster-01/traefik.yaml
@@ -16,4 +16,20 @@ spec:
     ssl:
       generateTLS: true
       defaultCN: "*.ss-service.core-compute-ithc.internal"
+    metrics:
+      prometheus:
+        enabled: true
+        buckets: [0.1,0.3,1.2,5]
+        service:
+          # Set a custom service name
+          name:
+            traefik-metrics
+          annotations:
+            prometheus.io/scrape: "true"
+          port: 9100
+          type: ClusterIP
+    deployment:
+      podAnnotations:
+        prometheus.io/port: "9100"
+        prometheus.io/scrape: "true"
 

--- a/k8s/release/admin/traefik/patches/sbox/cluster-01/traefik.yaml
+++ b/k8s/release/admin/traefik/patches/sbox/cluster-01/traefik.yaml
@@ -21,3 +21,19 @@ spec:
     ssl:
       generateTLS: true
       defaultCN: "*.ss-service.core-compute-sandbox.internal"
+    metrics:
+      prometheus:
+        enabled: true
+        buckets: [0.1,0.3,1.2,5]
+        service:
+          # Set a custom service name
+          name:
+            traefik-metrics
+          annotations:
+            prometheus.io/scrape: "true"
+          port: 9100
+          type: ClusterIP
+    deployment:
+      podAnnotations:
+        prometheus.io/port: "9100"
+        prometheus.io/scrape: "true"

--- a/k8s/release/admin/traefik/patches/test/cluster-00/traefik.yaml
+++ b/k8s/release/admin/traefik/patches/test/cluster-00/traefik.yaml
@@ -16,4 +16,20 @@ spec:
     ssl:
       generateTLS: true
       defaultCN: "*.ss-service.core-compute-test.internal"
+    metrics:
+      prometheus:
+        enabled: true
+        buckets: [0.1,0.3,1.2,5]
+        service:
+          # Set a custom service name
+          name:
+            traefik-metrics
+          annotations:
+            prometheus.io/scrape: "true"
+          port: 9100
+          type: ClusterIP
+    deployment:
+      podAnnotations:
+        prometheus.io/port: "9100"
+        prometheus.io/scrape: "true"
 

--- a/k8s/release/admin/traefik/patches/test/cluster-01/traefik.yaml
+++ b/k8s/release/admin/traefik/patches/test/cluster-01/traefik.yaml
@@ -18,4 +18,19 @@ spec:
     ssl:
       generateTLS: true
       defaultCN: "*.ss-service.core-compute-test.internal"
-
+    metrics:
+      prometheus:
+        enabled: true
+        buckets: [0.1,0.3,1.2,5]
+        service:
+          # Set a custom service name
+          name:
+            traefik-metrics
+          annotations:
+            prometheus.io/scrape: "true"
+          port: 9100
+          type: ClusterIP
+    deployment:
+      podAnnotations:
+        prometheus.io/port: "9100"
+        prometheus.io/scrape: "true"


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RDO-9467


### Change description ###
Creted the configs for enabling prometheus metrics in all non prod clusters.


**Does this PR introduce a breaking change?** (check one with "x")

```
[] Yes
[X ] No
```
