### PR TITLE
removed kubernetes.io/ingress.class: traefik as not needed in configu…

### DIFF
--- a/apps/monitoring/kube-prometheus-stack/dev/00.yaml
+++ b/apps/monitoring/kube-prometheus-stack/dev/00.yaml
@@ -73,7 +73,6 @@ spec:
                         - system
       ingress:
         annotations:
-          kubernetes.io/ingress.class: traefik
           traefik.ingress.kubernetes.io/router.tls: "true"
         enabled: true
         hosts:
@@ -100,7 +99,6 @@ spec:
                         - system
       ingress:
         annotations:
-          kubernetes.io/ingress.class: traefik
           traefik.ingress.kubernetes.io/router.tls: "true"
         enabled: true
         hosts:

--- a/apps/monitoring/kube-prometheus-stack/dev/01.yaml
+++ b/apps/monitoring/kube-prometheus-stack/dev/01.yaml
@@ -73,7 +73,6 @@ spec:
                         - system
       ingress:
         annotations:
-          kubernetes.io/ingress.class: traefik
           traefik.ingress.kubernetes.io/router.tls: "true"
         enabled: true
         hosts:
@@ -100,7 +99,6 @@ spec:
                         - system
       ingress:
         annotations:
-          kubernetes.io/ingress.class: traefik
           traefik.ingress.kubernetes.io/router.tls: "true"
         enabled: true
         hosts:


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-4400


### Change description ###

removed kubernetes.io/ingress.class: traefik as not needed in configuration

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
