### PR TITLE
Amend VH Azure Identity name

### DIFF
--- a/apps/vh/identity/dev.yaml
+++ b/apps/vh/identity/dev.yaml
@@ -1,7 +1,7 @@
 apiVersion: "aadpodidentity.k8s.io/v1"
 kind: AzureIdentity
 metadata:
-  name: vh
+  name: vh-aad-identity
   namespace: vh
 spec:
   resourceID: /subscriptions/867a878b-cb68-4de5-9741-361ac9e178b6/resourceGroups/managed-identities-dev-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/vh-infra-core-dev-kvuser

--- a/apps/vh/identity/vh-azure-identity.yaml
+++ b/apps/vh/identity/vh-azure-identity.yaml
@@ -13,4 +13,4 @@ metadata:
   name: vh-binding
 spec:
   azureIdentity: vh
-  selector: vh
+  selector: vh-aad-identity

--- a/apps/vh/identity/vh-azure-identity.yaml
+++ b/apps/vh/identity/vh-azure-identity.yaml
@@ -2,7 +2,7 @@
 apiVersion: "aadpodidentity.k8s.io/v1"
 kind: AzureIdentity
 metadata:
-  name: vh
+  name: vh-aad-identity
   namespace: vh
 spec:
   type: 0


### PR DESCRIPTION
### Change description ###
Amend VH Azure Identity name to vh-aad-identity to fir error:
`"No AzureIdentityBinding found for pod vh/vh-test-web-d68b89c89-pr5kz that matches selector: vh-aad-identity."`


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
