### PR TITLE
DTSPO-6494 - Migrate Toffee to Flux V2

### DIFF
--- a/apps/toffee/base/kustomization.yaml
+++ b/apps/toffee/base/kustomization.yaml
@@ -5,6 +5,5 @@ resources:
   - ../frontend/toffee-frontend.yaml
   - ../recipe-backend/toffee-recipe-backend.yaml
   - ../identity/toffee-azure-identity.yaml
-  - ../identity/apple-azure-identity.yaml
   - ../recipe-receiver/toffee-recipe-receiver.yaml
 namespace: toffee

--- a/apps/toffee/demo/base/kustomization.yaml
+++ b/apps/toffee/demo/base/kustomization.yaml
@@ -4,7 +4,6 @@ resources:
   - ../../base
 namespace: toffee
 patchesStrategicMerge:
-  - ../../identity/apple-azure-identity.yaml
   - ../../identity/demo.yaml
   - ../../frontend/demo.yaml
   - ../../recipe-backend/demo.yaml

--- a/apps/toffee/dev/base/kustomization.yaml
+++ b/apps/toffee/dev/base/kustomization.yaml
@@ -4,5 +4,4 @@ resources:
   - ../../base
 namespace: toffee
 patchesStrategicMerge:
-  - ../../identity/apple-azure-identity.yaml
   - ../../identity/dev.yaml

--- a/apps/toffee/frontend/demo.yaml
+++ b/apps/toffee/frontend/demo.yaml
@@ -3,8 +3,6 @@ kind: HelmRelease
 metadata:
   name: toffee-frontend
   namespace: toffee
-  annotations:
-    fluxcd.io/automated: "false"
 spec:
   values:
     nodejs:

--- a/apps/toffee/frontend/ithc.yaml
+++ b/apps/toffee/frontend/ithc.yaml
@@ -3,8 +3,6 @@ kind: HelmRelease
 metadata:
   name: toffee-frontend
   namespace: toffee
-  annotations:
-    fluxcd.io/automated: "false"
 spec:
   values:
     nodejs:

--- a/apps/toffee/frontend/prod.yaml
+++ b/apps/toffee/frontend/prod.yaml
@@ -1,0 +1,23 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: toffee-frontend
+  namespace: toffee
+  annotations:
+    fluxcd.io/automated: "false"
+spec:
+  values:
+    nodejs:
+      image: sdshmctspublic.azurecr.io/toffee/frontend:prod-91925d1-20220606152310 #{"$imagepolicy": "flux-system:toffee-frontend"}
+      ingressHost: toffee.platform.hmcts.net
+      environment:
+        RECIPE_BACKEND_URL: http://toffee-recipe-backend.platform.hmcts.net
+    global:
+      environment: prod
+    volumes:
+      - name: azurekeyvault
+        csi:
+          driver: secrets-store.csi.k8s.io
+          readOnly: true
+          volumeAttributes:
+            secretProviderClass: "default-cert"

--- a/apps/toffee/frontend/prod.yaml
+++ b/apps/toffee/frontend/prod.yaml
@@ -3,8 +3,6 @@ kind: HelmRelease
 metadata:
   name: toffee-frontend
   namespace: toffee
-  annotations:
-    fluxcd.io/automated: "false"
 spec:
   values:
     nodejs:

--- a/apps/toffee/frontend/sbox.yaml
+++ b/apps/toffee/frontend/sbox.yaml
@@ -3,8 +3,6 @@ kind: HelmRelease
 metadata:
   name: toffee-frontend
   namespace: toffee
-  annotations:
-    fluxcd.io/automated: "false"
 spec:
   values:
     nodejs:

--- a/apps/toffee/frontend/toffee-frontend.yaml
+++ b/apps/toffee/frontend/toffee-frontend.yaml
@@ -2,8 +2,6 @@ apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease
 metadata:
   name: toffee-frontend
-  annotations:
-    filter.fluxcd.io/nodejs: glob:prod-*
 spec:
   interval: 5m
   releaseName: toffee-frontend

--- a/apps/toffee/identity/prod.yaml
+++ b/apps/toffee/identity/prod.yaml
@@ -1,0 +1,8 @@
+apiVersion: "aadpodidentity.k8s.io/v1"
+kind: AzureIdentity
+metadata:
+  name: toffee
+  namespace: toffee
+spec:
+  resourceID: /subscriptions/5ca62022-6aa2-4cee-aaa7-e7536c8d566c/resourcegroups/managed-identities-prod-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/toffee-prod-mi
+  clientID: 74b9420d-5d98-476b-adc9-a519a58b6f9e

--- a/apps/toffee/ithc/base/kustomization.yaml
+++ b/apps/toffee/ithc/base/kustomization.yaml
@@ -4,7 +4,6 @@ resources:
   - ../../base
 namespace: toffee
 patchesStrategicMerge:
-  - ../../identity/apple-azure-identity.yaml
   - ../../identity/ithc.yaml
   - ../../frontend/ithc.yaml
   - ../../recipe-backend/ithc.yaml

--- a/apps/toffee/prod/base/kustomization.yaml
+++ b/apps/toffee/prod/base/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+namespace: toffee
+patchesStrategicMerge:
+  - ../../identity/prod.yaml
+  - ../../frontend/prod.yaml
+  - ../../recipe-backend/prod.yaml
+  - ../../recipe-receiver/prod.yaml

--- a/apps/toffee/recipe-backend/demo.yaml
+++ b/apps/toffee/recipe-backend/demo.yaml
@@ -3,8 +3,6 @@ kind: HelmRelease
 metadata:
   name: toffee-recipe-backend
   namespace: toffee
-  annotations:
-    fluxcd.io/automated: "false"
 spec:
   values:
     java:

--- a/apps/toffee/recipe-backend/ithc.yaml
+++ b/apps/toffee/recipe-backend/ithc.yaml
@@ -3,8 +3,6 @@ kind: HelmRelease
 metadata:
   name: toffee-recipe-backend
   namespace: toffee
-  annotations:
-    fluxcd.io/automated: "false"
 spec:
   values:
     java:

--- a/apps/toffee/recipe-backend/prod.yaml
+++ b/apps/toffee/recipe-backend/prod.yaml
@@ -1,0 +1,12 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: toffee-recipe-backend
+  namespace: toffee
+spec:
+  values:
+    java:
+      image: sdshmctspublic.azurecr.io/toffee/recipe-backend:prod-070a43a-20220607120251 #{"$imagepolicy": "flux-system:toffee-recipe-backend"}
+      ingressHost: toffee-recipe-backend.platform.hmcts.net
+    global:
+      environment: prod

--- a/apps/toffee/recipe-backend/sbox.yaml
+++ b/apps/toffee/recipe-backend/sbox.yaml
@@ -3,8 +3,6 @@ kind: HelmRelease
 metadata:
   name: toffee-recipe-backend
   namespace: toffee
-  annotations:
-    fluxcd.io/automated: "false"
 spec:
   values:
     java:

--- a/apps/toffee/recipe-backend/toffee-recipe-backend.yaml
+++ b/apps/toffee/recipe-backend/toffee-recipe-backend.yaml
@@ -3,8 +3,6 @@ apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease
 metadata:
   name: toffee-recipe-backend
-  annotations:
-    filter.fluxcd.io/java: glob:prod-*
 spec:
   interval: 5 min
   releaseName: toffee-recipe-backend

--- a/apps/toffee/recipe-receiver/prod.yaml
+++ b/apps/toffee/recipe-receiver/prod.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: toffee-recipe-receiver
+spec:
+  values:
+    function:
+      image: sdshmctspublic.azurecr.io/toffee/recipe-receiver:prod-1100a0e-20220609130124 #{"$imagepolicy": "flux-system:toffee-recipe-receiver"}

--- a/apps/toffee/sbox/base/kustomization.yaml
+++ b/apps/toffee/sbox/base/kustomization.yaml
@@ -5,7 +5,6 @@ resources:
   - ../../identity/apple-azure-identity.yaml
 namespace: toffee
 patchesStrategicMerge:
-  # - ../../identity/apple-azure-identity.yaml
   - ../../identity/sbox.yaml
   - ../../frontend/sbox.yaml
   - ../../recipe-backend/sbox.yaml

--- a/apps/toffee/sbox/base/kustomization.yaml
+++ b/apps/toffee/sbox/base/kustomization.yaml
@@ -2,9 +2,10 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
+  - ../../identity/apple-azure-identity.yaml
 namespace: toffee
 patchesStrategicMerge:
-  - ../../identity/apple-azure-identity.yaml
+  # - ../../identity/apple-azure-identity.yaml
   - ../../identity/sbox.yaml
   - ../../frontend/sbox.yaml
   - ../../recipe-backend/sbox.yaml

--- a/apps/toffee/stg/base/kustomization.yaml
+++ b/apps/toffee/stg/base/kustomization.yaml
@@ -4,6 +4,5 @@ resources:
   - ../../base
 namespace: toffee
 patchesStrategicMerge:
-  - ../../identity/apple-azure-identity.yaml
   - ../../identity/stg.yaml
   - ../../recipe-receiver/stg.yaml

--- a/clusters/prod/base/kustomization.yaml
+++ b/clusters/prod/base/kustomization.yaml
@@ -6,7 +6,7 @@ resources:
 - ../../../apps/dynatrace/base/kustomize.yaml
 - ../../../apps/admin/base/kustomize.yaml
 - ../../../apps/pip/base/kustomize.yaml
-- ../../../apps/vh/base/kustomize.yaml
+- ../../../apps/toffee/base/kustomize.yaml
 
 patches:
 - path: ../../../apps/base/kustomize.yaml

--- a/clusters/prod/base/kustomization.yaml
+++ b/clusters/prod/base/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
 - ../../../apps/dynatrace/base/kustomize.yaml
 - ../../../apps/admin/base/kustomize.yaml
 - ../../../apps/pip/base/kustomize.yaml
+- ../../../apps/vh/base/kustomize.yaml
 
 patches:
 - path: ../../../apps/base/kustomize.yaml


### PR DESCRIPTION
### JIRA link (if applicable) ###
DTSPO-6494


### Change description ###
- Migrate Toffee to Flux V2
- Deploy Toffee to prod
- Remove old annotations
- Only deploy apple mi to sbox

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
