### PR TITLE
DTSPO-9539 - remove csi driver and crds from sbox 01 temporarily

### DIFF
--- a/apps/admin/sbox/01/kustomization.yaml
+++ b/apps/admin/sbox/01/kustomization.yaml
@@ -5,3 +5,10 @@ resources:
 
 patchesStrategicMerge:
   - ../../traefik2/sbox/01-traefik2.yaml
+  - |-
+    apiVersion: helm.toolkit.fluxcd.io/v2beta1
+    kind: HelmRelease
+    metadata:
+      name: csi-secrets-store-provider-azure
+      namespace: admin
+    $patch: delete

--- a/clusters/sbox/01/kustomization.yaml
+++ b/clusters/sbox/01/kustomization.yaml
@@ -5,3 +5,20 @@ resources:
 
 patchesStrategicMerge:
 - ../../../apps/flux-system/sbox/01/kustomize.yaml
+- |-
+  apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+  kind: Kustomization
+  metadata:
+    name: csi-crd
+    namespace: flux-system
+  $patch: delete
+
+patchesJSON6902:
+- target:
+    group: kustomize.toolkit.fluxcd.io
+    version: v1beta2
+    kind: Kustomization
+    name: admin
+  patch: |-
+    - op: remove
+      path: /spec/dependsOn/0


### PR DESCRIPTION
### Change description ###
Removing csi driver and crds from sbox 01 to be able to test the cluster add-on properly


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
