### PR TITLE
updated the csidriver release chart

### DIFF
--- a/k8s/release/admin/secrets-csi-driver/secrets-csi-driver.yaml
+++ b/k8s/release/admin/secrets-csi-driver/secrets-csi-driver.yaml
@@ -12,7 +12,7 @@ spec:
   chart:
     repository: https://raw.githubusercontent.com/Azure/secrets-store-csi-driver-provider-azure/master/charts/
     name: csi-secrets-store-provider-azure
-    version: 0.0.11
+    version: 0.0.13
   values:
     secrets-store-csi-driver:
       linux:


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RDO-9415


### Change description ###
updating the CSI driver chart to update the image to the latest version which allows flux to read all the tags.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
