### PR TITLE
Ingest Historical Notify data one time job

### DIFF
--- a/k8s/environments/test/common/mi/mi-integration-service-historical-notify.yaml
+++ b/k8s/environments/test/common/mi/mi-integration-service-historical-notify.yaml
@@ -1,0 +1,50 @@
+---
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: mi-integration-service-historical-notify
+  namespace: mi
+  annotations:
+    flux.weave.works/automated: "true"
+    repository.fluxcd.io/job: job.image
+    filter.fluxcd.io/job: glob:pr-*
+    repository.fluxcd.io/smoke: job.smoketests.image
+    filter.fluxcd.io/smoke: glob:pr-*
+spec:
+  releaseName: mi-integration-service-historical-notify
+  chart:
+    git: git@github.com:hmcts/shared-services-flux
+    path: k8s/release/mi/mi-integration-service
+    ref: master
+  values:
+    job:
+      image: ssprivatetest.azurecr.io/mi-integration-service:pr-135-2ffbfbd
+      suspend: false
+      kind: Job
+      schedule: '15 1 * * *'
+      labels:
+        app.kubernetes.io/instance: mi-integration-service-historical-notify-job
+        app.kubernetes.io/name: mi-integration-service-historical-notify-job
+      keyVaults:
+        "mi-vault":
+          excludeEnvironmentSuffix: false
+          resourceGroup: mi-{{ .Values.global.environment }}-rg
+          secrets:
+          - appinsights-instrumentationkey
+          - mi-historical-storage-connection-string
+      environment:
+        APPINSIGHTS_INSTRUMENTATIONKEY: "350a1a4c-d746-4c63-814c-4fee92e6e07c"
+        DATA_SOURCE_HISTORICAL_NOTIFY: true
+        HISTORICAL_NOTIFY_CONTAINER: historical
+        MI_CLIENT_ID: 3fafeddd-d882-42b6-806c-00a7f6eccaca
+      smoketests:
+        image: ssprivatetest.azurecr.io/mi-integration-service:pr-135-2ffbfbd
+        enabled: false
+      testsConfig:
+        environment:
+          APPINSIGHTS_INSTRUMENTATIONKEY: "350a1a4c-d746-4c63-814c-4fee92e6e07c"
+          MI_CLIENT_ID: 3fafeddd-d882-42b6-806c-00a7f6eccaca
+    global:
+      subscriptionId: "3eec5bde-7feb-4566-bfb6-805df6e10b90"
+      tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
+      environment: "test"


### PR DESCRIPTION
### Change description ###

Release chart to create a job which ingests historical notify data.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
