### PR TITLE
Adding staging back

### DIFF
--- a/apps/toffee/frontend/stg.yaml
+++ b/apps/toffee/frontend/stg.yaml
@@ -1,0 +1,23 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: toffee-frontend
+  namespace: toffee
+  annotations:
+    fluxcd.io/automated: "false"
+spec:
+  values:
+    nodejs:
+      image: sdshmctspublic.azurecr.io/toffee/frontend:prod-20db955-20220330143201 #{"$imagepolicy": "flux-system:toffee-frontend"}
+      ingressHost: toffee.staging.platform.hmcts.net
+      environment:
+        RECIPE_BACKEND_URL: http://toffee-recipe-backend.staging.platform.hmcts.net
+    global:
+      environment: staging
+    volumes:
+      - name: azurekeyvault
+        csi:
+          driver: secrets-store.csi.k8s.io
+          readOnly: true
+          volumeAttributes:
+            secretProviderClass: "default-cert"

--- a/apps/toffee/recipe-backend/stg.yaml
+++ b/apps/toffee/recipe-backend/stg.yaml
@@ -1,0 +1,14 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: toffee-recipe-backend
+  namespace: toffee
+  annotations:
+    fluxcd.io/automated: "false"
+spec:
+  values:
+    java:
+      image: sdshmctspublic.azurecr.io/toffee/recipe-backend:prod-7098754-20220302151854 #{"$imagepolicy": "flux-system:toffee-recipe-backend"}
+      ingressHost: toffee-recipe-backend.staging.platform.hmcts.net
+    global:
+      environment: staging

--- a/apps/toffee/stg/base/kustomization.yaml
+++ b/apps/toffee/stg/base/kustomization.yaml
@@ -6,3 +6,5 @@ namespace: toffee
 patchesStrategicMerge:
   - ../../identity/stg.yaml
   - ../../recipe-receiver/stg.yaml
+  - ../../frontend/stg.yaml
+  - ../../recipe-backend/stg.yaml


### PR DESCRIPTION
### Change description ###
Adding staging back, not sure if it was removed on purpose, but toffee is still being deployed just without an ingress and whatever else in the hr overlay for staging.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
