### PR TITLE
DTSPO-7181 -Update sbox jenkins version to 3.9.0

### DIFF
--- a/k8s/namespaces/jenkins/patches/ptlsbox/cluster-00/jenkins.yaml
+++ b/k8s/namespaces/jenkins/patches/ptlsbox/cluster-00/jenkins.yaml
@@ -5,6 +5,10 @@ metadata:
   name: jenkins
   namespace: jenkins
 spec:
+  chart:
+    repository: https://charts.jenkins.io
+    name: jenkins
+    version: 3.10.0
   values:
     controller:
       ingress:

--- a/k8s/namespaces/jenkins/patches/ptlsbox/cluster-00/jenkins.yaml
+++ b/k8s/namespaces/jenkins/patches/ptlsbox/cluster-00/jenkins.yaml
@@ -8,7 +8,7 @@ spec:
   chart:
     repository: https://charts.jenkins.io
     name: jenkins
-    version: 3.10.0
+    version: 3.9.0
   values:
     controller:
       ingress:


### PR DESCRIPTION
### JIRA link (if applicable) ###
DTSPO-7181


### Change description ###
Update Sbox Jenkins version to 3.9.0. Testing sbox as version update broke production jenkins.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
