### PR TITLE
DTSPO-161 - hardcode toffee ingressHost for sandbox

### DIFF
--- a/k8s/environments/sbox/common-overlay/toffee/backend-patch.yaml
+++ b/k8s/environments/sbox/common-overlay/toffee/backend-patch.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: toffee-recipe-backend
+  namespace: toffee
+spec:
+  values:
+    java:
+      ingressHost: toffee-backend.sandbox.platform.hmcts.net
+    global:
+      environment: sbox

--- a/k8s/environments/sbox/common-overlay/toffee/kustomization.yaml
+++ b/k8s/environments/sbox/common-overlay/toffee/kustomization.yaml
@@ -9,19 +9,7 @@ patches:
     version: v1
     kind: HelmRelease
     name: toffee-recipe-backend
-  patch: |-
-    - op: replace
-      path: /spec/values/global/environment
-      value: sbox
-- target:
-    group: helm.fluxcd.io
-    version: v1
-    kind: HelmRelease
-    name: toffee-recipe-backend
-  patch: |-
-    - op: replace
-      path: /spec/values/java/ingressHost
-      value: toffee-backend.staging.platform.hmcts.net
+  path: backend-patch.yaml
 - target:
     group: aadpodidentity.k8s.io
     version: v1


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-161


### Change description ###
Just gone for the easiest solution. This kustomize config is only needed for staging/stg and sandbox/sbox, the rest of the environments will have their ingressHost generated via the values in helmRelease. 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
