### PR TITLE
Revert "DTSPO-9517 - Test using private acr for toffee"

### DIFF
--- a/apps/toffee/frontend/prod.yaml
+++ b/apps/toffee/frontend/prod.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   values:
     nodejs:
-      image: sdshmctsprivate.azurecr.io/toffee/frontend:ek-test-4 #{"$imagepolicy": "flux-system:toffee-frontend"}
+      image: sdshmctspublic.azurecr.io/toffee/frontend:prod-bf45eab-20220725102731 #{"$imagepolicy": "flux-system:toffee-frontend"}
       ingressHost: toffee.platform.hmcts.net
       environment:
         RECIPE_BACKEND_URL: http://toffee-recipe-backend.platform.hmcts.net

--- a/apps/toffee/frontend/stg.yaml
+++ b/apps/toffee/frontend/stg.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   values:
     nodejs:
-      image: sdshmctsprivate.azurecr.io/toffee/frontend:ek-test-4 #{"$imagepolicy": "flux-system:toffee-frontend"}
+      image: sdshmctspublic.azurecr.io/toffee/frontend:prod-bf45eab-20220725102731 #{"$imagepolicy": "flux-system:toffee-frontend"}
       ingressHost: toffee.staging.platform.hmcts.net
       environment:
         RECIPE_BACKEND_URL: http://toffee-recipe-backend.staging.platform.hmcts.net


### PR DESCRIPTION
Reverts hmcts/sds-flux-config#2130

Pulling from private acr is working on both stg and prod clusters so this can be reverted