### PR TITLE
fix flux errors in ss-ptl

### DIFF
--- a/apps/hmi/automation/kustomization.yaml
+++ b/apps/hmi/automation/kustomization.yaml
@@ -5,6 +5,3 @@ resources:
   - ../hmi-pactbroker/image-policy.yaml
   - ../hmi-wiremock/image-repo.yaml
   - ../hmi-wiremock/image-policy.yaml
-  - ../hmi-az-devops-agent/image-repo.yaml
-  - ../hmi-az-devops-agent/image-policy.yaml
-  


### PR DESCRIPTION
### Change description ###
Fixes error in flux-system
`accumulation err='accumulating resources from '../hmi-az-devops-agent/image-repo.yaml': open /tmp/flux-system3623365517/apps/hmi/hmi-az-devops-agent/image-repo.yaml: no such file or directory
`
- Might look at some CI for this going forward, no CI check for apps/namespace/automation 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
