### PR TITLE
Add the lgy-iac identity back to the helm chart now that the Key Vaul…

### DIFF
--- a/apps/dts-legacy/base/kustomization.yaml
+++ b/apps/dts-legacy/base/kustomization.yaml
@@ -3,4 +3,5 @@ kind: Kustomization
 resources:
   - ../../base
   - ../lgy-iac-web/lgy-iac-web.yaml
+  - ../identity/lgy-iac-identity.yaml
 namespace: dts-legacy

--- a/apps/dts-legacy/identity/lgy-iac-identity.yaml
+++ b/apps/dts-legacy/identity/lgy-iac-identity.yaml
@@ -1,7 +1,7 @@
 apiVersion: "aadpodidentity.k8s.io/v1"
 kind: AzureIdentity
 metadata:
-  name: dts-legacy
+  name: lgy-iac
   namespace: dts-legacy
 spec:
   type: 0
@@ -11,8 +11,8 @@ spec:
 apiVersion: "aadpodidentity.k8s.io/v1"
 kind: AzureIdentityBinding
 metadata:
-  name: dts-legacy-binding
+  name: lgy-iac-binding
   namespace: dts-legacy
 spec:
-  azureIdentity: dts-legacy
-  selector: dts-legacy
+  azureIdentity: lgy-iac
+  selector: lgy-iac


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RST-4469

### Change description ###
Add the lgy-iac identity back to the helm chart now that the Key Vault has been created by the cnp-module-keyvault


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
