### PR TITLE
Troubleshot: updating image on pod in cluster for mailrelay

### DIFF
--- a/apps/mailrelay2/mailrelay2/dev/01.yaml
+++ b/apps/mailrelay2/mailrelay2/dev/01.yaml
@@ -6,10 +6,6 @@ metadata:
   namespace: mailrelay2
 spec:
   values:
-    image:
-      repository: sdshmctspublic.azurecr.io/exim-relay
-      tag: pr-53
-      pullPolicy: IfNotPresent
     service:
       type: LoadBalancer
       loadBalancerIP: "10.145.31.32"

--- a/apps/mailrelay2/mailrelay2/dev/dev.yaml
+++ b/apps/mailrelay2/mailrelay2/dev/dev.yaml
@@ -8,7 +8,7 @@ spec:
   values:
     image:
       repository: sdshmctspublic.azurecr.io/exim-relay
-      tag: v0.2.16
+      tag: pr-53
       pullPolicy: IfNotPresent
     service:
       type: LoadBalancer


### PR DESCRIPTION
### Change description ###

`Troubleshot:` Testing mail delivery to other domain other then `.hmcts.net`.

Noticed that the relay would drop external domain email but deliver the email if its a `.hmcts.net`
Updating the pod image for one of the clusters to test out changes to the exim config

`NOTE:` This would be reverted soon as the exercise is complete. mailrelay pods in the cluster would be in and out of a healthy state for a bit as i tweak the config

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
