### PR TITLE
DTSPO-6480 - Add oauth2-proxy in sds demo

### DIFF
--- a/k8s/environments/demo/cluster-00-overlay/kustomization.yaml
+++ b/k8s/environments/demo/cluster-00-overlay/kustomization.yaml
@@ -6,6 +6,7 @@ bases:
 - ../../../release/admin/secrets-csi-driver
 - ../../../namespaces/admin/traefik2
 - ../../../namespaces/admin/traefik2/traefik-no-proxy.yaml
+- ../../../namespaces/admin/oauth2-proxy/oauth2-proxy.yaml
 - ../../../namespaces/admin/aad-pod-identity
 - ../../../namespaces/kube-system/aad-pod-identity
 # - ../../../release/admin/env-injector
@@ -20,6 +21,9 @@ patchesStrategicMerge:
 - ../../../namespaces/admin/traefik2/patches/demo/secret-provider.yaml
 - ../../../namespaces/admin/traefik2/patches/demo/cluster-00/traefik-no-proxy.yaml
 - ../../../namespaces/admin/traefik2/patches/demo/traefik-private.yaml
+
+#oauth2-proxy patch
+- ../../../namespaces/admin/oauth2-proxy/patches/demo/cluster-00/oauth2-proxy.yaml
 
 
 #kured patch

--- a/k8s/environments/demo/cluster-01-overlay/kustomization.yaml
+++ b/k8s/environments/demo/cluster-01-overlay/kustomization.yaml
@@ -6,6 +6,7 @@ bases:
 - ../../../release/admin/secrets-csi-driver
 - ../../../namespaces/admin/traefik2
 - ../../../namespaces/admin/traefik2/traefik-no-proxy.yaml
+- ../../../namespaces/admin/oauth2-proxy/oauth2-proxy.yaml
 - ../../../namespaces/admin/aad-pod-identity
 - ../../../namespaces/kube-system/aad-pod-identity
 # - ../../../release/admin/env-injector
@@ -21,6 +22,8 @@ patchesStrategicMerge:
 - ../../../namespaces/admin/traefik2/patches/demo/cluster-01/traefik-no-proxy.yaml
 - ../../../namespaces/admin/traefik2/patches/demo/traefik-private.yaml
 
+#oauth2-proxy patch
+- ../../../namespaces/admin/oauth2-proxy/patches/demo/cluster-01/oauth2-proxy.yaml
 
 #kured patch
 - ../../../release/admin/kured/patches/demo/cluster-01/kured.yaml

--- a/k8s/namespaces/admin/oauth2-proxy/identity-binding.yaml
+++ b/k8s/namespaces/admin/oauth2-proxy/identity-binding.yaml
@@ -1,0 +1,8 @@
+apiVersion: aadpodidentity.k8s.io/v1
+kind: AzureIdentityBinding
+metadata:
+  name: oauth2-proxy-binding
+  namespace: admin
+spec:
+  azureIdentity: "aks-pod-identity-mi"
+  selector: oauth2-proxy

--- a/k8s/namespaces/admin/oauth2-proxy/kustomization.yaml
+++ b/k8s/namespaces/admin/oauth2-proxy/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - oauth2-proxy.yaml
+  - secret-provider.yaml
+  - identity-binding.yaml

--- a/k8s/namespaces/admin/oauth2-proxy/oauth2-proxy-values.enc.yaml
+++ b/k8s/namespaces/admin/oauth2-proxy/oauth2-proxy-values.enc.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+data:
+  oauth2-proxy-values.yaml: ENC[AES256_GCM,data:Khl8xt+EvXQVl5q/41Mfw2DVRfrVvOGBem3rJ+UOGXDmmY6iMXayz3pIc8jhfz0hPdAe+YDiZTN5r+iIgxoWM3EbBc3yVqKF9l4NnrbUwI8HBhHYOPUEj3MltwJB715ffQq1ovOBSYTIyr+Yc9QERtfkOIXeX6sYTQUo50cD9YM2HdsyYU5Si3M1QNbiKQge0qwlcaIAcD0=,iv:S8p6xlQkkORHPiqJ7K/3s7jNaGJiIsPa69MuwfvRuMA=,tag:23j3TbpeNOB4CoTmyfnP4Q==,type:str]
+kind: Secret
+metadata:
+  creationTimestamp: null
+  name: oauth2-proxy-values
+  namespace: admin
+sops:
+  kms: []
+  gcp_kms: []
+  azure_kv:
+    - vault_url: https://dtssharedservicesdemokv.vault.azure.net
+      name: sops-key
+      version: 0657d01a616f4a0abb44e8b4ff26ac71
+      created_at: "2022-02-11T15:31:38Z"
+      enc: fbV2HMoA16nCdNfBB6N5U-y-_6IWhQLsT9-82rRvlI9FEszdtKk7rMVuQTe89NtJTrhEYG3d16zGCzwd4roMUskvsKrHV8n2N1KT3rBo_3laHfyyZVIKr5-LobyaxrSRiFemilVfiqf0AJ5MjCkh09fEo9feR8WjvAFx5cXvPuhrLxx5XCPUp5HqrGs-n1ga99KjmL7eQz1ZIDyDNoy8KnRSrBEIUVw3wtdeKNTtbYxpJOmXgAG_HGZYg_1EyHez6hQNGpI9Wxt2EGIU2iZPdpKtnT-jzmb1uilLZJYyNxmM93otWYn2y6gzfqoWQ0ESf44311uy92l_x67NW302tQ
+  hc_vault: []
+  age: []
+  lastmodified: "2022-02-11T15:31:42Z"
+  mac: ENC[AES256_GCM,data:eszND/ZUwiosD+c+OXrz3NwLbz18zDN0WIIUgJ39510n2atc3nyQjFDJeBj6fn625nrVTnltSsRVzCVR5Zmmo00dhJw8YLZ6FvRudssKoQuo7yQpie5W/mul8zdbMw6BvMKT/t5oEPJWflVSqi/S5mRIMs8vQEncoIxJpCG2N34=,iv:UsNeCExkO7OVDrCnbR11VjV8tmbc5GcKUxdw+OmDNcQ=,tag:c1naGdBAzu38JaNNj7aJ0A==,type:str]
+  pgp: []
+  encrypted_regex: ^(data|stringData)$
+  version: 3.7.1

--- a/k8s/namespaces/admin/oauth2-proxy/oauth2-proxy.yaml
+++ b/k8s/namespaces/admin/oauth2-proxy/oauth2-proxy.yaml
@@ -1,0 +1,62 @@
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: oauth2-proxy
+  namespace: admin
+  annotations:
+    flux.weave.works/automated: "false"
+spec:
+  releaseName: oauth2-proxy
+  chart:
+    repository: https://oauth2-proxy.github.io/manifests
+    name: oauth2-proxy
+    version: 6.0.0
+  values:
+    extraArgs:
+      azure-tenant: "21ae17a1-694c-4005-8e0f-6a0e51c35a5f"
+      cookie-httponly: false
+      cookie-secure: true
+      email-domain: "*"
+      http-address: 4180
+      https-address: 4443
+      oidc-issuer-url: https://login.microsoftonline.com/21ae17a1-694c-4005-8e0f-6a0e51c35a5f/v2.0
+      pass-basic-auth: false
+      pass-host-header: true
+      pass-user-headers: false
+      provider: "azure"
+      proxy-prefix: "/oauth-proxy"
+      request-logging: true
+      skip-provider-button: true
+      tls-cert: "/var/oauth2/demo-platform-hmcts-crt.pem"
+      tls-key: "/var/oauth2/demo-platform-hmcts-key.pem"
+      upstream: http://traefik:80/
+    extraVolumes:
+      - name: tls-cert
+        csi:
+          driver: secrets-store.csi.k8s.io
+          readOnly: true
+          volumeAttributes:
+            secretProviderClass: oauth2-proxy-secrets-store
+    extraVolumeMounts:
+      - mountPath: "/var/oauth2"
+        name: "oauth2-proxy-secrets-store"
+    ingress:
+      enabled: true
+      annotations:
+        kubernetes.io/ingress.class: oauth2-proxy
+    podLabels:
+      app: oauth2-proxy
+    proxyVarsAsSecrets: true
+    resources:
+      limits:
+        cpu: 100m
+        memory: 256Mi
+      requests:
+        cpu: 10m
+        memory: 128Mi
+    service:
+      annotations: 
+        service.beta.kubernetes.io/azure-load-balancer-internal: "true"
+    valuesFrom:
+      - name: "oauth2-proxy-values"
+        kind: Secret

--- a/k8s/namespaces/admin/oauth2-proxy/patches/demo/cluster-00/oauth2-proxy.yaml
+++ b/k8s/namespaces/admin/oauth2-proxy/patches/demo/cluster-00/oauth2-proxy.yaml
@@ -1,0 +1,10 @@
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: oauth2-proxy
+  namespace: admin
+spec:
+  values:
+    service:
+      spec:
+        loadBalancerIP: "10.51.79.251"

--- a/k8s/namespaces/admin/oauth2-proxy/patches/demo/cluster-01/oauth2-proxy.yaml
+++ b/k8s/namespaces/admin/oauth2-proxy/patches/demo/cluster-01/oauth2-proxy.yaml
@@ -1,0 +1,10 @@
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: oauth2-proxy
+  namespace: admin
+spec:
+  values:
+    service:
+      spec:
+        loadBalancerIP: "10.51.95.251"

--- a/k8s/namespaces/admin/oauth2-proxy/patches/demo/kustomization.yaml
+++ b/k8s/namespaces/admin/oauth2-proxy/patches/demo/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+patchesStrategicMerge:
+  - ../../oauth2-proxy-values.enc.yaml

--- a/k8s/namespaces/admin/oauth2-proxy/patches/demo/secret-provider.yaml
+++ b/k8s/namespaces/admin/oauth2-proxy/patches/demo/secret-provider.yaml
@@ -1,0 +1,15 @@
+apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
+kind: SecretProviderClass
+metadata:
+  name: oauth2-proxy-secrets-store
+  namespace: admin
+spec:
+  parameters:
+    keyvaultName: acmedtssdsdemo
+    objects: |
+      array:
+        - |
+          objectName: wildcard-demo-platform-hmcts-net
+          objectType: secret
+          objectAlias: tls-cert
+          objectVersion: ""

--- a/k8s/namespaces/admin/oauth2-proxy/secret-provider.yaml
+++ b/k8s/namespaces/admin/oauth2-proxy/secret-provider.yaml
@@ -1,0 +1,18 @@
+apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
+kind: SecretProviderClass
+metadata:
+  name: oauth2-proxy-secrets-store
+  namespace: admin
+spec:
+  provider: azure
+  secretObjects:
+  - secretName: oauth2-proxy-cert
+    type: kubernetes.io/tls
+    data: 
+    - objectName: tls-cert
+      key: tls.crt
+    - objectName: tls-cert
+      key: tls.key
+  parameters:
+    usePodIdentity: "true"
+    tenantId: 531ff96d-0ae9-462a-8d2d-bec7c0b42082

--- a/k8s/namespaces/toffee/toffee-frontend/demo/demo.yaml
+++ b/k8s/namespaces/toffee/toffee-frontend/demo/demo.yaml
@@ -8,5 +8,5 @@ spec:
   releaseName: toffee-frontend
   values:
     nodejs:
-      ingressClass: traefik
+      ingressClass: oauth2-proxy
       disableTraefikTls: false


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/browse/DTSPO-6480


### Change description ###
WORK IN PROGRESS

A client secret and id is required. This could be added via a keyvault but started off adding via secret values file as not sure which key vault should be used.

Also have a secret provider class pointing to acmedtssdsdemo to get the wildcard cert for demo.platform.hmcts.net

Identity added to access the keyvault

Have adapted the cnp code to match more recent version of the helm values


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
