### PR TITLE
DTSPO-6489 - fluxv2 ithc migration - azure-devops - patch 2

### DIFF
--- a/apps/azure-devops/azure-devops-agent/ithc.yaml
+++ b/apps/azure-devops/azure-devops-agent/ithc.yaml
@@ -12,7 +12,7 @@ spec:
     azureDevOps:
       pool: hmcts-ss-ithc
     keyVaults:
-      - name: dtssharedservicesithcakv
+      - name: dtssharedservicesithckv
         tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
         secrets:
           - azure-devops-agent-token


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-6489


### Change description ###
Fix typo in ithc keyvault name for azure-devops


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
