### PR TITLE
DTSPO-6498 - set owner id's to active and inactive

### DIFF
--- a/k8s/namespaces/admin/external-dns/patches/demo/cluster-00/external-dns.yaml
+++ b/k8s/namespaces/admin/external-dns/patches/demo/cluster-00/external-dns.yaml
@@ -7,4 +7,4 @@ spec:
   releaseName: external-dns
   values:
     logLevel: debug
-    txtOwnerId: sds-demo-00-aks
+    txtOwnerId: sds-demo-aks-active

--- a/k8s/namespaces/admin/external-dns/patches/demo/cluster-01/external-dns.yaml
+++ b/k8s/namespaces/admin/external-dns/patches/demo/cluster-01/external-dns.yaml
@@ -7,4 +7,4 @@ spec:
   releaseName: external-dns
   values:
     logLevel: debug
-    txtOwnerId: sds-demo-01-aks
+    txtOwnerId: sds-demo-aks-inactive


### PR DESCRIPTION
### Change description ###
- fix owner id's for single active cluster


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
