### PR TITLE
PUB-1021 Add auth return url to each pip-frontend env

### DIFF
--- a/k8s/namespaces/pip/pip-frontend/patches/demo/pip-frontend.yaml
+++ b/k8s/namespaces/pip/pip-frontend/patches/demo/pip-frontend.yaml
@@ -11,3 +11,4 @@ spec:
     nodejs:
       environment:
         DATA_MANAGEMENT_URL: https://pip-data-management.demo.platform.hmcts.net
+        AUTH_RETURN_URL: https://pip-frontend.demo.platform.hmcts.net/login/return

--- a/k8s/namespaces/pip/pip-frontend/patches/dev/pip-frontend.yaml
+++ b/k8s/namespaces/pip/pip-frontend/patches/dev/pip-frontend.yaml
@@ -11,3 +11,5 @@ spec:
   values:
     nodejs:
       image: sdshmctspublic.azurecr.io/pip/frontend:prod-936c55f-20211213105441 # {"$imagepolicy": "flux-system:pip-frontend"}
+      environment:
+        AUTH_RETURN_URL: https://pip-frontend.dev.platform.hmcts.net/login/return

--- a/k8s/namespaces/pip/pip-frontend/patches/ithc/pip-frontend.yaml
+++ b/k8s/namespaces/pip/pip-frontend/patches/ithc/pip-frontend.yaml
@@ -9,3 +9,4 @@ spec:
     nodejs:
       environment:
         DATA_MANAGEMENT_URL: https://pip-data-management.ithc.platform.hmcts.net
+        AUTH_RETURN_URL: https://pip-frontend.ithc.platform.hmcts.net/login/return

--- a/k8s/namespaces/pip/pip-frontend/patches/prod/pip-frontend.yaml
+++ b/k8s/namespaces/pip/pip-frontend/patches/prod/pip-frontend.yaml
@@ -11,3 +11,4 @@ spec:
       environment:
         DATA_MANAGEMENT_URL: https://pip-data-management.platform.hmcts.net
         SUBSCRIPTION_MANAGEMENT_URL: https://pip-subscription-management.platform.hmcts.net
+        AUTH_RETURN_URL: https://pip-frontend.platform.hmcts.net/login/return

--- a/k8s/namespaces/pip/pip-frontend/patches/stg/pip-frontend.yaml
+++ b/k8s/namespaces/pip/pip-frontend/patches/stg/pip-frontend.yaml
@@ -10,3 +10,4 @@ spec:
       ingressHost: pip-frontend.staging.platform.hmcts.net 
       environment:
         DATA_MANAGEMENT_URL: https://pip-data-management.staging.platform.hmcts.net
+        AUTH_RETURN_URL: https://pip-frontend.staging.platform.hmcts.net/login/return

--- a/k8s/namespaces/pip/pip-frontend/patches/test/pip-frontend.yaml
+++ b/k8s/namespaces/pip/pip-frontend/patches/test/pip-frontend.yaml
@@ -10,3 +10,4 @@ spec:
       ingressHost: pip-frontend.staging.platform.hmcts.net 
       environment:
         DATA_MANAGEMENT_URL: https://pip-data-management.test.platform.hmcts.net
+        AUTH_RETURN_URL: https://pip-frontend.test.platform.hmcts.net/login/return


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/PUB-1021


### Change description ###
Added the AUTH_RETURN_URL to each pip-frontend environment. 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
