### PR TITLE
DTSPO-6498 - deploy external dns to demo

### DIFF
--- a/k8s/environments/demo/cluster-00-overlay/kustomization.yaml
+++ b/k8s/environments/demo/cluster-00-overlay/kustomization.yaml
@@ -9,6 +9,7 @@ bases:
 - ../../../namespaces/admin/oauth2-proxy/oauth2-proxy.yaml
 - ../../../namespaces/admin/aad-pod-identity
 - ../../../namespaces/kube-system/aad-pod-identity
+- ../../../namespaces/admin/external-dns
 # - ../../../release/admin/env-injector
 # - ../../../release/kube-system/nodelocaldns
 
@@ -31,3 +32,6 @@ patchesStrategicMerge:
 
 # env-injector
 # - ../../../release/admin/env-injector/patches/demo/cluster-00/env-injector.yaml
+
+# external-dns patches
+- ../../../namespaces/admin/external-dns/patches/demo/cluster-00/external-dns.yaml

--- a/k8s/environments/demo/cluster-01-overlay/kustomization.yaml
+++ b/k8s/environments/demo/cluster-01-overlay/kustomization.yaml
@@ -9,6 +9,7 @@ bases:
 - ../../../namespaces/admin/oauth2-proxy/oauth2-proxy.yaml
 - ../../../namespaces/admin/aad-pod-identity
 - ../../../namespaces/kube-system/aad-pod-identity
+- ../../../namespaces/admin/external-dns
 # - ../../../release/admin/env-injector
 # - ../../../release/kube-system/nodelocaldns
 
@@ -30,3 +31,6 @@ patchesStrategicMerge:
 
 # env-injector
 # - ../../../release/admin/env-injector/patches/demo/cluster-00/env-injector.yaml
+
+# external-dns patches
+- ../../../namespaces/admin/external-dns/patches/demo/cluster-01/external-dns.yaml

--- a/k8s/namespaces/admin/external-dns/external-dns.yaml
+++ b/k8s/namespaces/admin/external-dns/external-dns.yaml
@@ -1,0 +1,25 @@
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: external-dns
+  namespace: admin 
+spec:
+  releaseName: external-dns
+  chart:
+    repository: https://charts.bitnami.com/bitnami
+    name: external-dns
+    version: 6.1.4
+  values:
+    podLabels:
+      aadpodidbinding: external-dns
+    provider: azure
+    sources:
+      - ingress
+    domainFilter: demo.platform.hmcts.net
+    annotationFilter: "kubernetes.io/ingress.class=traefik"
+    azure:
+      resourceGroup: reformMgmtRG
+      tenantId: 531ff96d-0ae9-462a-8d2d-bec7c0b42082
+      subscriptionId: ed302caf-ec27-4c64-a05e-85731c3ce90e
+      useManagedIdentityExtension: true
+      userAssignedIdentityID: 04561461-0f92-42b3-9328-8b0c1bba4641

--- a/k8s/namespaces/admin/external-dns/identity-binding.yaml
+++ b/k8s/namespaces/admin/external-dns/identity-binding.yaml
@@ -1,0 +1,8 @@
+apiVersion: "aadpodidentity.k8s.io/v1"
+kind: AzureIdentityBinding
+metadata:
+  name: external-dns-binding
+  namespace: admin
+spec:
+  azureIdentity: aks-pod-identity-mi
+  selector: external-dns

--- a/k8s/namespaces/admin/external-dns/kustomization.yaml
+++ b/k8s/namespaces/admin/external-dns/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+namespace: admin
+kind: Kustomization
+resources:
+  - external-dns.yaml
+  - identity-binding.yaml

--- a/k8s/namespaces/admin/external-dns/patches/demo/cluster-00/external-dns.yaml
+++ b/k8s/namespaces/admin/external-dns/patches/demo/cluster-00/external-dns.yaml
@@ -1,0 +1,10 @@
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: external-dns
+  namespace: admin 
+spec:
+  releaseName: external-dns
+  values:
+    logLevel: debug
+    txtOwnerId: sds-demo-00-aks

--- a/k8s/namespaces/admin/external-dns/patches/demo/cluster-01/external-dns.yaml
+++ b/k8s/namespaces/admin/external-dns/patches/demo/cluster-01/external-dns.yaml
@@ -1,0 +1,10 @@
+apiVersion: helm.fluxcd.io/v1
+kind: HelmRelease
+metadata:
+  name: external-dns
+  namespace: admin 
+spec:
+  releaseName: external-dns
+  values:
+    logLevel: debug
+    txtOwnerId: sds-demo-01-aks


### PR DESCRIPTION
### Change description ###
This external-dns instance will work for azure public dns zones, but due to the annotation filter, will only work for traefik-no-proxy. I think we should add another label or annotation to ingresses e.g.

`external.dns/provider: azure-public-dns` & `external.dns/provider: azure-private-dns`

- Added configuration to deploy external dns to demo 
- Uses the external dns helm chart
- Uses the AKS Managed Identity - may want to create a new one
 
Leaving debug logging on for now, until everything is proven to work 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
