### PR TITLE
Set ingressClass in spec rather than an annotation

### DIFF
--- a/apps/monitoring/kube-prometheus-stack/kube-prometheus-stack.yaml
+++ b/apps/monitoring/kube-prometheus-stack/kube-prometheus-stack.yaml
@@ -145,8 +145,8 @@ spec:
             - port: exporter
               path: /metrics
       ingress:
+        ingressClassName: traefik
         annotations:
-          kubernetes.io/ingress.class: traefik
           traefik.ingress.kubernetes.io/router.tls: "true"
         enabled: true
     prometheus-node-exporter:
@@ -176,8 +176,8 @@ spec:
                       values:
                         - system
       ingress:
+        ingressClassName: traefik
         annotations:
-          kubernetes.io/ingress.class: traefik
           traefik.ingress.kubernetes.io/router.tls: "true"
         enabled: true
       config:

--- a/apps/monitoring/kube-prometheus-stack/sbox/01.yaml
+++ b/apps/monitoring/kube-prometheus-stack/sbox/01.yaml
@@ -72,10 +72,6 @@ spec:
                       values:
                         - system
       ingress:
-        ingressClassName: traefik
-        annotations:
-          traefik.ingress.kubernetes.io/router.tls: "true"
-        enabled: true
         hosts:
           - sds-prometheus-01.sandbox.platform.hmcts.net
         tls:
@@ -99,10 +95,6 @@ spec:
                       values:
                         - system
       ingress:
-        ingressClassName: traefik
-        annotations:
-          traefik.ingress.kubernetes.io/router.tls: "true"
-        enabled: true
         hosts:
           - sds-alertmanager-01.sandbox.platform.hmcts.net
         tls:


### PR DESCRIPTION
### Change description ###
Now the traefik ingressClass has been deployed to all envs we can set the ingressClassName in the ingresses spec and stop using the deprecated way of using annotations.

- Set ingressClassName in ingress spec 
- Clean up sbox config

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
