### PR TITLE
Change the VH API Version

### DIFF
--- a/apps/vh/base/kustomize.yaml
+++ b/apps/vh/base/kustomize.yaml
@@ -1,4 +1,4 @@
-apiVersion: kustomize.toolkit.fluxcd.io/v1beta1
+apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
   name: vh

--- a/apps/vh/bookings-api/bookings-api.yaml
+++ b/apps/vh/bookings-api/bookings-api.yaml
@@ -12,10 +12,10 @@ spec:
       disableTraefikTls: true
   chart:
     spec:
-      chart: ./charts/vh-bookings-api
+      chart: ./stable/vh-bookings-api
       sourceRef:
         kind: GitRepository
-        name: vh-bookings-api
+        name: hmcts-charts
         namespace: flux-system
       interval: 5m
   install:

--- a/apps/vh/dev/base/kustomization.yaml
+++ b/apps/vh/dev/base/kustomization.yaml
@@ -1,4 +1,4 @@
-apiVersion: kustomize.config.k8s.io/v1beta1
+apiVersion: kustomize.config.k8s.io/v1
 kind: Kustomization
 resources:
   - ../../base


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-7590


### Change description ###
Changing the API Version to 'v1' to try fix issue:
`Helm install failed: unable to build kubernetes objects from release manifest: unable
to recognize "": no matches for kind "Ingress" in version "[networking.k8s.io/v1beta1](http://networking.k8s.io/v1beta1)`


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x ] No
```
