### PR TITLE
DTSPO-9539 - remove csi driver from both sbox clusters

### DIFF
--- a/apps/admin/sbox/01/kustomization.yaml
+++ b/apps/admin/sbox/01/kustomization.yaml
@@ -5,10 +5,3 @@ resources:
 
 patchesStrategicMerge:
   - ../../traefik2/sbox/01-traefik2.yaml
-  - |-
-    apiVersion: helm.toolkit.fluxcd.io/v2beta1
-    kind: HelmRelease
-    metadata:
-      name: csi-secrets-store-provider-azure
-      namespace: admin
-    $patch: delete

--- a/apps/admin/sbox/base/kustomization.yaml
+++ b/apps/admin/sbox/base/kustomization.yaml
@@ -9,6 +9,15 @@ resources:
 patchesStrategicMerge:
   - ../../traefik2/sbox/secret-provider.yaml
   - ../../keda/sbox/identity.yaml
+  - ../../traefik2/sbox/01-traefik2.yaml
+  - |-
+    apiVersion: helm.toolkit.fluxcd.io/v2beta1
+    kind: HelmRelease
+    metadata:
+      name: csi-secrets-store-provider-azure
+      namespace: admin
+    $patch: delete
+
 patches:
   - path: ../../aad-pod-identity/sbox/azure-identity-patch.yaml
     target:

--- a/apps/admin/sbox/base/kustomization.yaml
+++ b/apps/admin/sbox/base/kustomization.yaml
@@ -9,7 +9,6 @@ resources:
 patchesStrategicMerge:
   - ../../traefik2/sbox/secret-provider.yaml
   - ../../keda/sbox/identity.yaml
-  - ../../traefik2/sbox/01-traefik2.yaml
   - |-
     apiVersion: helm.toolkit.fluxcd.io/v2beta1
     kind: HelmRelease

--- a/clusters/sbox/01/kustomization.yaml
+++ b/clusters/sbox/01/kustomization.yaml
@@ -5,20 +5,3 @@ resources:
 
 patchesStrategicMerge:
 - ../../../apps/flux-system/sbox/01/kustomize.yaml
-- |-
-  apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
-  kind: Kustomization
-  metadata:
-    name: csi-crd
-    namespace: flux-system
-  $patch: delete
-
-patchesJSON6902:
-- target:
-    group: kustomize.toolkit.fluxcd.io
-    version: v1beta2
-    kind: Kustomization
-    name: admin
-  patch: |-
-    - op: remove
-      path: /spec/dependsOn/0

--- a/clusters/sbox/base/kustomization.yaml
+++ b/clusters/sbox/base/kustomization.yaml
@@ -15,3 +15,22 @@ patches:
     target:
       kind: Kustomization
       annotationSelector: hmcts.github.com/kustomize-defaults != disabled
+
+patchesStrategicMerge:
+  - |-
+    apiVersion: kustomize.toolkit.fluxcd.io/v1beta2
+    kind: Kustomization
+    metadata:
+      name: csi-crd
+      namespace: flux-system
+    $patch: delete
+
+patchesJSON6902:
+  - target:
+      group: kustomize.toolkit.fluxcd.io
+      version: v1beta2
+      kind: Kustomization
+      name: admin
+    patch: |-
+      - op: remove
+        path: /spec/dependsOn/0


### PR DESCRIPTION
### Change description ###
Removing csi driver from both sbox clusters as we're using the aks add-on now


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
