### PR TITLE
DTSPO-6494 - remove flux v1 config for traefik & pod identity on prod 01

### DIFF
--- a/k8s/environments/prod/cluster-01-overlay/kustomization.yaml
+++ b/k8s/environments/prod/cluster-01-overlay/kustomization.yaml
@@ -1,10 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 bases:
-- ../../../namespaces/admin/traefik2
 - ../../../namespaces/azure-devops
-- ../../../namespaces/admin/aad-pod-identity
-- ../../../namespaces/kube-system/aad-pod-identity
 - ../../../namespaces/neuvector
 - ../../../namespaces/monitoring/kube-prometheus-stack
 
@@ -14,10 +11,6 @@ patches:
     kind: HelmRelease
 
 patchesStrategicMerge:
-
-#traefik patch
-- ../../../namespaces/admin/traefik2/patches/prod/secret-provider.yaml
-- ../../../namespaces/admin/traefik2/patches/prod/cluster-01/traefik2.yaml
 
 #azure-devops-agent patch
 - ../../../namespaces/azure-devops/azure-devops-agent/patches/prod/cluster-01/azure-devops-agent.yaml


### PR DESCRIPTION
### Change description ###
- Removing flux v1 traefik config for prod 01 
- Removing flux v1 pod identity config on prod 01 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
