### PR TITLE
Added employment tribunals to Jenkins

### DIFF
--- a/k8s/namespaces/jenkins/patches/ptl/cluster-00/jenkins.yaml
+++ b/k8s/namespaces/jenkins/patches/ptl/cluster-00/jenkins.yaml
@@ -143,6 +143,12 @@ spec:
                     name: TT
                     recurse: true
                     title: Tax Tribunals Dashboard
+                - buildMonitor:
+                    includeRegex: >-
+                      ^HMCTS_.*ET-.*\/.+\/master
+                    name: ET
+                    recurse: true
+                    title: Employment Tribunals Dashboard                    
           authentication: |
             jenkins:
               securityRealm:


### PR DESCRIPTION
### JIRA link (if applicable) ###



### Change description ###

This PR adds employment tribunals to Jenkins dashboard. It clones the previous change for tax tribunals and modified accordingly

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
