### PR TITLE
Add certificate support in flux

### DIFF
--- a/k8s/release/mi/common/job/templates/secretprovider.yaml
+++ b/k8s/release/mi/common/job/templates/secretprovider.yaml
@@ -19,6 +19,13 @@ spec:
           objectType: secret
           objectVersion: ""
     {{- end }}
+    {{- range $cert := $val.certs}}       
+        - |
+          objectName: {{ $cert.name }}
+          objectType: cert
+          objectVersion: ""
+          objectAlias: {{ $cert.alias }}
+    {{- end }}
     resourceGroup: {{ tpl $val.resourceGroup $ }}
     subscriptionId: {{ $globals.subscriptionId }}
     tenantId: {{ $globals.tenantId }} 


### PR DESCRIPTION
### JIRA link (if applicable) ###
Doc: https://docs.microsoft.com/en-us/azure/aks/csi-secrets-store-driver#obtain-certificates-and-keys
Example: https://github.com/hmcts/pip-frontend/pull/297

### Change description ###
Currently Certificates are not being mounted to the pods like secrets.
This will allow the users to add the certs to the Helm Values and mount them.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X ] No
```
