### PR TITLE
DTSPO-6488 - Bump neuvector chart version

### DIFF
--- a/apps/neuvector/neuvector/neuvector.yaml
+++ b/apps/neuvector/neuvector/neuvector.yaml
@@ -181,7 +181,7 @@ spec:
   chart:
     spec:
       chart: neuvector-azure-keyvault
-      version: 1.2.5
+      version: 1.2.7
       sourceRef:
         kind: HelmRepository
         name: hmctspublic


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-6488


### Change description ###
Bump neuvector chart version to 1.2.7 to mitigate error with post-install script


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
