### PR TITLE
DTSPO-6556 - set version for reply urls operation's kustomization base

### DIFF
--- a/apps/admin/demo/base/kustomization.yaml
+++ b/apps/admin/demo/base/kustomization.yaml
@@ -6,15 +6,12 @@ resources:
   - ../../kured/demo/kured-values.enc.yaml
   - ../../../rbac/reader-clusterrole.yaml
   - ../../keda
-  - ../../reply-urls-operator
-  - ../../reply-urls-operator/demo/secret.enc.yaml
-  - ../../reply-urls-operator/demo/reply-url-sync-config.yaml
+  - ../../reply-urls-operator/demo
 namespace: admin
 patchesStrategicMerge:
   - ../../traefik2/demo/secret-provider.yaml
   - ../../traefik2/demo/traefik-private.yaml
   - ../../keda/demo/identity.yaml
-  - ../../reply-urls-operator/demo/deployment-patch.yaml
 
 patches:
   - path: ../../aad-pod-identity/demo/azure-identity-patch.yaml

--- a/apps/admin/reply-urls-operator/demo/kustomization.yaml
+++ b/apps/admin/reply-urls-operator/demo/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+namespace: admin
+kind: Kustomization
+resources:
+  - https://github.com/hmcts/reply-urls-operator/config/default?ref=v0.0.2
+  - secret.enc.yaml
+  - reply-url-sync-config.yaml
+
+patchesStrategicMerge:
+  - deployment-patch.yaml

--- a/apps/admin/reply-urls-operator/kustomization.yaml
+++ b/apps/admin/reply-urls-operator/kustomization.yaml
@@ -1,5 +1,0 @@
-apiVersion: kustomize.config.k8s.io/v1beta1
-namespace: admin
-kind: Kustomization
-resources:
-  - https://github.com/hmcts/reply-urls-operator/config/default?ref=v0.0.2

--- a/apps/admin/reply-urls-operator/kustomization.yaml
+++ b/apps/admin/reply-urls-operator/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 namespace: admin
 kind: Kustomization
 resources:
-  - https://github.com/hmcts/reply-urls-operator/config/default?ref=master
+  - https://github.com/hmcts/reply-urls-operator/config/default?ref=v0.0.2

--- a/apps/admin/reply-urls-operator/sbox/kustomization.yaml
+++ b/apps/admin/reply-urls-operator/sbox/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+namespace: admin
+kind: Kustomization
+resources:
+  - https://github.com/hmcts/reply-urls-operator/config/default?ref=v0.0.2
+  - secret.enc.yaml
+  - reply-url-sync-config.yaml
+
+patchesStrategicMerge:
+  - deployment-patch.yaml

--- a/apps/admin/sbox/00/kustomization.yaml
+++ b/apps/admin/sbox/00/kustomization.yaml
@@ -2,11 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../base
-  - ../../reply-urls-operator
-  - ../../reply-urls-operator/sbox/secret.enc.yaml
-  - ../../reply-urls-operator/sbox/reply-url-sync-config.yaml
-
+  - ../../reply-urls-operator/sbox
 
 patchesStrategicMerge:
   - ../../traefik2/sbox/00-traefik2.yaml
-  - ../../reply-urls-operator/sbox/deployment-patch.yaml


### PR DESCRIPTION
### Change description ###
- Using tag instead of master branch
- Moved kustomizations to environment folders so different versions of the reply urls operator can be used in sbox/demo


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
