### PR TITLE
DTSPO-9517 - remove image automation components

### DIFF
--- a/apps/admin/aad-pod-identity/aks-kubelet-binding.yaml
+++ b/apps/admin/aad-pod-identity/aks-kubelet-binding.yaml
@@ -2,7 +2,7 @@ apiVersion: "aadpodidentity.k8s.io/v1"
 kind: AzureIdentityBinding
 metadata:
   name: aks-kubelet-identity-mi-binding
-  namespace: admin
+  namespace: flux-system
 spec:
   azureIdentity: aks-kubelet-identity-mi
   selector: aks-kubelet-identity-mi

--- a/apps/admin/aad-pod-identity/aks-kubelet-identity.yaml
+++ b/apps/admin/aad-pod-identity/aks-kubelet-identity.yaml
@@ -2,6 +2,6 @@ apiVersion: "aadpodidentity.k8s.io/v1"
 kind: AzureIdentity
 metadata:
   name: aks-kubelet-identity-mi
-  namespace: admin
+  namespace: flux-system
 spec:
   type: 0

--- a/apps/flux-system/demo/base/kustomization.yaml
+++ b/apps/flux-system/demo/base/kustomization.yaml
@@ -3,19 +3,3 @@ kind: Kustomization
 resources:
   - ../../base
   - git-credentials.enc.yaml
-  - ../../base/image-automation-components.yaml
-patches:
-  - target:
-      version: v1
-      group: apps
-      kind: Deployment
-      name: image-reflector-controller
-      namespace: flux-system
-    patch: |-
-      - op: add
-        path: /spec/template/spec/containers/0/args/-
-        value: --azure-autologin-for-acr
-        # Add this if you are using aad pod identity with managed identity
-      - op: add 
-        path: /spec/template/metadata/labels/aadpodidbinding
-        value: aks-kubelet-identity-mi

--- a/apps/flux-system/dev/base/kustomization.yaml
+++ b/apps/flux-system/dev/base/kustomization.yaml
@@ -3,19 +3,3 @@ kind: Kustomization
 resources:
   - ../../base
   - git-credentials.enc.yaml
-  - ../../base/image-automation-components.yaml
-patches:
-  - target:
-      version: v1
-      group: apps
-      kind: Deployment
-      name: image-reflector-controller
-      namespace: flux-system
-    patch: |-
-      - op: add
-        path: /spec/template/spec/containers/0/args/-
-        value: --azure-autologin-for-acr
-        # Add this if you are using aad pod identity with managed identity
-      - op: add 
-        path: /spec/template/metadata/labels/aadpodidbinding
-        value: aks-kubelet-identity-mi

--- a/apps/flux-system/ithc/base/kustomization.yaml
+++ b/apps/flux-system/ithc/base/kustomization.yaml
@@ -3,19 +3,3 @@ kind: Kustomization
 resources:
   - ../../base
   - git-credentials.enc.yaml
-  - ../../base/image-automation-components.yaml
-patches:
-  - target:
-      version: v1
-      group: apps
-      kind: Deployment
-      name: image-reflector-controller
-      namespace: flux-system
-    patch: |-
-      - op: add
-        path: /spec/template/spec/containers/0/args/-
-        value: --azure-autologin-for-acr
-        # Add this if you are using aad pod identity with managed identity
-      - op: add 
-        path: /spec/template/metadata/labels/aadpodidbinding
-        value: aks-kubelet-identity-mi

--- a/apps/flux-system/prod/base/kustomization.yaml
+++ b/apps/flux-system/prod/base/kustomization.yaml
@@ -3,19 +3,3 @@ kind: Kustomization
 resources:
   - git-credentials.enc.yaml
   - ../../base
-  - ../../base/image-automation-components.yaml
-patches:
-  - target:
-      version: v1
-      group: apps
-      kind: Deployment
-      name: image-reflector-controller
-      namespace: flux-system
-    patch: |-
-      - op: add
-        path: /spec/template/spec/containers/0/args/-
-        value: --azure-autologin-for-acr
-        # Add this if you are using aad pod identity with managed identity
-      - op: add 
-        path: /spec/template/metadata/labels/aadpodidbinding
-        value: aks-kubelet-identity-mi

--- a/apps/flux-system/ptlsbox/base/kustomization.yaml
+++ b/apps/flux-system/ptlsbox/base/kustomization.yaml
@@ -3,19 +3,3 @@ kind: Kustomization
 resources:
   - ../../base
   - git-credentials.enc.yaml
-  - ../../base/image-automation-components.yaml
-patches:
-  - target:
-      version: v1
-      group: apps
-      kind: Deployment
-      name: image-reflector-controller
-      namespace: flux-system
-    patch: |-
-      - op: add
-        path: /spec/template/spec/containers/0/args/-
-        value: --azure-autologin-for-acr
-        # Add this if you are using aad pod identity with managed identity
-      - op: add 
-        path: /spec/template/metadata/labels/aadpodidbinding
-        value: aks-kubelet-identity-mi

--- a/apps/flux-system/sbox/base/kustomization.yaml
+++ b/apps/flux-system/sbox/base/kustomization.yaml
@@ -3,19 +3,3 @@ kind: Kustomization
 resources:
   - ../../base
   - git-credentials.enc.yaml
-  - ../../base/image-automation-components.yaml
-patches:
-  - target:
-      version: v1
-      group: apps
-      kind: Deployment
-      name: image-reflector-controller
-      namespace: flux-system
-    patch: |-
-      - op: add
-        path: /spec/template/spec/containers/0/args/-
-        value: --azure-autologin-for-acr
-        # Add this if you are using aad pod identity with managed identity
-      - op: add 
-        path: /spec/template/metadata/labels/aadpodidbinding
-        value: aks-kubelet-identity-mi

--- a/apps/flux-system/stg/base/kustomization.yaml
+++ b/apps/flux-system/stg/base/kustomization.yaml
@@ -3,19 +3,3 @@ kind: Kustomization
 resources:
   - ../../base
   - git-credentials.enc.yaml
-  - ../../base/image-automation-components.yaml
-patches:
-  - target:
-      version: v1
-      group: apps
-      kind: Deployment
-      name: image-reflector-controller
-      namespace: flux-system
-    patch: |-
-      - op: add
-        path: /spec/template/spec/containers/0/args/-
-        value: --azure-autologin-for-acr
-        # Add this if you are using aad pod identity with managed identity
-      - op: add 
-        path: /spec/template/metadata/labels/aadpodidbinding
-        value: aks-kubelet-identity-mi

--- a/apps/flux-system/test/base/kustomization.yaml
+++ b/apps/flux-system/test/base/kustomization.yaml
@@ -3,19 +3,3 @@ kind: Kustomization
 resources:
   - ../../base
   - git-credentials.enc.yaml
-  - ../../base/image-automation-components.yaml
-patches:
-  - target:
-      version: v1
-      group: apps
-      kind: Deployment
-      name: image-reflector-controller
-      namespace: flux-system
-    patch: |-
-      - op: add
-        path: /spec/template/spec/containers/0/args/-
-        value: --azure-autologin-for-acr
-        # Add this if you are using aad pod identity with managed identity
-      - op: add 
-        path: /spec/template/metadata/labels/aadpodidbinding
-        value: aks-kubelet-identity-mi


### PR DESCRIPTION
### Change description ###
- remove image automation components from all envs apart from ptl
- move image reflector identity to flux-system 


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
