### PR TITLE
DTSPO-6480 - Oauth2-proxy: remove toffee flux

### DIFF
--- a/k8s/environments/demo/common-overlay/kustomization.yaml
+++ b/k8s/environments/demo/common-overlay/kustomization.yaml
@@ -1,7 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - toffee
+  # - toffee
   - pip
   - vh
 patches:
@@ -9,5 +9,5 @@ patches:
     target:
       kind: HelmRelease
 patchesStrategicMerge:
-  - ../../../namespaces/toffee/toffee-frontend/demo/demo.yaml
-  - ../../../namespaces/toffee/toffee-recipe-backend/demo/demo.yaml
+  # - ../../../namespaces/toffee/toffee-frontend/demo/demo.yaml
+  # - ../../../namespaces/toffee/toffee-recipe-backend/demo/demo.yaml


### PR DESCRIPTION
JIRA link (if applicable)
https://tools.hmcts.net/browse/DTSPO-6480

Change description
Removing toffee from flux to more easily test oauth2-proxy

Does this PR introduce a breaking change? (check one with "x")

[ ] Yes
[x] No
