### PR TITLE
Fix kube-prometheus-stack HR

### DIFF
--- a/k8s/namespaces/monitoring/kube-prometheus-stack/kube-prometheus-stack.yaml
+++ b/k8s/namespaces/monitoring/kube-prometheus-stack/kube-prometheus-stack.yaml
@@ -15,8 +15,8 @@ spec:
     name: kube-prometheus-stack
     version: 18.0.7
   valuesFrom:
-    - secretKeyRef:
-        name: "prometheus-values"
+    - name: "prometheus-values"
+      kind: Secret
   values:
     defaultRules:
       create: true


### PR DESCRIPTION
### Change description ###
Attempting to fix the below error 🤞🏼 :
```bash
monitoring     False   HelmRelease/monitoring/kube-prometheus-stack dry-run failed, error: failed to create typed patch object: .spec.valuesFrom[0].secretKeyRef: field not declared in schema
               46m
```

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
