### PR TITLE
Change the default liveness path for lgy-iac-web

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -45,6 +45,10 @@ apps/pip/ @hmcts/pip-admins
 ## VH
 apps/vh/ @hmcts/vh-devops
 
+### DTS-LEGACY
+apps/dts-legacy/ @hmcts/dts-legacy-apps
+apps/dts-legacy/lgy-iac-web/lgy-iac-web.yaml @hmcts/dts-legacy-apps
+
 ### Next team
 
 ### Kustomization control

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -47,7 +47,6 @@ apps/vh/ @hmcts/vh-devops
 
 ### DTS-LEGACY
 apps/dts-legacy/ @hmcts/dts-legacy-apps
-apps/dts-legacy/lgy-iac-web/lgy-iac-web.yaml @hmcts/dts-legacy-apps
 
 ### Next team
 

--- a/apps/dts-legacy/lgy-iac-web/lgy-iac-web.yaml
+++ b/apps/dts-legacy/lgy-iac-web/lgy-iac-web.yaml
@@ -9,6 +9,8 @@ spec:
       replicas: 2
       useInterpodAntiAffinity: true
       image: sdshmctspublic.azurecr.io/lgy-iac/web:prod-b6678d8-20220906114416 #{"$imagepolicy": "flux-system:lgy-iac-web"}
+      readinessPath: /IACFees/health/liveness.do
+      livenessPath: /IACFees/health/liveness.do
   chart:
     spec:
       chart: ./stable/lgy-iac-web


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RST-4467

### Change description ###

Change the default liveness path from /health/liveness to /IACFees/health/liveness.do (the struts application needs .do suffix on url names)

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
