### PR TITLE
DTSPO-6480 - set enableOauth flag for toffee

### DIFF
--- a/k8s/namespaces/toffee/toffee-frontend/demo/demo.yaml
+++ b/k8s/namespaces/toffee/toffee-frontend/demo/demo.yaml
@@ -10,3 +10,4 @@ spec:
     nodejs:
       ingressClass: traefik-auth-proxy
       disableTraefikTls: false
+      enableOauth: true


### PR DESCRIPTION
Set enableOauth flag for toffee in demo to true to add required ingress annotations﻿
