### PR TITLE
Change MI Azure Functions internal port to 7072

### DIFF
--- a/k8s/release/mi/mi-azure-functions/values.yaml
+++ b/k8s/release/mi/mi-azure-functions/values.yaml
@@ -28,7 +28,7 @@ keyVaultCoreSecrets:
 
 secretsMountPath: '/mnt/kvmnt'
 
-internalPort: 80
+internalPort: 7072
 externalPort: 80
 
 env:


### PR DESCRIPTION
mi-azure-functions has been updated to use a non-root user. This means it can no longer start services on ports lower than 1024. The new internal port is 7072.