### PR TITLE
DTSPO-6258 - Enable fluxv2 on dev cluster

### DIFF
--- a/apps/flux-system/dev/00/kustomize.yaml
+++ b/apps/flux-system/dev/00/kustomize.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+kind: Kustomization
+metadata:
+  name: flux-system
+  namespace: flux-system
+spec:
+  path: ./clusters/dev/00
+  postBuild:
+    substitute:
+      ENVIRONMENT: "dev"
+      CLUSTER: "00"
+      ENV_MONITOR_CHANNEL: "aks-monitor-dev"
+      KEYVAULT_ENVIRONMENT: "dev"

--- a/apps/flux-system/dev/01/kustomize.yaml
+++ b/apps/flux-system/dev/01/kustomize.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+kind: Kustomization
+metadata:
+  name: flux-system
+  namespace: flux-system
+spec:
+  path: ./clusters/dev/01
+  postBuild:
+    substitute:
+      ENVIRONMENT: "dev"
+      CLUSTER: "01"
+      ENV_MONITOR_CHANNEL: "aks-monitor-dev"
+      KEYVAULT_ENVIRONMENT: "dev"

--- a/apps/flux-system/dev/base/kustomization.yaml
+++ b/apps/flux-system/dev/base/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+  - git-credentials.yaml


### PR DESCRIPTION
Trying to fix script error in https://dev.azure.com/hmcts/PlatformOperations/_build/results?buildId=203628&view=logs&j=ea2ffe14-2e90-56d6-306f-4291b0be40fb&t=a1ee437a-aef6-50cc-929a-d1e6d9ce954a
by ensuring necessary files exist first.