### PR TITLE
Reduce replica count of SHIR pods on ss-test

### DIFF
--- a/apps/mi/mi-adf-shir/test.yaml
+++ b/apps/mi/mi-adf-shir/test.yaml
@@ -7,7 +7,7 @@ spec:
   releaseName: mi-adf-shir
   values:
     image: sdshmctspublic.azurecr.io/mi/adf-integration-runtime:prod-02be20f-20220823154108 #{"$imagepolicy": "flux-system:mi-adf-shir"}
-    replicaCount: 4
+    replicaCount: 2
     secretsMountPath: ''
     environment: "test"
     resourceGroup: "mi-test-rg"


### PR DESCRIPTION
It seems some sort of cross cluster networking is working now and the SHIR pods can communicate with each other. This means we can spread the number of SHIR pods from 4 on one cluster with the other 4 failing, to 2 working pods on each cluster.