### PR TITLE
DTSPO-6494 - fix structure of mi identities 

### DIFF
--- a/apps/mi/base/kustomization.yaml
+++ b/apps/mi/base/kustomization.yaml
@@ -4,12 +4,12 @@ resources:
   - ../../base
   - mi-developer-rbac.yaml
   - ../mi-azure-functions/mi-azure-functions.yaml
-  - ../mi-azure-functions/mi-azure-functions-identity.yaml
-  - ../mi-azure-functions/mi-azure-functions-identity-binding.yaml
+  - ../identity/mi-azure-functions-identity.yaml
+  - ../identity/mi-azure-functions-identity-binding.yaml
   - ../mi-adf-shir/mi-adf-shir.yaml
-  - ../mi-house-keeping-service/mi-house-keeping-service-identity-binding.yaml
-  - ../mi-house-keeping-service/mi-house-keeping-service-identity.yaml
+  - ../identity/mi-house-keeping-service-identity-binding.yaml
+  - ../identity/mi-house-keeping-service-identity.yaml
   - ../mi-house-keeping-service/mi-house-keeping-service.yaml
-  - ../mi-integration-service/mi-integration-service-identity-binding.yaml
-  - ../mi-integration-service/mi-integration-service-identity.yaml
+  - ../identity/mi-integration-service-identity-binding.yaml
+  - ../identity/mi-integration-service-identity.yaml
 namespace: mi

--- a/apps/mi/dev/base/kustomization.yaml
+++ b/apps/mi/dev/base/kustomization.yaml
@@ -8,7 +8,7 @@ resources:
   - ../../mi-reverse-proxy/mi-reverse-proxy-secret-provider.yaml
 
 patchesStrategicMerge:
-- ../../identity/dev.yaml
+  - ../../identity/dev.yaml
 
 patches:
   #overlays for mi-azure-functions

--- a/apps/mi/dev/base/kustomization.yaml
+++ b/apps/mi/dev/base/kustomization.yaml
@@ -1,37 +1,22 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: mi
 resources:
   - ../../base
   - ../../mi-adf-shir/dev/mi-adf-auth-values.enc.yaml
   - ../../mi-reverse-proxy/mi-reverse-proxy.yaml
   - ../../mi-reverse-proxy/mi-reverse-proxy-secret-provider.yaml
-namespace: mi
+
+patchesStrategicMerge:
+- ../../identity/dev.yaml
+
 patches:
   #overlays for mi-azure-functions
   - path: ../../mi-azure-functions/dev.yaml
-  - path: ../../mi-azure-functions/dev-identity-patch.yaml
-    target:
-      group: aadpodidentity.k8s.io
-      version: v1
-      kind: AzureIdentity
-      name: mi-azure-functions
   #overlays for mi-adf-shir
   - path: ../../mi-adf-shir/dev/dev.yaml
   #overlays for mi-house-keeping-service
   - path: ../../mi-house-keeping-service/dev.yaml
-  - path: ../../mi-house-keeping-service/dev-identity-patch.yaml
-    target:
-      group: aadpodidentity.k8s.io
-      version: v1
-      kind: AzureIdentity
-      name: mi-house-keeping-service
-  #overlays for mi-integration-service identity for adf-shir
-  - path: ../../mi-integration-service/dev-identity-patch.yaml
-    target:
-      group: aadpodidentity.k8s.io
-      version: v1
-      kind: AzureIdentity
-      name: mi-integration-service
   #overlays for mi-reverse-proxy-secret-provider
   - path: ../../mi-reverse-proxy/dev-secret-provider-patch.yaml
     target:

--- a/apps/mi/identity/dev.yaml
+++ b/apps/mi/identity/dev.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: aadpodidentity.k8s.io/v1
+kind: AzureIdentity
+metadata:
+  name: mi-azure-functions
+  namespace: mi
+spec:
+  resourceID: /subscriptions/867a878b-cb68-4de5-9741-361ac9e178b6/resourceGroups/managed-identities-dev-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-azure-functions-dev-mi
+  clientID: ac07f3c3-de8b-4df7-ad08-7ca2db07e220
+
+---
+apiVersion: aadpodidentity.k8s.io/v1
+kind: AzureIdentity
+metadata:
+  name: mi-house-keeping-service
+  namespace: mi
+spec:
+  resourceID: /subscriptions/867a878b-cb68-4de5-9741-361ac9e178b6/resourceGroups/managed-identities-dev-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-housekeeping-service-dev-mi
+  clientID: 5793ad47-8629-4723-82dc-78b1b49ed280
+
+---
+apiVersion: aadpodidentity.k8s.io/v1
+kind: AzureIdentity
+metadata:
+  name: mi-integration-service
+  namespace: mi
+spec:
+  resourceID: /subscriptions/867a878b-cb68-4de5-9741-361ac9e178b6/resourceGroups/managed-identities-dev-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-integration-service-dev-mi
+  clientID: 47b18d2f-9a02-4f45-a87c-bacd17ea3583

--- a/apps/mi/identity/ithc.yaml
+++ b/apps/mi/identity/ithc.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: aadpodidentity.k8s.io/v1
+kind: AzureIdentity
+metadata:
+  name: mi-azure-functions
+  namespace: mi
+spec:
+  resourceID: /subscriptions/ba71a911-e0d6-4776-a1a6-079af1df7139/resourceGroups/managed-identities-ithc-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-azure-functions-ithc-mi
+  clientID: 259b6e80-5132-40af-a35b-b3413ae828a9
+
+---
+apiVersion: aadpodidentity.k8s.io/v1
+kind: AzureIdentity
+metadata:
+  name: mi-house-keeping-service
+  namespace: mi
+spec:
+  resourceID: /subscriptions/ba71a911-e0d6-4776-a1a6-079af1df7139/resourceGroups/managed-identities-ithc-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-housekeeping-service-ithc-mi
+  clientID: baf8db11-a87e-4212-8c85-d72622dc26c9
+
+---
+apiVersion: aadpodidentity.k8s.io/v1
+kind: AzureIdentity
+metadata:
+  name: mi-integration-service
+  namespace: mi
+spec:
+  resourceID: /subscriptions/ba71a911-e0d6-4776-a1a6-079af1df7139/resourceGroups/managed-identities-ithc-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-integration-service-ithc-mi
+  clientID: 9106f8ad-3189-4053-925d-0d4579c4e0d9

--- a/apps/mi/identity/mi-azure-functions-identity-binding.yaml
+++ b/apps/mi/identity/mi-azure-functions-identity-binding.yaml
@@ -1,4 +1,4 @@
-apiVersion: "aadpodidentity.k8s.io/v1"
+apiVersion: aadpodidentity.k8s.io/v1
 kind: AzureIdentityBinding
 metadata:
   name: mi-azure-functions

--- a/apps/mi/identity/mi-azure-functions-identity.yaml
+++ b/apps/mi/identity/mi-azure-functions-identity.yaml
@@ -1,0 +1,7 @@
+apiVersion: aadpodidentity.k8s.io/v1
+kind: AzureIdentity
+metadata:
+  name: mi-azure-functions
+  namespace: mi
+spec:
+  type: 0

--- a/apps/mi/identity/mi-house-keeping-service-identity-binding.yaml
+++ b/apps/mi/identity/mi-house-keeping-service-identity-binding.yaml
@@ -1,4 +1,4 @@
-apiVersion: "aadpodidentity.k8s.io/v1"
+apiVersion: aadpodidentity.k8s.io/v1
 kind: AzureIdentityBinding
 metadata:
   name: mi-house-keeping-service

--- a/apps/mi/identity/mi-house-keeping-service-identity.yaml
+++ b/apps/mi/identity/mi-house-keeping-service-identity.yaml
@@ -1,9 +1,7 @@
-apiVersion: "aadpodidentity.k8s.io/v1"
+apiVersion: aadpodidentity.k8s.io/v1
 kind: AzureIdentity
 metadata:
   name: mi-house-keeping-service
   namespace: mi
 spec:
   type: 0
-  resourceID: replace
-  clientID: replace

--- a/apps/mi/identity/mi-integration-service-identity-binding.yaml
+++ b/apps/mi/identity/mi-integration-service-identity-binding.yaml
@@ -1,4 +1,4 @@
-apiVersion: "aadpodidentity.k8s.io/v1"
+apiVersion: aadpodidentity.k8s.io/v1
 kind: AzureIdentityBinding
 metadata:
   name: mi-integration-service

--- a/apps/mi/identity/mi-integration-service-identity.yaml
+++ b/apps/mi/identity/mi-integration-service-identity.yaml
@@ -1,0 +1,7 @@
+apiVersion: aadpodidentity.k8s.io/v1
+kind: AzureIdentity
+metadata:
+  name: mi-integration-service
+  namespace: mi
+spec:
+  type: 0

--- a/apps/mi/identity/prod.yaml
+++ b/apps/mi/identity/prod.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: aadpodidentity.k8s.io/v1
+kind: AzureIdentity
+metadata:
+  name: mi-azure-functions
+  namespace: mi
+spec:
+  resourceID: /subscriptions/5ca62022-6aa2-4cee-aaa7-e7536c8d566c/resourceGroups/managed-identities-prod-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-azure-functions-prod-mi
+  clientID: 6ca63ebe-d898-42fb-b5bb-88d67433c78f
+
+---
+apiVersion: aadpodidentity.k8s.io/v1
+kind: AzureIdentity
+metadata:
+  name: mi-house-keeping-service
+  namespace: mi
+spec:
+  resourceID: /subscriptions/5ca62022-6aa2-4cee-aaa7-e7536c8d566c/resourceGroups/managed-identities-prod-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-housekeeping-service-prod-mi
+  clientID: 12d8c94d-2d49-48d8-9e1b-0bc9937c6670
+
+---
+apiVersion: aadpodidentity.k8s.io/v1
+kind: AzureIdentity
+metadata:
+  name: mi-integration-service
+  namespace: mi
+spec:
+  resourceID: /subscriptions/5ca62022-6aa2-4cee-aaa7-e7536c8d566c/resourceGroups/managed-identities-prod-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-integration-service-prod-mi
+  clientID: ee31a18f-45e9-41db-881d-5976695188fb

--- a/apps/mi/identity/sbox.yaml
+++ b/apps/mi/identity/sbox.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: aadpodidentity.k8s.io/v1
+kind: AzureIdentity
+metadata:
+  name: mi-azure-functions
+  namespace: mi
+spec:
+  resourceID: /subscriptions/a8140a9e-f1b0-481f-a4de-09e2ee23f7ab/resourceGroups/managed-identities-sbox-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-azure-functions-sbox-mi
+  clientID: 106e1ba9-8eef-4a9f-a103-b2f35052d717
+
+---
+apiVersion: aadpodidentity.k8s.io/v1
+kind: AzureIdentity
+metadata:
+  name: mi-house-keeping-service
+  namespace: mi
+spec:
+  resourceID: /subscriptions/a8140a9e-f1b0-481f-a4de-09e2ee23f7ab/resourceGroups/managed-identities-sbox-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-housekeeping-service-sbox-mi
+  clientID: f74e3f17-9785-480b-8bd4-fcac2b53c682
+
+---
+apiVersion: aadpodidentity.k8s.io/v1
+kind: AzureIdentity
+metadata:
+  name: mi-integration-service
+  namespace: mi
+spec:
+  resourceID: /subscriptions/a8140a9e-f1b0-481f-a4de-09e2ee23f7ab/resourceGroups/managed-identities-sbox-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-integration-service-sbox-mi
+  clientID: 9278a876-6f8a-489d-9053-01c996a7b6f6

--- a/apps/mi/identity/stg.yaml
+++ b/apps/mi/identity/stg.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: aadpodidentity.k8s.io/v1
+kind: AzureIdentity
+metadata:
+  name: mi-azure-functions
+  namespace: mi
+spec:
+  resourceID: /subscriptions/74dacd4f-a248-45bb-a2f0-af700dc4cf68/resourceGroups/managed-identities-stg-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-azure-functions-stg-mi
+  clientID: 51bbb6d8-80a8-4c6d-a003-ceaf583d5b69
+
+---
+apiVersion: aadpodidentity.k8s.io/v1
+kind: AzureIdentity
+metadata:
+  name: mi-house-keeping-service
+  namespace: mi
+spec:
+  resourceID: /subscriptions/74dacd4f-a248-45bb-a2f0-af700dc4cf68/resourceGroups/managed-identities-stg-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-housekeeping-service-stg-mi
+  clientID: 6ad9dea6-326e-4b34-9ccf-f7785b1ddb58
+
+---
+apiVersion: aadpodidentity.k8s.io/v1
+kind: AzureIdentity
+metadata:
+  name: mi-integration-service
+  namespace: mi
+spec:
+  resourceID: /subscriptions/74dacd4f-a248-45bb-a2f0-af700dc4cf68/resourceGroups/managed-identities-stg-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-integration-service-stg-mi
+  clientID: dfdc9e79-b5a5-44a9-892b-e02ebc31358f

--- a/apps/mi/identity/test.yaml
+++ b/apps/mi/identity/test.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: aadpodidentity.k8s.io/v1
+kind: AzureIdentity
+metadata:
+  name: mi-azure-functions
+  namespace: mi
+spec:
+  resourceID: /subscriptions/3eec5bde-7feb-4566-bfb6-805df6e10b90/resourceGroups/managed-identities-test-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-azure-functions-test-mi
+  clientID: 4531cfbf-c944-4025-bcac-9126016baa4c
+
+---
+apiVersion: aadpodidentity.k8s.io/v1
+kind: AzureIdentity
+metadata:
+  name: mi-house-keeping-service
+  namespace: mi
+spec:
+  resourceID: /subscriptions/3eec5bde-7feb-4566-bfb6-805df6e10b90/resourceGroups/managed-identities-test-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-housekeeping-service-test-mi
+  clientID: b97f7ade-7db0-41b0-bac2-22effc9d79b5
+
+---
+apiVersion: aadpodidentity.k8s.io/v1
+kind: AzureIdentity
+metadata:
+  name: mi-integration-service
+  namespace: mi
+spec:
+  resourceID: /subscriptions/3eec5bde-7feb-4566-bfb6-805df6e10b90/resourceGroups/managed-identities-test-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-integration-service-test-mi
+  clientID: 4b4479ac-2998-4353-b202-675df08389f5

--- a/apps/mi/ithc/base/kustomization.yaml
+++ b/apps/mi/ithc/base/kustomization.yaml
@@ -7,7 +7,7 @@ resources:
   - ../../mi-adf-shir/ithc/mi-adf-auth-values.enc.yaml
 
 patchesStrategicMerge:
-- ../../identity/ithc.yaml
+  - ../../identity/ithc.yaml
 
 patches:
   #overlays for mi-azure-functions

--- a/apps/mi/ithc/base/kustomization.yaml
+++ b/apps/mi/ithc/base/kustomization.yaml
@@ -1,32 +1,18 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: mi
+
 resources:
   - ../../base
   - ../../mi-adf-shir/ithc/mi-adf-auth-values.enc.yaml
-namespace: mi
+
+patchesStrategicMerge:
+- ../../identity/ithc.yaml
+
 patches:
   #overlays for mi-azure-functions
   - path: ../../mi-azure-functions/ithc.yaml
-  - path: ../../mi-azure-functions/ithc-identity-patch.yaml
-    target:
-      group: aadpodidentity.k8s.io
-      version: v1
-      kind: AzureIdentity
-      name: mi-azure-functions
   #overlays for mi-adf-shir
   - path: ../../mi-adf-shir/ithc/ithc.yaml
   #overlays for mi-house-keeping-service
   - path: ../../mi-house-keeping-service/ithc.yaml
-  - path: ../../mi-house-keeping-service/ithc-identity-patch.yaml
-    target:
-      group: aadpodidentity.k8s.io
-      version: v1
-      kind: AzureIdentity
-      name: mi-house-keeping-service
-  #overlays for mi-integration-service identity for adf-shir
-  - path: ../../mi-integration-service/ithc-identity-patch.yaml
-    target:
-      group: aadpodidentity.k8s.io
-      version: v1
-      kind: AzureIdentity
-      name: mi-integration-service

--- a/apps/mi/mi-azure-functions/dev-identity-patch.yaml
+++ b/apps/mi/mi-azure-functions/dev-identity-patch.yaml
@@ -1,6 +1,0 @@
-- op: replace
-  path: /spec/resourceID
-  value: /subscriptions/867a878b-cb68-4de5-9741-361ac9e178b6/resourceGroups/managed-identities-dev-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-azure-functions-dev-mi
-- op: replace
-  path: /spec/clientID
-  value: ac07f3c3-de8b-4df7-ad08-7ca2db07e220

--- a/apps/mi/mi-azure-functions/ithc-identity-patch.yaml
+++ b/apps/mi/mi-azure-functions/ithc-identity-patch.yaml
@@ -1,6 +1,0 @@
-- op: replace
-  path: /spec/resourceID
-  value: /subscriptions/ba71a911-e0d6-4776-a1a6-079af1df7139/resourceGroups/managed-identities-ithc-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-azure-functions-ithc-mi
-- op: replace
-  path: /spec/clientID
-  value: 259b6e80-5132-40af-a35b-b3413ae828a9

--- a/apps/mi/mi-azure-functions/mi-azure-functions-identity.yaml
+++ b/apps/mi/mi-azure-functions/mi-azure-functions-identity.yaml
@@ -1,9 +1,0 @@
-apiVersion: "aadpodidentity.k8s.io/v1"
-kind: AzureIdentity
-metadata:
-  name: mi-azure-functions
-  namespace: mi
-spec:
-  type: 0
-  resourceID: replace
-  clientID: replace

--- a/apps/mi/mi-azure-functions/sbox-identity-patch.yaml
+++ b/apps/mi/mi-azure-functions/sbox-identity-patch.yaml
@@ -1,6 +1,0 @@
-- op: replace
-  path: /spec/resourceID
-  value: /subscriptions/a8140a9e-f1b0-481f-a4de-09e2ee23f7ab/resourceGroups/managed-identities-sbox-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-azure-functions-sbox-mi
-- op: replace
-  path: /spec/clientID
-  value: 106e1ba9-8eef-4a9f-a103-b2f35052d717

--- a/apps/mi/mi-azure-functions/stg-identity-patch.yaml
+++ b/apps/mi/mi-azure-functions/stg-identity-patch.yaml
@@ -1,6 +1,0 @@
-- op: replace
-  path: /spec/resourceID
-  value: /subscriptions/74dacd4f-a248-45bb-a2f0-af700dc4cf68/resourceGroups/managed-identities-stg-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-azure-functions-stg-mi
-- op: replace
-  path: /spec/clientID
-  value: 51bbb6d8-80a8-4c6d-a003-ceaf583d5b69

--- a/apps/mi/mi-azure-functions/test-identity-patch.yaml
+++ b/apps/mi/mi-azure-functions/test-identity-patch.yaml
@@ -1,6 +1,0 @@
-- op: replace
-  path: /spec/resourceID
-  value: /subscriptions/3eec5bde-7feb-4566-bfb6-805df6e10b90/resourceGroups/managed-identities-test-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-azure-functions-test-mi
-- op: replace
-  path: /spec/clientID
-  value: 4531cfbf-c944-4025-bcac-9126016baa4c

--- a/apps/mi/mi-house-keeping-service/dev-identity-patch.yaml
+++ b/apps/mi/mi-house-keeping-service/dev-identity-patch.yaml
@@ -1,6 +1,0 @@
-- op: replace
-  path: /spec/resourceID
-  value: /subscriptions/867a878b-cb68-4de5-9741-361ac9e178b6/resourceGroups/managed-identities-dev-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-housekeeping-service-dev-mi
-- op: replace
-  path: /spec/clientID
-  value: 5793ad47-8629-4723-82dc-78b1b49ed280

--- a/apps/mi/mi-house-keeping-service/ithc-identity-patch.yaml
+++ b/apps/mi/mi-house-keeping-service/ithc-identity-patch.yaml
@@ -1,6 +1,0 @@
-- op: replace
-  path: /spec/resourceID
-  value: /subscriptions/ba71a911-e0d6-4776-a1a6-079af1df7139/resourceGroups/managed-identities-ithc-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-housekeeping-service-ithc-mi
-- op: replace
-  path: /spec/clientID
-  value: baf8db11-a87e-4212-8c85-d72622dc26c9

--- a/apps/mi/mi-house-keeping-service/sbox-identity-patch.yaml
+++ b/apps/mi/mi-house-keeping-service/sbox-identity-patch.yaml
@@ -1,6 +1,0 @@
-- op: replace
-  path: /spec/resourceID
-  value: /subscriptions/a8140a9e-f1b0-481f-a4de-09e2ee23f7ab/resourceGroups/managed-identities-sbox-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-housekeeping-service-sbox-mi
-- op: replace
-  path: /spec/clientID
-  value: f74e3f17-9785-480b-8bd4-fcac2b53c682

--- a/apps/mi/mi-house-keeping-service/stg-identity-patch.yaml
+++ b/apps/mi/mi-house-keeping-service/stg-identity-patch.yaml
@@ -1,6 +1,0 @@
-- op: replace
-  path: /spec/resourceID
-  value: /subscriptions/74dacd4f-a248-45bb-a2f0-af700dc4cf68/resourceGroups/managed-identities-stg-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-housekeeping-service-stg-mi
-- op: replace
-  path: /spec/clientID
-  value: 6ad9dea6-326e-4b34-9ccf-f7785b1ddb58

--- a/apps/mi/mi-house-keeping-service/test-identity-patch.yaml
+++ b/apps/mi/mi-house-keeping-service/test-identity-patch.yaml
@@ -1,6 +1,0 @@
-- op: replace
-  path: /spec/resourceID
-  value: /subscriptions/3eec5bde-7feb-4566-bfb6-805df6e10b90/resourceGroups/managed-identities-test-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-housekeeping-service-test-mi
-- op: replace
-  path: /spec/clientID
-  value: b97f7ade-7db0-41b0-bac2-22effc9d79b5

--- a/apps/mi/mi-integration-service/dev-identity-patch.yaml
+++ b/apps/mi/mi-integration-service/dev-identity-patch.yaml
@@ -1,6 +1,0 @@
-- op: replace
-  path: /spec/resourceID
-  value: /subscriptions/867a878b-cb68-4de5-9741-361ac9e178b6/resourceGroups/managed-identities-dev-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-integration-service-dev-mi
-- op: replace
-  path: /spec/clientID
-  value: 47b18d2f-9a02-4f45-a87c-bacd17ea3583

--- a/apps/mi/mi-integration-service/ithc-identity-patch.yaml
+++ b/apps/mi/mi-integration-service/ithc-identity-patch.yaml
@@ -1,6 +1,0 @@
-- op: replace
-  path: /spec/resourceID
-  value: /subscriptions/ba71a911-e0d6-4776-a1a6-079af1df7139/resourceGroups/managed-identities-ithc-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-integration-service-ithc-mi
-- op: replace
-  path: /spec/clientID
-  value: 9106f8ad-3189-4053-925d-0d4579c4e0d9

--- a/apps/mi/mi-integration-service/mi-integration-service-identity.yaml
+++ b/apps/mi/mi-integration-service/mi-integration-service-identity.yaml
@@ -1,9 +1,0 @@
-apiVersion: "aadpodidentity.k8s.io/v1"
-kind: AzureIdentity
-metadata:
-  name: mi-integration-service
-  namespace: mi
-spec:
-  type: 0
-  resourceID: replace
-  clientID: replace

--- a/apps/mi/mi-integration-service/sbox-identity-patch.yaml
+++ b/apps/mi/mi-integration-service/sbox-identity-patch.yaml
@@ -1,6 +1,0 @@
-- op: replace
-  path: /spec/resourceID
-  value: /subscriptions/a8140a9e-f1b0-481f-a4de-09e2ee23f7ab/resourceGroups/managed-identities-sbox-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-integration-service-sbox-mi
-- op: replace
-  path: /spec/clientID
-  value: 9278a876-6f8a-489d-9053-01c996a7b6f6

--- a/apps/mi/mi-integration-service/stg-identity-patch.yaml
+++ b/apps/mi/mi-integration-service/stg-identity-patch.yaml
@@ -1,6 +1,0 @@
-- op: replace
-  path: /spec/resourceID
-  value: /subscriptions/74dacd4f-a248-45bb-a2f0-af700dc4cf68/resourceGroups/managed-identities-stg-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-integration-service-stg-mi
-- op: replace
-  path: /spec/clientID
-  value: dfdc9e79-b5a5-44a9-892b-e02ebc31358f

--- a/apps/mi/mi-integration-service/test-identity-patch.yaml
+++ b/apps/mi/mi-integration-service/test-identity-patch.yaml
@@ -1,6 +1,0 @@
-- op: replace
-  path: /spec/resourceID
-  value: /subscriptions/3eec5bde-7feb-4566-bfb6-805df6e10b90/resourceGroups/managed-identities-test-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/mi-integration-service-test-mi
-- op: replace
-  path: /spec/clientID
-  value: 4b4479ac-2998-4353-b202-675df08389f5

--- a/apps/mi/sbox/base/kustomization.yaml
+++ b/apps/mi/sbox/base/kustomization.yaml
@@ -1,32 +1,18 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: mi
+
 resources:
   - ../../base
   - ../../mi-adf-shir/sbox/mi-adf-auth-values.enc.yaml
-namespace: mi
+
+patchesStrategicMerge:
+- ../../identity/sbox.yaml
+
 patches:
   #overlays for mi-azure-functions
   - path: ../../mi-azure-functions/sbox.yaml
-  - path: ../../mi-azure-functions/sbox-identity-patch.yaml
-    target:
-      group: aadpodidentity.k8s.io
-      version: v1
-      kind: AzureIdentity
-      name: mi-azure-functions
   #overlays for mi-adf-shir
   - path: ../../mi-adf-shir/sbox/sbox.yaml
   #overlays for mi-house-keeping-service
   - path: ../../mi-house-keeping-service/sbox.yaml
-  - path: ../../mi-house-keeping-service/sbox-identity-patch.yaml
-    target:
-      group: aadpodidentity.k8s.io
-      version: v1
-      kind: AzureIdentity
-      name: mi-house-keeping-service
-  #overlays for mi-integration-service
-  - path: ../../mi-integration-service/sbox-identity-patch.yaml
-    target:
-      group: aadpodidentity.k8s.io
-      version: v1
-      kind: AzureIdentity
-      name: mi-integration-service

--- a/apps/mi/sbox/base/kustomization.yaml
+++ b/apps/mi/sbox/base/kustomization.yaml
@@ -7,7 +7,7 @@ resources:
   - ../../mi-adf-shir/sbox/mi-adf-auth-values.enc.yaml
 
 patchesStrategicMerge:
-- ../../identity/sbox.yaml
+  - ../../identity/sbox.yaml
 
 patches:
   #overlays for mi-azure-functions

--- a/apps/mi/stg/base/kustomization.yaml
+++ b/apps/mi/stg/base/kustomization.yaml
@@ -7,7 +7,7 @@ resources:
   - ../../mi-adf-shir/stg/mi-adf-auth-values.enc.yaml
 
 patchesStrategicMerge:
-- ../../identity/stg.yaml
+  - ../../identity/stg.yaml
 
 patches:
   #overlays for mi-azure-functions

--- a/apps/mi/stg/base/kustomization.yaml
+++ b/apps/mi/stg/base/kustomization.yaml
@@ -1,32 +1,18 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: mi
+
 resources:
   - ../../base
   - ../../mi-adf-shir/stg/mi-adf-auth-values.enc.yaml
-namespace: mi
+
+patchesStrategicMerge:
+- ../../identity/stg.yaml
+
 patches:
   #overlays for mi-azure-functions
   - path: ../../mi-azure-functions/stg.yaml
-  - path: ../../mi-azure-functions/stg-identity-patch.yaml
-    target:
-      group: aadpodidentity.k8s.io
-      version: v1
-      kind: AzureIdentity
-      name: mi-azure-functions
   #overlays for mi-adf-shir
   - path: ../../mi-adf-shir/stg/stg.yaml
   #overlays for mi-house-keeping-service
   - path: ../../mi-house-keeping-service/stg.yaml
-  - path: ../../mi-house-keeping-service/stg-identity-patch.yaml
-    target:
-      group: aadpodidentity.k8s.io
-      version: v1
-      kind: AzureIdentity
-      name: mi-house-keeping-service
-  #overlays for mi-integration-service
-  - path: ../../mi-integration-service/stg-identity-patch.yaml
-    target:
-      group: aadpodidentity.k8s.io
-      version: v1
-      kind: AzureIdentity
-      name: mi-integration-service

--- a/apps/mi/test/base/kustomization.yaml
+++ b/apps/mi/test/base/kustomization.yaml
@@ -9,7 +9,8 @@ resources:
   - ../../mi-reverse-proxy/mi-reverse-proxy-secret-provider.yaml
 
 patchesStrategicMerge:
-- ../../identity/test.yaml
+  - ../../identity/test.yaml
+
 patches:
   #overlays for mi-azure-functions
   - path: ../../mi-azure-functions/test.yaml

--- a/apps/mi/test/base/kustomization.yaml
+++ b/apps/mi/test/base/kustomization.yaml
@@ -1,37 +1,22 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
+namespace: mi
+
 resources:
   - ../../base
   - ../../mi-adf-shir/test/mi-adf-auth-values.enc.yaml
   - ../../mi-reverse-proxy/mi-reverse-proxy.yaml
   - ../../mi-reverse-proxy/mi-reverse-proxy-secret-provider.yaml
-namespace: mi
+
+patchesStrategicMerge:
+- ../../identity/test.yaml
 patches:
   #overlays for mi-azure-functions
   - path: ../../mi-azure-functions/test.yaml
-  - path: ../../mi-azure-functions/test-identity-patch.yaml
-    target:
-      group: aadpodidentity.k8s.io
-      version: v1
-      kind: AzureIdentity
-      name: mi-azure-functions
   #overlays for mi-adf-shir
   - path: ../../mi-adf-shir/test/test.yaml
   #overlays for mi-house-keeping-service
   - path: ../../mi-house-keeping-service/test.yaml
-  - path: ../../mi-house-keeping-service/test-identity-patch.yaml
-    target:
-      group: aadpodidentity.k8s.io
-      version: v1
-      kind: AzureIdentity
-      name: mi-house-keeping-service
-  #overlays for mi-integration-service
-  - path: ../../mi-integration-service/test-identity-patch.yaml
-    target:
-      group: aadpodidentity.k8s.io
-      version: v1
-      kind: AzureIdentity
-      name: mi-integration-service
   #overlays for mi-reverse-proxy-secret-provider
   - path: ../../mi-reverse-proxy/test-secret-provider-patch.yaml
     target:


### PR DESCRIPTION
### Change description ###
- Bring structure of identities more inline with rest of flux v2 apps
- Tested all current environments, no changes planned

Moving identity base and patch files to identity folder like below:
```
apps/mi/identity
├── dev.yaml
├── ithc.yaml
├── mi-azure-functions-identity-binding.yaml
├── mi-azure-functions-identity.yaml
├── mi-house-keeping-service-identity-binding.yaml
├── mi-house-keeping-service-identity.yaml
├── mi-integration-service-identity-binding.yaml
├── mi-integration-service-identity.yaml
├── prod.yaml
├── sbox.yaml
├── stg.yaml
└── test.yaml
```

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
