### PR TITLE
DTSPO-6480 - set traefik-auth-proxy to default

### DIFF
--- a/k8s/namespaces/admin/traefik2/patches/demo/cluster-00/traefik-auth-proxy.yaml
+++ b/k8s/namespaces/admin/traefik2/patches/demo/cluster-00/traefik-auth-proxy.yaml
@@ -10,7 +10,7 @@ spec:
         loadBalancerIP: "10.51.79.251"
     ingressClass:
       enabled: true
-      isDefaultClass: false
+      isDefaultClass: true
     ports:
       web:
         redirectTo: websecure

--- a/k8s/namespaces/admin/traefik2/patches/demo/cluster-00/traefik-no-proxy.yaml
+++ b/k8s/namespaces/admin/traefik2/patches/demo/cluster-00/traefik-no-proxy.yaml
@@ -10,7 +10,7 @@ spec:
         loadBalancerIP: "10.51.79.250"
     ingressClass:
       enabled: true
-      isDefaultClass: true
+      isDefaultClass: false
     ports:
       web:
         redirectTo: websecure

--- a/k8s/namespaces/admin/traefik2/patches/demo/cluster-01/traefik-no-proxy.yaml
+++ b/k8s/namespaces/admin/traefik2/patches/demo/cluster-01/traefik-no-proxy.yaml
@@ -10,7 +10,7 @@ spec:
         loadBalancerIP: "10.51.95.250"
     ingressClass:
       enabled: true
-      isDefaultClass: true
+      isDefaultClass: false
     ports:
       web:
         redirectTo: websecure

--- a/k8s/namespaces/admin/traefik2/traefik-auth-proxy.yaml
+++ b/k8s/namespaces/admin/traefik2/traefik-auth-proxy.yaml
@@ -17,7 +17,7 @@ spec:
       - --providers.kubernetesingress.ingressendpoint.ip=20.90.197.52
     ingressClass:
       enabled: true
-      isDefaultClass: true
+      isDefaultClass: false
     deployment:
       podLabels:
         aadpodidbinding: traefik

--- a/k8s/namespaces/admin/traefik2/traefik-auth-proxy.yaml
+++ b/k8s/namespaces/admin/traefik2/traefik-auth-proxy.yaml
@@ -13,11 +13,11 @@ spec:
     version: 10.6.0
   values:
     additionalArguments:
-      - --providers.kubernetesingress.ingressclass=traefik-auth-proxy
+      - --providers.kubernetesingress.ingressclass=traefik
       - --providers.kubernetesingress.ingressendpoint.ip=20.90.197.52
     ingressClass:
       enabled: true
-      isDefaultClass: false
+      isDefaultClass: true
     deployment:
       podLabels:
         aadpodidbinding: traefik
@@ -36,8 +36,6 @@ spec:
       annotations:
         service.beta.kubernetes.io/azure-load-balancer-internal: "true"
     logs:
-      general:
-        level: INFO
       access:
         enabled: true
     rbac:

--- a/k8s/namespaces/admin/traefik2/traefik-no-proxy.yaml
+++ b/k8s/namespaces/admin/traefik2/traefik-no-proxy.yaml
@@ -13,7 +13,7 @@ spec:
     version: 10.6.0
   values:
     additionalArguments:
-      - --providers.kubernetesingress.ingressclass=traefik
+      - --providers.kubernetesingress.ingressclass=traefik-no-proxy
       - --providers.kubernetesingress.ingressendpoint.ip=20.108.232.218
     ingressClass:
       enabled: true

--- a/k8s/namespaces/pip/pip-account-management/patches/demo/pip-account-management.yaml
+++ b/k8s/namespaces/pip/pip-account-management/patches/demo/pip-account-management.yaml
@@ -10,4 +10,5 @@ spec:
   values:
     java:
       disableTraefikTls: false
+      ingressClass: traefik-no-proxy
       environment:

--- a/k8s/namespaces/pip/pip-channel-management/patches/demo/pip-channel-management.yaml
+++ b/k8s/namespaces/pip/pip-channel-management/patches/demo/pip-channel-management.yaml
@@ -10,4 +10,5 @@ spec:
   values:
     java:
       disableTraefikTls: false
+      ingressClass: traefik-no-proxy
       environment:

--- a/k8s/namespaces/pip/pip-data-management/patches/demo/pip-data-management.yaml
+++ b/k8s/namespaces/pip/pip-data-management/patches/demo/pip-data-management.yaml
@@ -10,4 +10,5 @@ spec:
   values:
     java:
       disableTraefikTls: false
+      ingressClass: traefik-no-proxy
       environment:

--- a/k8s/namespaces/pip/pip-frontend/patches/demo/pip-frontend.yaml
+++ b/k8s/namespaces/pip/pip-frontend/patches/demo/pip-frontend.yaml
@@ -10,6 +10,7 @@ spec:
   values:
     nodejs:
       disableTraefikTls: false
+      ingressClass: traefik-no-proxy
       environment:
         DATA_MANAGEMENT_URL: https://pip-data-management.demo.platform.hmcts.net
         ACCOUNT_MANAGEMENT_URL: https://pip-account-management.demo.platform.hmcts.net

--- a/k8s/namespaces/pip/pip-publication-services/patches/demo/pip-publication-services.yaml
+++ b/k8s/namespaces/pip/pip-publication-services/patches/demo/pip-publication-services.yaml
@@ -10,4 +10,5 @@ spec:
   values:
     java:
       disableTraefikTls: false
+      ingressClass: traefik-no-proxy
       environment:

--- a/k8s/namespaces/pip/pip-subscription-management/patches/demo/pip-subscription-management.yaml
+++ b/k8s/namespaces/pip/pip-subscription-management/patches/demo/pip-subscription-management.yaml
@@ -10,5 +10,6 @@ spec:
   values:
     java:
       disableTraefikTls: false
+      ingressClass: traefik-no-proxy
       environment:
         DATA_MANAGEMENT_URL: 'https://pip-data-management.demo.platform.hmcts.net'


### PR DESCRIPTION
JIRA link (if applicable)
https://tools.hmcts.net/browse/DTSPO-6480

Change description
Set traefik-auth-proxy as default ingressClass
Update pip to continue using traefik-no-proxy

Does this PR introduce a breaking change? (check one with "x")

[ ] Yes
[x] No
