### PR TITLE
DTSPO-6493 - fix jenkins config

### DIFF
--- a/apps/jenkins/jenkins/helmrepo.yaml
+++ b/apps/jenkins/jenkins/helmrepo.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: jenkins
+  namespace: admin
+spec:
+  url: https://charts.jenkins.io
+  interval: 10m

--- a/apps/jenkins/jenkins/jenkins.yaml
+++ b/apps/jenkins/jenkins/jenkins.yaml
@@ -10,9 +10,13 @@ spec:
     timeout: 600s
   timeout: 600s
   chart:
-    repository: https://charts.jenkins.io
-    name: jenkins
-    version: 3.11.8
+    spec:
+      chart: jenkins
+      version: 3.11.8
+      sourceRef:
+        kind: HelmRepository
+        name: jenkins
+        namespace: admin
   values:
     controller:
       # Used for label app.kubernetes.io/component
@@ -189,32 +193,32 @@ spec:
                       - string:
                           scope: GLOBAL
                           id: sonarcloud-api-token
-                          secret: '${sonarcloud-api-token}'
+                          secret: '$${sonarcloud-api-token}'
                           description: SonarCloud API token
                       - string:
                           scope: GLOBAL
                           id: slack-token
-                          secret: '${slack-token}'
+                          secret: '$${slack-token}'
                           description: Slack token
                       - usernamePassword:
                           description: "SSH credentials for Jenkins agents"
                           id: "vm_agent_creds"
-                          password: "${jenkins-agent-password}"
+                          password: "$${jenkins-agent-password}"
                           scope: GLOBAL
                           username: "jenkinsssh"
                       - string:
                           description: "Read/Write Key To Publish CosmosDB Metrics"
                           id: "COSMOSDB_TOKEN_KEY"
                           scope: GLOBAL
-                          secret: "${cosmosdb-token-key}"
+                          secret: "$${cosmosdb-token-key}"
                       - usernamePassword:
                           description: "Username and password for the OWASP vulnerability database"
                           id: "owasp-db-login"
-                          password: "${OWASPDb-Password}"
+                          password: "$${OWASPDb-Password}"
                           scope: GLOBAL
                           username: "owasp_administrator"
                       - sauce:
-                          apiKey: "${sauce-access-key}"
+                          apiKey: "$${sauce-access-key}"
                           description: "Sauce Labs Reform Key"
                           id: "reform_tunnel"
                           scope: GLOBAL
@@ -222,7 +226,7 @@ spec:
                           restEndpoint: "https://eu-central-1.saucelabs.com/"
                       - azureImds:
                           azureEnvName: "Azure"
-                          subscriptionId: "${subscription-id}"
+                          subscriptionId: "$${subscription-id}"
                           description: "Jenkins Azure identity"
                           id: "jenkins-managed-identity"
                           scope: GLOBAL
@@ -230,13 +234,13 @@ spec:
                           appID: "52960"
                           description: "GitHub APP Key - CNP"
                           id: "hmcts-jenkins-cnp"
-                          privateKey: "${hmcts-jenkins-cnp-ghapp}"
+                          privateKey: "$${hmcts-jenkins-cnp-ghapp}"
                       - azureCosmosDB:
                           credentialsId: "jenkins-managed-identity"
                           id: "cosmos-connection"
                           preferredRegion: "UK South"
                           scope: GLOBAL
-                          url: "https://${pipeline-metrics-account-name}.documents.azure.com:443/"
+                          url: "https://$${pipeline-metrics-account-name}.documents.azure.com:443/"
           jobs: |
             jobs:
               - url: https://raw.githubusercontent.com/hmcts/sds-jenkins-config/master/jobdsl/organisations.groovy

--- a/apps/jenkins/jenkins/ptlsbox/jenkins.yaml
+++ b/apps/jenkins/jenkins/ptlsbox/jenkins.yaml
@@ -6,8 +6,9 @@ metadata:
   namespace: jenkins
 spec:
   chart:
-    repository: https://charts.jenkins.io
-    name: jenkins
+    spec:
+      chart: jenkins
+      version: 3.11.8
   values:
     controller:
       containerSecurityContext:
@@ -124,8 +125,8 @@ spec:
               securityRealm:
                 azure:
                   cacheDuration: 3600
-                  clientId: "${aad-auth-app-id}"
-                  clientSecret: "${aad-auth-client-secret}"
+                  clientId: "$${aad-auth-app-id}"
+                  clientSecret: "$${aad-auth-client-secret}"
                   tenant: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
           location: |
             unclassified:


### PR DESCRIPTION
### Change description ###
Disabling env var substitution on jenkins variables by using $${var} syntax, this is needed as flux was trying to substitute them and failing . Also needed to update the chart info as I missed doing that in the previous PR. Flux seems happy with the config now after the changes.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
