### PR TITLE
Fix helm release

### DIFF
--- a/apps/monitoring/kube-prometheus-stack/kube-prometheus-stack.yaml
+++ b/apps/monitoring/kube-prometheus-stack/kube-prometheus-stack.yaml
@@ -6,7 +6,8 @@ metadata:
   namespace: monitoring
 spec:
   releaseName: kube-prometheus-stack
-  forceUpgrade: true
+  upgrade: 
+    force: true
   valuesFrom:
     - secretKeyRef:
         name: "prometheus-values"


### PR DESCRIPTION
### Change description ###
Attempting to fix the error below, looks like api has slightly changed.

```bash
k get kustomizations.kustomize.toolkit.fluxcd.io monitoring        
NAME         READY   STATUS   AGE
monitoring   False   HelmRelease/monitoring/kube-prometheus-stack dry-run failed, error: failed to create typed patch object: .spec.forceUpgrade: field not declared in schema
             34m
```


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
