### PR TITLE
DTSPO-8053 - Enable keda on test

### DIFF
--- a/apps/admin/aad-pod-identity/test/azure-identity-patch.yaml
+++ b/apps/admin/aad-pod-identity/test/azure-identity-patch.yaml
@@ -1,0 +1,6 @@
+- op: replace
+  path: /spec/resourceID
+  value: /subscriptions/3eec5bde-7feb-4566-bfb6-805df6e10b90/resourceGroups/genesis-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aks-test-mi
+- op: replace
+  path: /spec/clientID
+  value: d477322e-1f41-4bec-9fbb-fceecd4edcc2

--- a/apps/admin/keda/test/identity.yaml
+++ b/apps/admin/keda/test/identity.yaml
@@ -1,0 +1,9 @@
+apiVersion: "aadpodidentity.k8s.io/v1"
+kind: AzureIdentity
+metadata:
+  name: keda
+  namespace: admin
+spec:
+  type: 0
+  resourceID: "/subscriptions/3eec5bde-7feb-4566-bfb6-805df6e10b90/resourceGroups/managed-identities-test-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/keda-test-mi"
+  clientID: "d36579a7-f513-420c-910b-a45830b8438c"

--- a/apps/admin/test/00/kustomization.yaml
+++ b/apps/admin/test/00/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base
+
+patchesStrategicMerge:

--- a/apps/admin/test/01/kustomization.yaml
+++ b/apps/admin/test/01/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../base
+
+patchesStrategicMerge:

--- a/apps/admin/test/base/kustomization.yaml
+++ b/apps/admin/test/base/kustomization.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+  - ../../keda
+patchesStrategicMerge:
+  - ../../keda/test/identity.yaml
+patches:
+  - path: ../../aad-pod-identity/test/azure-identity-patch.yaml
+    target:
+      group: aadpodidentity.k8s.io
+      version: v1
+      kind: AzureIdentity
+      name: aks-pod-identity-mi

--- a/clusters/test/base/kustomization.yaml
+++ b/clusters/test/base/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../../apps/flux-system/test/base
+  - ../../../apps/admin/test/base
 patches:
   - path: ../../../apps/base/kustomize.yaml
     target:


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-8053


### Change description ###
Enable keda on test cluster
Requires admin namespace in test to be added to flux v2 config
Requires aad-pod-identity for test to be added


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
