### PR TITLE
DTSPO-8053 - Fix admin ns test cluster kustomization

### DIFF
--- a/clusters/test/base/kustomization.yaml
+++ b/clusters/test/base/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../../apps/flux-system/test/base
-  - ../../../apps/admin/test/base
+  - ../../../apps/admin/base/kustomize.yaml
 patches:
   - path: ../../../apps/base/kustomize.yaml
     target:


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-8053


### Change description ###
Fix kustomization for test so admin flux v2 config is enabled


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
