### PR TITLE
Set resource limits for mi azure functions

### DIFF
--- a/apps/mi/mi-azure-functions/dev.yaml
+++ b/apps/mi/mi-azure-functions/dev.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   releaseName: mi-azure-functions
   values:
-    image: sdshmctspublic.azurecr.io/mi/azure-functions:dev-61b85ef-20220328124233 #{"$imagepolicy": "flux-system:mi-azure-functions"}
+    image: sdshmctspublic.azurecr.io/mi/azure-functions:dev-61b85ef-20220328124233 #{"$imagepolicy": "flux-system:mi-azure-functions-dev"}
     env:
       ADF_RESOURCEGROUP: mi-dev-rg
       ADF_NAME: mi-ingestion-adf-dev

--- a/apps/mi/mi-azure-functions/dev.yaml
+++ b/apps/mi/mi-azure-functions/dev.yaml
@@ -6,11 +6,12 @@ metadata:
 spec:
   releaseName: mi-azure-functions
   values:
-    image: sdshmctspublic.azurecr.io/mi/azure-functions:prod-60fceb8-20220314125646 #{"$imagepolicy": "flux-system:mi-azure-functions"}
+    image: sdshmctspublic.azurecr.io/mi/azure-functions:dev-61b85ef-20220328124233 #{"$imagepolicy": "flux-system:mi-azure-functions"}
     env:
       ADF_RESOURCEGROUP: mi-dev-rg
       ADF_NAME: mi-ingestion-adf-dev
       ADF_STORAGEACCOUNTNAME: miauditdev
+      MI_METADATA_SERVER_DB: mi-metadata-db-dev
     keyVaultSecrets:
       - encryption-publicKey
     environment: "dev"

--- a/apps/mi/mi-azure-functions/image-policy.yaml
+++ b/apps/mi/mi-azure-functions/image-policy.yaml
@@ -1,13 +1,44 @@
+---
 apiVersion: image.toolkit.fluxcd.io/v1alpha2
 kind: ImagePolicy
 metadata:
-  name: mi-azure-functions
+  name: mi-azure-functions-sbox
 spec:
   imageRepositoryRef:
     name: mi-azure-functions
   filterTags:
     extract: $ts
-    pattern: '^prod-[a-f0-9]+-(?P<ts>[0-9]+-[0-9]+)'
+    pattern: '^sbox-[a-f0-9]+-(?P<ts>[0-9]+-[0-9]+)'
+  policy:
+    alphabetical:
+      order: asc
+
+---
+apiVersion: image.toolkit.fluxcd.io/v1alpha2
+kind: ImagePolicy
+metadata:
+  name: mi-azure-functions-dev
+spec:
+  imageRepositoryRef:
+    name: mi-azure-functions
+  filterTags:
+    extract: $ts
+    pattern: '^dev-[a-f0-9]+-(?P<ts>[0-9]+-[0-9]+)'
+  policy:
+    alphabetical:
+      order: asc
+
+---
+apiVersion: image.toolkit.fluxcd.io/v1alpha2
+kind: ImagePolicy
+metadata:
+  name: mi-azure-functions-test
+spec:
+  imageRepositoryRef:
+    name: mi-azure-functions
+  filterTags:
+    extract: $ts
+    pattern: '^test-[a-f0-9]+-(?P<ts>[0-9]+-[0-9]+)'
   policy:
     alphabetical:
       order: asc

--- a/apps/mi/mi-azure-functions/sbox.yaml
+++ b/apps/mi/mi-azure-functions/sbox.yaml
@@ -11,6 +11,7 @@ spec:
       ADF_RESOURCEGROUP: mi-sbox-rg
       ADF_NAME: mi-ingestion-adf-sbox
       ADF_STORAGEACCOUNTNAME: miauditsbox
+      MI_METADATA_SERVER_DB: mi-metadata-db-sbox
     keyVaultSecrets:
       - encryption-publicKey
     environment: "sbox"

--- a/apps/mi/mi-azure-functions/sbox.yaml
+++ b/apps/mi/mi-azure-functions/sbox.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   releaseName: mi-azure-functions
   values:
-    image: sdshmctspublic.azurecr.io/mi/azure-functions:prod-60fceb8-20220314125646 #{"$imagepolicy": "flux-system:mi-azure-functions"}
+    image: sdshmctspublic.azurecr.io/mi/azure-functions:prod-60fceb8-20220314125646 #{"$imagepolicy": "flux-system:mi-azure-functions-sbox"}
     env:
       ADF_RESOURCEGROUP: mi-sbox-rg
       ADF_NAME: mi-ingestion-adf-sbox

--- a/k8s/release/mi/mi-azure-functions/templates/deployment.yaml
+++ b/k8s/release/mi/mi-azure-functions/templates/deployment.yaml
@@ -35,3 +35,10 @@ spec:
             - name: {{ .Values.keyVaultName }}-secrets-store
               mountPath: {{ .Values.secretsMountPath }}
               readOnly: true
+          resources:
+            requests:
+              memory: {{ .Values.memoryRequests }}
+              cpu: {{ .Values.cpuRequests }}
+            limits:
+              memory: {{ .Values.memoryLimits }}
+              cpu: {{ .Values.cpuLimits }}

--- a/k8s/release/mi/mi-azure-functions/values.yaml
+++ b/k8s/release/mi/mi-azure-functions/values.yaml
@@ -5,8 +5,11 @@ tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
 
 image: sdshmctspublic.azurecr.io/mi/azure-functions
 
+memoryRequests: '512Mi'
+cpuRequests: '200m'
 memoryLimits: '2048Mi'
 cpuLimits: '2000m'
+
 replicaCount: 2
 
 appName: mi-azure-functions

--- a/k8s/release/mi/mi-azure-functions/values.yaml
+++ b/k8s/release/mi/mi-azure-functions/values.yaml
@@ -5,6 +5,8 @@ tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
 
 image: sdshmctspublic.azurecr.io/mi/azure-functions
 
+memoryLimits: '2048Mi'
+cpuLimits: '2000m'
 replicaCount: 2
 
 appName: mi-azure-functions


### PR DESCRIPTION
Setting a resource request of 512MiB memory and 200m CPU.
Setting a limit of 2048MiB and 2000m CPU, which should be sufficient for even high loads.