### PR TITLE
DTSPO-6491 - fix oauth config

### DIFF
--- a/apps/admin/traefik-auth-proxy/oauth-routes.yaml
+++ b/apps/admin/traefik-auth-proxy/oauth-routes.yaml
@@ -6,8 +6,6 @@ metadata:
 spec:
   entryPoints:
     - websecure
-  forwardedHeaders:
-    insecure: true
   routes:
     - kind: Rule
       match: PathPrefix(`/oauth-proxy/`)


### PR DESCRIPTION
### Change description ###
Fixing error: `"error":"IngressRoute/admin/oauth2-proxy dry-run failed, error: failed to create typed patch object: .spec.forwardedHeaders`


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
