### PR TITLE
Add ingressclass to all environments

### DIFF
--- a/apps/admin/traefik2/sbox/01-traefik2.yaml
+++ b/apps/admin/traefik2/sbox/01-traefik2.yaml
@@ -8,7 +8,3 @@ spec:
     service:
       spec:
         loadBalancerIP: "10.140.31.250"
-    ingressClass:
-      # true is not unit-testable yet, pending https://github.com/rancher/helm-unittest/pull/12
-      enabled: true
-      isDefaultClass: true

--- a/apps/admin/traefik2/traefik2.yaml
+++ b/apps/admin/traefik2/traefik2.yaml
@@ -21,6 +21,9 @@ spec:
     deployment:
       podLabels:
         aadpodidbinding: traefik
+    ingressClass:
+      enabled: true
+      isDefaultClass: true
       additionalVolumes:
         - name: traefik-default-cert
           csi:


### PR DESCRIPTION
### Change description ###

Adding the ingressClass to all environments. I have suspended the admin kustomization on the prod clusters and will resume on cluster at a time.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
