### PR TITLE
Correct namespace in lgy-iac-web.yaml

### DIFF
--- a/apps/dts-legacy/lgy-iac-web/lgy-iac-web.yaml
+++ b/apps/dts-legacy/lgy-iac-web/lgy-iac-web.yaml
@@ -3,7 +3,7 @@ apiVersion: helm.toolkit.fluxcd.io/v2beta1
 kind: HelmRelease
 metadata:
   name: lgy-iac-web
-  namespace: legacy-apps
+  namespace: dts-legacy
 spec:
   releaseName: lgy-iac-web
   values:

--- a/k8s/namespaces/jenkins/patches/ptl/cluster-00/jenkins.yaml
+++ b/k8s/namespaces/jenkins/patches/ptl/cluster-00/jenkins.yaml
@@ -175,6 +175,12 @@ spec:
                     name: Libra GoB
                     recurse: true
                     title: Libra Green on Black Dashboard
+                - buildMonitor:
+                    includeRegex: >-
+                      ^HMCTS.*\/lgy-.*\/master
+                    name: Legacy
+                    recurse: true
+                    title: DTS Legacy Apps
           authentication: |
             jenkins:
               securityRealm:

--- a/k8s/namespaces/jenkins/patches/ptlsbox/cluster-00/jenkins.yaml
+++ b/k8s/namespaces/jenkins/patches/ptlsbox/cluster-00/jenkins.yaml
@@ -115,6 +115,12 @@ spec:
                     name: HMI
                     recurse: true
                     title: Hearing Management Interface
+                - buildMonitor:
+                    includeRegex: >-
+                      ^HMCTS.*\/lgy-.*\/master
+                    name: Legacy
+                    recurse: true
+                    title: DTS Legacy Apps
           authentication: |
             jenkins:
               securityRealm:


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RST-4469


### Change description ###
Add DTS Legacy monitor dashboard and correct namespace


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
