### PR TITLE
DTSPO-6492 - add admin & netbox namespaces to flux v2 sync

### DIFF
--- a/clusters/ptl/base/kustomization.yaml
+++ b/clusters/ptl/base/kustomization.yaml
@@ -2,8 +2,10 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../../../apps/flux-system/ptl/base
+- ../../../apps/admin/base/kustomize.yaml
 - ../../../apps/azure-devops/base/kustomize.yaml
 - ../../../apps/monitoring/base/kustomize.yaml
+- ../../../apps/netbox/base/kustomize.yaml
 
 patches:
 - path: ../../../apps/base/kustomize.yaml


### PR DESCRIPTION
### Change description ###
Adding admin & netbox namespaces to flux v2 sync, but not removing from flux v1 yet. Will make sure the hr is looking good first.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
