### PR TITLE
DTSPO-9517 - Test using private acr for toffee

### DIFF
--- a/apps/toffee/frontend/prod.yaml
+++ b/apps/toffee/frontend/prod.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   values:
     nodejs:
-      image: sdshmctspublic.azurecr.io/toffee/frontend:prod-bf45eab-20220725102731 #{"$imagepolicy": "flux-system:toffee-frontend"}
+      image: sdshmctsprivate.azurecr.io/toffee/frontend:ek-test-4 #{"$imagepolicy": "flux-system:toffee-frontend"}
       ingressHost: toffee.platform.hmcts.net
       environment:
         RECIPE_BACKEND_URL: http://toffee-recipe-backend.platform.hmcts.net

--- a/apps/toffee/frontend/stg.yaml
+++ b/apps/toffee/frontend/stg.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   values:
     nodejs:
-      image: sdshmctspublic.azurecr.io/toffee/frontend:prod-bf45eab-20220725102731 #{"$imagepolicy": "flux-system:toffee-frontend"}
+      image: sdshmctsprivate.azurecr.io/toffee/frontend:ek-test-4 #{"$imagepolicy": "flux-system:toffee-frontend"}
       ingressHost: toffee.staging.platform.hmcts.net
       environment:
         RECIPE_BACKEND_URL: http://toffee-recipe-backend.staging.platform.hmcts.net


### PR DESCRIPTION
JIRA link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-9517

Change description
Testing toffee with new image to ensure stg and prod clusters can pull from private acr
Will be reverted after confirmation that authentication to private acr on prod is working

Does this PR introduce a breaking change? (check one with "x")
[ ] Yes
[x] No
