### PR TITLE
DTSPO-6492 - rename secret data to values.yaml

### DIFF
--- a/apps/monitoring/kube-prometheus-stack/ptl/prometheus-values.enc.yaml
+++ b/apps/monitoring/kube-prometheus-stack/ptl/prometheus-values.enc.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-  pro-values.yaml: ENC[AES256_GCM,data:pC2fc0kxv8DQES3rylKackzy1ELGv4ILPE+sz3Xo1h3PDW22l8QBPMirvChwjWXv9xddEwY3s+9XRFvQVrdBQh3mHAvb09cQgNwvLX2EbqhDglxQfmy1HohmASlPZZlYGeHc11SN71O08iewbHO072utP6tRMl3u32muyjhv9yDvOZQ21H0o1uyVkvBCUOd/lqbMNB2oi9ogEKFn9hH8Bs0MaSASgEPLMQScUXpLM7pBhGqNhyjjioxIMUQ=,iv:EU+GDCDsQNb1BhKlDd62JrdG/m6eRGGr3m7G1ADTp2E=,tag:8oNhYaelbB2JTcWlyjkVWg==,type:str]
+  values.yaml: ENC[AES256_GCM,data:dY3S8GtSct2l4uDN54hffRnTvkFocKZZh4lD21bXjuWndbXstn4BaYKBTyte9iydznx5FZLwECBcKqsV0se44RQ7YBmheBoYZlKhaas5vuf9h50KBcpPs8U7a5TUkNBY4BTuiDrqg3+Qr1tKopvpPmDz3+gbMg852PN8/mTDu4ftcSCS4lA1oY5mVmyR0fzO8R4T79KmNnfHFPHEbA7EnoGQeqOniigmdmeLOboWL9wOvIHaTSdcK0r9xTY=,iv:ZTttclRsP0V0gWLAL6UP8LfktDCmj2G2y8+Mb+xJygU=,tag:pPPtHIZbDYFJ03phrkxGjw==,type:str]
 kind: Secret
 metadata:
   creationTimestamp: null
@@ -13,12 +13,12 @@ sops:
     - vault_url: https://dtssdsptl.vault.azure.net
       name: sops-key
       version: b047792919f74e6c875ba3a8945ed7a9
-      created_at: "2022-07-20T10:32:21Z"
-      enc: crtj5_TOzHi1LyJPkKG-OdjzpuBCiMROzelpnCLI7Z3zzfGnMavLFW2bB3xexMZwOBXmA8f6GbCEtaU_f7yb-DspFYw-ejBi_K8YNigDnkGZY6tt4bm4ZL4r2KXSX2S6xRnsEeudlPLejJ-mZgVehZ78K2gb_KxMZnyQodsXK_DP9OpeNPY2YwEYc3NEy-YMPrJYC9uSDIP_Yh_4yc02a7OpnUReWSeCoq8VWYnzuFvD7g4u0j4liu1P3SDnYte_MLOFMwD7U4TMUkJ678vR44slpqzPYrdwagAyNHiJMxWbNKCF0bH4oPLYm61TIXXG9lat8Fz2Cc2EkqZjdffVIw
+      created_at: "2022-07-20T14:33:24Z"
+      enc: NRSirC6l1LSj2ukTmoyrOolH12qxdGBn6_3oXsM2nqI5gxm96aPuVHMLNEAh0s4LaTwRibIhUGeYzQvBW8nZopNDEqS8c550VGix25o23S5FaW6xZqp3yGCsctxyNa55zSe7AyZqQGAzJ-Zrre2j57CrjTFfMMvbwQKbzuT1SNt-WTcdldWBD5rQNDzNc4Av7255U5Pvp45X_DBBNWlCSFYoJYyjdeuiwpFSS9s_haFntgm36wkzdVeNjZxJrUEDeb76SQOevAdzye9Gv7sheZWNpRA1UWoSKycv_5Ai8rsIUFsOcVGsEgHipIe4hnecdFGkc_pW24BgkKpVjas1mQ
   hc_vault: []
   age: []
-  lastmodified: "2022-07-20T10:32:22Z"
-  mac: ENC[AES256_GCM,data:J8mufmyAiesRSmXM7PQi1VUW7fScqYbP+z07igK9XoW/Eq5jNn6dTkhn4zGfWjzL4rTx7dqfIN622kzVOCCvMkCoeXcNubcK66B2VIZ9TwwYZRkL5Sb7HeaSrFXFs+w0ICcwYraBAVbg/+V7JFP8FIVpbgOz9IhJebA0cYoKMkk=,iv:4riXKLTI5iK2XTQP8ZoNfu6jm9Lm0NJxJdqdbYLmolo=,tag:H7O9C5hCBAzTMBbBKlUtUA==,type:str]
+  lastmodified: "2022-07-20T14:33:25Z"
+  mac: ENC[AES256_GCM,data:PkTx0Wd74qD41H73fqFy06UwAHRGhhNJRKI86nP7F+5bF5+gbfjBoqqRiUBqTOMqnb0aLJ34ky8T9oappuInp7JFt6UOmv7z14FgnGjnZxoQhRJPe0q+BErlaFcmJ8CivDuEYpfio9xrESHO8O9Xqw6nfZpWb82DV21N6Og25eQ=,iv:kYSdodQB8gG5Bsp/yv9CMgKeoirV0RlrLdRENMcCFBw=,tag:fIGWgB5phwEgx7+RdGfNPA==,type:str]
   pgp: []
   encrypted_regex: ^(data|stringData)$
   version: 3.7.3


### PR DESCRIPTION
### Change description ###
Not sure if something has changed upstream but the helm release is complaining it can't find the secret data as its looking for `values.yaml` key.

Error: `missing key 'values.yaml' in Secret 'monitoring/prometheus-values'`


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
