### PR TITLE
DTSPO-6258 - remove git-credentials from dev

### DIFF
--- a/apps/flux-system/dev/base/kustomization.yaml
+++ b/apps/flux-system/dev/base/kustomization.yaml
@@ -2,4 +2,3 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
-  - git-credentials.yaml


### PR DESCRIPTION
- dev: migrate az-devops to fluxv2
- Remove git-credentials from dev
