### PR TITLE
Remove toffee apps from dev but mi's and namespace

### DIFF
--- a/apps/toffee/dev/base/kustomization.yaml
+++ b/apps/toffee/dev/base/kustomization.yaml
@@ -1,7 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ../../base
+  - ../../../base/namespace.yaml
+  - ../../identity/toffee-azure-identity.yaml
+  - ../../identity/apple-azure-identity.yaml
 namespace: toffee
 patchesStrategicMerge:
   - ../../identity/apple-azure-identity.yaml


### PR DESCRIPTION
### Change description ###
Remove toffee apps from dev but mi's and namespace

Tested locally and looks good


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
