### PR TITLE
DTSPO-6480 - Oauth2-proxy: patch 1

### DIFF
--- a/k8s/namespaces/admin/oauth2-proxy/oauth2-proxy.yaml
+++ b/k8s/namespaces/admin/oauth2-proxy/oauth2-proxy.yaml
@@ -31,15 +31,15 @@ spec:
       tls-key: "/var/oauth2/demo-platform-hmcts-key.pem"
       upstream: http://traefik:80/
     extraVolumes:
-      - name: tls-cert
+      - name: oauth2-proxy-cert
         csi:
           driver: secrets-store.csi.k8s.io
           readOnly: true
           volumeAttributes:
-            secretProviderClass: oauth2-proxy-secrets-store
+            secretProviderClass: oauth2-proxy-cert
     extraVolumeMounts:
       - mountPath: "/var/oauth2"
-        name: "oauth2-proxy-secrets-store"
+        name: "oauth2-proxy-cert"
     ingress:
       enabled: true
       annotations:

--- a/k8s/namespaces/admin/oauth2-proxy/oauth2-proxy.yaml
+++ b/k8s/namespaces/admin/oauth2-proxy/oauth2-proxy.yaml
@@ -32,11 +32,8 @@ spec:
       upstream: http://traefik:80/
     extraVolumes:
       - name: oauth2-proxy-cert
-        csi:
-          driver: secrets-store.csi.k8s.io
-          readOnly: true
-          volumeAttributes:
-            secretProviderClass: oauth2-proxy-cert
+        secret:
+          secretName: oauth2-proxy-cert
     extraVolumeMounts:
       - mountPath: "/var/oauth2"
         name: "oauth2-proxy-cert"

--- a/k8s/namespaces/admin/oauth2-proxy/secret-provider.yaml
+++ b/k8s/namespaces/admin/oauth2-proxy/secret-provider.yaml
@@ -1,7 +1,7 @@
 apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
 kind: SecretProviderClass
 metadata:
-  name: oauth2-proxy-secrets-store
+  name: oauth2-proxy-cert
   namespace: admin
 spec:
   provider: azure


### PR DESCRIPTION
JIRA link (if applicable)
tools.hmcts.net/browse/DTSPO-6480

Change description
WORK IN PROGRESS

Patch to fix volumes and volume mounts

Update secret provider, volume and mounts to use same name

Was using incorrect extraVolumes syntax previously

Does this PR introduce a breaking change? (check one with "x")

[ ] Yes
[x] No
