### PR TITLE
Adding kustomization for common-overlay

### DIFF
--- a/k8s/environments/sbox/common-overlay/kustomization.yaml
+++ b/k8s/environments/sbox/common-overlay/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- toffee


### PR DESCRIPTION
### Change description ###
I misread, I thought we wouldn't need a kustomization file here but that would mean the git-path would need to include  k8s/environments/sbox/common-overlay/toffee and then update for anything else added into the common-overlay dir.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
