### PR TITLE
DTSPO-6489 - fluxv2 ithc migration - admin

### DIFF
--- a/apps/admin/aad-pod-identity/ithc/azure-identity-patch.yaml
+++ b/apps/admin/aad-pod-identity/ithc/azure-identity-patch.yaml
@@ -1,0 +1,6 @@
+- op: replace
+  path: /spec/resourceID
+  value: /subscriptions/ba71a911-e0d6-4776-a1a6-079af1df7139/resourceGroups/genesis-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aks-ithc-mi
+- op: replace
+  path: /spec/clientID
+  value: 9bcd6a33-c10b-4a8b-a77d-7341592874de

--- a/apps/admin/ithc/00/kustomization.yaml
+++ b/apps/admin/ithc/00/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
 
 patchesStrategicMerge:
   - ../../kube-slack/ithc/00.yaml
+  - ../../kured/ithc/00.yaml 

--- a/apps/admin/ithc/00/kustomization.yaml
+++ b/apps/admin/ithc/00/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base
+
+patchesStrategicMerge:
+  - ../../kube-slack/ithc/00.yaml

--- a/apps/admin/ithc/01/kustomization.yaml
+++ b/apps/admin/ithc/01/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base
+
+patchesStrategicMerge:
+  - ../../kube-slack/ithc/01.yaml
+  - ../../secrets-csi-driver/ithc/01.yaml

--- a/apps/admin/ithc/01/kustomization.yaml
+++ b/apps/admin/ithc/01/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
 patchesStrategicMerge:
   - ../../kube-slack/ithc/01.yaml
   - ../../secrets-csi-driver/ithc/01.yaml
+  - ../../kured/ithc/01.yaml

--- a/apps/admin/ithc/base/kustomization.yaml
+++ b/apps/admin/ithc/base/kustomization.yaml
@@ -3,8 +3,8 @@ kind: Kustomization
 resources:
   - ../../base
   - ../../kube-slack/ithc/kube-slack-values.enc.yaml
-  - ../../kured/ithc/kured-values.enc.yaml
   - ../../../rbac/reader-clusterrole.yaml
+  - ../../kured/ithc/kured-values.enc.yaml
 namespace: admin
 patchesStrategicMerge:
   - ../../traefik2/ithc/secret-provider.yaml

--- a/apps/admin/ithc/base/kustomization.yaml
+++ b/apps/admin/ithc/base/kustomization.yaml
@@ -1,0 +1,17 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+  - ../../kube-slack/ithc/kube-slack-values.enc.yaml
+  - ../../kured/ithc/kured-values.enc.yaml
+  - ../../../rbac/reader-clusterrole.yaml
+namespace: admin
+patchesStrategicMerge:
+  - ../../traefik2/ithc/secret-provider.yaml
+patches:
+  - path: ../../aad-pod-identity/ithc/azure-identity-patch.yaml
+    target:
+      group: aadpodidentity.k8s.io
+      version: v1
+      kind: AzureIdentity
+      name: aks-pod-identity-mi

--- a/apps/admin/kured/ithc/00.yaml
+++ b/apps/admin/kured/ithc/00.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: kured
+  namespace: admin
+spec:
+  values:
+    extraArgs:
+      slack-username: ithc-00-aks
+      slack-channel: aks-monitor-ss

--- a/apps/admin/kured/ithc/01.yaml
+++ b/apps/admin/kured/ithc/01.yaml
@@ -1,0 +1,11 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: kured
+  namespace: admin
+spec:
+  values:
+    extraArgs:
+      slack-username: ithc-01-aks
+      slack-channel: aks-monitor-ss

--- a/apps/admin/kured/ithc/kured-values.enc.yaml
+++ b/apps/admin/kured/ithc/kured-values.enc.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+data:
+  values.yaml: ENC[AES256_GCM,data:6hVqwT81hbZRXtQieo+PRraIKP3OW42nBDV6ZjzaxQjVILzPdPmYAZ5j4fHflz2+TqgkIptBWHw5o5REdCXziygnWAj0ct0lBmYNFgACkO7kowXarxKGZyGZJ9H0b6aGeLXfx7vtMINReqhEiN1VsspACVQp5B2ODcnEGipCx4efvzSq+14f3pRSYKM=,iv:eM0aYaYSRsqITrzpXJ4wNBMFsxivZV1BKv4RxIMHnYM=,tag:8WiJ85jCsxrb06h7DatfqA==,type:str]
+kind: Secret
+metadata:
+  creationTimestamp: null
+  name: kured-values
+  namespace: admin
+sops:
+  kms: []
+  gcp_kms: []
+  azure_kv:
+    - vault_url: https://dtssharedservicesithckv.vault.azure.net
+      name: sops-key
+      version: 96812ee192044e6daabee8d3621b456f
+      created_at: "2022-04-20T14:38:16Z"
+      enc: OP5AAurS_Lb_vnZRgn1j33raBT68njUacxj88wFV_7SBxpXRZSte9AnAGgJY5pBUiVSvbLp5pXcP2Fn0q33NUFX8kxfGdhlS1oxlcwd-YXaBiFq-AKPKHWVkfYMULv6XQ2G0zyvCFOJ_SH0OdiERSG6tMw_sHar-hdBhSXP8R-qDJb0RRbx3k89QyhxDiRmXF2nIhqXCIABxYHiXt2qw4ctBZRAxagawOqoU8lTggDLUyk8zGStjHhn7-YJcGreBKAvN7F-67hODl-7yTpaDHaV8KLD7qDwYYaBTNMw7r-Nk_O7_wC5oCLRXBNUlusEoICZWSQmtlGP4_iurXRJp2A
+  hc_vault: []
+  age: []
+  lastmodified: "2022-04-20T14:38:20Z"
+  mac: ENC[AES256_GCM,data:funyP7bJn8DsEkugSaB3xkJnMBaLvW4m7UqPKT/2/hNvC8G/qD8rL6BRlX6wO3W9zBxsF9TWSK3c+My4M/92r5E+xslBm3Ovgdu30YEufQt38e5YKD/Op/zbGV/xj+2L+mLwYC3747W8M9BPl0If5xfdPA2JRhTAvSCeUWQzlDI=,iv:Uvspjsxy/K/r4+2ZQjrF059OieJnpVkPzx4WEYS+e+A=,tag:7J+ZZfIYCgZviq8l9Oiglg==,type:str]
+  pgp: []
+  encrypted_regex: ^(data|stringData)$
+  version: 3.7.1

--- a/apps/admin/secrets-csi-driver/ithc/01.yaml
+++ b/apps/admin/secrets-csi-driver/ithc/01.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: csi-secrets-store-provider-azure
+  namespace: admin

--- a/apps/admin/traefik2/ithc/00-traefik2.yaml
+++ b/apps/admin/traefik2/ithc/00-traefik2.yaml
@@ -1,0 +1,10 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: traefik2
+  namespace: admin
+spec:
+  values:
+    service:
+      spec:
+        loadBalancerIP: "10.143.15.250"

--- a/apps/admin/traefik2/ithc/01-traefik2.yaml
+++ b/apps/admin/traefik2/ithc/01-traefik2.yaml
@@ -1,0 +1,10 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: traefik2
+  namespace: admin
+spec:
+  values:
+    service:
+      spec:
+        loadBalancerIP: "10.143.31.250"

--- a/apps/admin/traefik2/ithc/kustomization.yaml
+++ b/apps/admin/traefik2/ithc/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+patchesStrategicMerge:
+  - secret-provider.yaml

--- a/apps/admin/traefik2/ithc/secret-provider.yaml
+++ b/apps/admin/traefik2/ithc/secret-provider.yaml
@@ -1,0 +1,15 @@
+apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
+kind: SecretProviderClass
+metadata:
+  name: traefik-default-cert
+  namespace: admin
+spec:
+  parameters:
+    keyvaultName: acmedtssdsithc
+    objects: |
+      array:
+        - |
+          objectName: wildcard-ithc-platform-hmcts-net
+          objectType: secret
+          objectAlias: tls-cert
+          objectVersion: ""

--- a/k8s/environments/ithc/cluster-00-overlay/kustomization.yaml
+++ b/k8s/environments/ithc/cluster-00-overlay/kustomization.yaml
@@ -3,12 +3,12 @@ kind: Kustomization
 bases:
 # - ../../../release/admin/kube-slack
 - ../../../release/admin/kured
-- ../../../release/admin/secrets-csi-driver
+# - ../../../release/admin/secrets-csi-driver
 # - ../../../namespaces/azure-devops
-- ../../../namespaces/admin/aad-pod-identity
+# - ../../../namespaces/admin/aad-pod-identity
 - ../../../namespaces/kube-system/aad-pod-identity
 - ../../../namespaces/neuvector
-- ../../../namespaces/admin/traefik2
+# - ../../../namespaces/admin/traefik2
 # - ../../../release/admin/env-injector
 # - ../../../release/kube-system/nodelocaldns
 
@@ -23,8 +23,8 @@ patchesStrategicMerge:
 # - ../../../release/admin/kube-slack/patches/ithc/cluster-00/kube-slack.yaml
 
 #traefik patch
-- ../../../namespaces/admin/traefik2/patches/ithc/secret-provider.yaml
-- ../../../namespaces/admin/traefik2/patches/ithc/cluster-00/traefik2.yaml
+# - ../../../namespaces/admin/traefik2/patches/ithc/secret-provider.yaml
+# - ../../../namespaces/admin/traefik2/patches/ithc/cluster-00/traefik2.yaml
 
 #kured patch
 - ../../../release/admin/kured/patches/ithc/cluster-00/kured.yaml

--- a/k8s/environments/ithc/cluster-00-overlay/kustomization.yaml
+++ b/k8s/environments/ithc/cluster-00-overlay/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 bases:
 # - ../../../release/admin/kube-slack
-- ../../../release/admin/kured
+# - ../../../release/admin/kured
 # - ../../../release/admin/secrets-csi-driver
 # - ../../../namespaces/azure-devops
 # - ../../../namespaces/admin/aad-pod-identity
@@ -27,7 +27,7 @@ patchesStrategicMerge:
 # - ../../../namespaces/admin/traefik2/patches/ithc/cluster-00/traefik2.yaml
 
 #kured patch
-- ../../../release/admin/kured/patches/ithc/cluster-00/kured.yaml
+# - ../../../release/admin/kured/patches/ithc/cluster-00/kured.yaml
 
 #azure-devops-agent patch
 # - ../../../namespaces/azure-devops/azure-devops-agent/patches/ithc/cluster-00/azure-devops-agent.yaml

--- a/k8s/environments/ithc/cluster-01-overlay/kustomization.yaml
+++ b/k8s/environments/ithc/cluster-01-overlay/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 bases:
 # - ../../../release/admin/kube-slack
-- ../../../release/admin/kured
+# - ../../../release/admin/kured
 # - ../../../release/admin/secrets-csi-driver
 # - ../../../namespaces/azure-devops
 # - ../../../namespaces/admin/aad-pod-identity
@@ -27,7 +27,7 @@ patchesStrategicMerge:
 # - ../../../namespaces/admin/traefik2/patches/ithc/cluster-01/traefik2.yaml
 
 #kured patch
-- ../../../release/admin/kured/patches/ithc/cluster-01/kured.yaml
+# - ../../../release/admin/kured/patches/ithc/cluster-01/kured.yaml
 
 #azure-devops-agent patch
 # - ../../../namespaces/azure-devops/azure-devops-agent/patches/ithc/cluster-00/azure-devops-agent.yaml

--- a/k8s/environments/ithc/cluster-01-overlay/kustomization.yaml
+++ b/k8s/environments/ithc/cluster-01-overlay/kustomization.yaml
@@ -3,12 +3,12 @@ kind: Kustomization
 bases:
 # - ../../../release/admin/kube-slack
 - ../../../release/admin/kured
-- ../../../release/admin/secrets-csi-driver
+# - ../../../release/admin/secrets-csi-driver
 # - ../../../namespaces/azure-devops
-- ../../../namespaces/admin/aad-pod-identity
+# - ../../../namespaces/admin/aad-pod-identity
 - ../../../namespaces/kube-system/aad-pod-identity
 - ../../../namespaces/neuvector
-- ../../../namespaces/admin/traefik2
+# - ../../../namespaces/admin/traefik2
 # - ../../../release/admin/env-injector
 # - ../../../release/kube-system/nodelocaldns
 
@@ -23,8 +23,8 @@ patchesStrategicMerge:
 # - ../../../release/admin/kube-slack/patches/ithc/cluster-01/kube-slack.yaml
 
 #traefik patch
-- ../../../namespaces/admin/traefik2/patches/ithc/secret-provider.yaml
-- ../../../namespaces/admin/traefik2/patches/ithc/cluster-01/traefik2.yaml
+# - ../../../namespaces/admin/traefik2/patches/ithc/secret-provider.yaml
+# - ../../../namespaces/admin/traefik2/patches/ithc/cluster-01/traefik2.yaml
 
 #kured patch
 - ../../../release/admin/kured/patches/ithc/cluster-01/kured.yaml


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-6489


### Change description ###
Migrating some admin apps to flux v2
Will move kube-system and neuvector separately


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
