### PR TITLE
Bump jenkins-packer version to 1.2.0

### DIFF
--- a/k8s/namespaces/jenkins/patches/ptl/cluster-00/jenkins.yaml
+++ b/k8s/namespaces/jenkins/patches/ptl/cluster-00/jenkins.yaml
@@ -369,7 +369,7 @@ spec:
                         existingStorageAccountName: "hmctsjenkinssds"
                         imageReference:
                           galleryImageDefinition: "jenkins-ubuntu"
-                          galleryImageVersion: "1.1.2"
+                          galleryImageVersion: "1.2.0"
                           galleryName: "hmcts"
                           galleryResourceGroup: "hmcts-image-gallery-rg"
                           gallerySubscriptionId: "2b1afc19-5ca9-4796-a56f-574a58670244"

--- a/k8s/namespaces/jenkins/patches/ptlsbox/cluster-00/jenkins.yaml
+++ b/k8s/namespaces/jenkins/patches/ptlsbox/cluster-00/jenkins.yaml
@@ -309,7 +309,7 @@ spec:
                         existingStorageAccountName: "hmctsjenkinssdssbox"
                         imageReference:
                           galleryImageDefinition: "jenkins-ubuntu"
-                          galleryImageVersion: "1.1.2"
+                          galleryImageVersion: "1.2.0"
                           galleryName: "hmcts"
                           galleryResourceGroup: "hmcts-image-gallery-rg"
                           gallerySubscriptionId: "2b1afc19-5ca9-4796-a56f-574a58670244"


### PR DESCRIPTION
**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSPO-9193
https://github.com/hmcts/jenkins-packer/commit/82cc8d660144bedeb9c6c3d59dfe0e80e7782f95

### Change description ###

Updates the jenkins-packer version used on jenkins builders to v 1.2.0

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
