### PR TITLE
DTSPO-8561: Update exim image tag revert

### DIFF
--- a/apps/mailrelay2/mailrelay2/dev/dev.yaml
+++ b/apps/mailrelay2/mailrelay2/dev/dev.yaml
@@ -8,7 +8,7 @@ spec:
   values:
     image:
       repository: sdshmctspublic.azurecr.io/exim-relay
-      tag: v0.2.18
+      tag: v0.2.19
       pullPolicy: IfNotPresent
     service:
       type: LoadBalancer

--- a/apps/mailrelay2/mailrelay2/mailrelay2.yaml
+++ b/apps/mailrelay2/mailrelay2/mailrelay2.yaml
@@ -20,7 +20,7 @@ spec:
   values:
     image:
       repository: sdshmctspublic.azurecr.io/exim-relay
-      tag: v0.2.18
+      tag: v0.2.19
       pullPolicy: IfNotPresent
 
     service:


### PR DESCRIPTION
### Change description ###

Now looking to the exchange server configuration. Turns out it'd not been configed to work with the `dev-in` certificate for mailrelay2 traffic. taking investigation down one


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
