### PR TITLE
DTSPO-4401: Adding entries for dcs

### DIFF
--- a/k8s/release/mailrelay/mailrelay2/patches/dev/cluster-00/mailrelay2.yaml
+++ b/k8s/release/mailrelay/mailrelay2/patches/dev/cluster-00/mailrelay2.yaml
@@ -25,6 +25,7 @@ spec:
       - "v1test"
       - "mailrelay-dev-user"
       - "tenable"
+      - "dcsdev"
     tenantId: 531ff96d-0ae9-462a-8d2d-bec7c0b42082
 
     certificate:

--- a/k8s/release/mailrelay/mailrelay2/patches/dev/cluster-01/mailrelay2.yaml
+++ b/k8s/release/mailrelay/mailrelay2/patches/dev/cluster-01/mailrelay2.yaml
@@ -25,6 +25,7 @@ spec:
       - "v1test"
       - "mailrelay-dev-user"
       - "tenable"
+      - "dcsdev"
     tenantId: 531ff96d-0ae9-462a-8d2d-bec7c0b42082
 
     certificate:

--- a/k8s/release/mailrelay/mailrelay2/patches/prod/cluster-00/mailrelay2.yaml
+++ b/k8s/release/mailrelay/mailrelay2/patches/prod/cluster-00/mailrelay2.yaml
@@ -25,8 +25,9 @@ spec:
       - "pcol"
       - "mailrelay-prod-user"
       - "tenable"
+      - "dcsprod"
     tenantId: 531ff96d-0ae9-462a-8d2d-bec7c0b42082
-  
+
     certificate:
       inboundCert:
         name: "prod-in"

--- a/k8s/release/mailrelay/mailrelay2/patches/prod/cluster-01/mailrelay2.yaml
+++ b/k8s/release/mailrelay/mailrelay2/patches/prod/cluster-01/mailrelay2.yaml
@@ -25,6 +25,7 @@ spec:
       - "pcol"
       - "mailrelay-prod-user"
       - "tenable"
+      - "dcsprod"
     tenantId: 531ff96d-0ae9-462a-8d2d-bec7c0b42082
 
     certificate:


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-4401


### Change description ###
DCS would like to use our mailrelay. Setting up entries/credentials needed. We'd be starting with `dev` and afterwards setup `prod` as well.

Creating both entries now


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
