### PR TITLE
Fix sbox monitoring ingress by adding ingressclass

### DIFF
--- a/apps/admin/traefik2/sbox/01-traefik2.yaml
+++ b/apps/admin/traefik2/sbox/01-traefik2.yaml
@@ -8,3 +8,7 @@ spec:
     service:
       spec:
         loadBalancerIP: "10.140.31.250"
+    ingressClass:
+      # true is not unit-testable yet, pending https://github.com/rancher/helm-unittest/pull/12
+      enabled: true
+      isDefaultClass: true


### PR DESCRIPTION
### Change description ###
Testing in sbox 01, but we should probably do this all the way up to Prod. Currently the ingressClassName is being set in the ingress config in the kube-prometheus-stack spec, so we either remove that or do this. I think it's probably better to be explicit with setting the name but open to suggestions.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
