### PR TITLE
DTSPO-6491 - add annotation for automatic dns

### DIFF
--- a/apps/admin/oauth2-proxy/oauth2-proxy.yaml
+++ b/apps/admin/oauth2-proxy/oauth2-proxy.yaml
@@ -71,6 +71,7 @@ spec:
         name: oauth2-proxy-values
     ingress:
       annotations:
+        kubernetes.io/ingress.class: traefik
         traefik.ingress.kubernetes.io/router.tls: "true"
       className: traefik
       enabled: true


### PR DESCRIPTION
### Change description ###
Waiting for ingressClassName filter to be available in external dns: https://github.com/kubernetes-sigs/external-dns/pull/2054


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
