### PR TITLE
Update oauth2-proxy.yaml

### DIFF
--- a/apps/admin/oauth2-proxy/oauth2-proxy.yaml
+++ b/apps/admin/oauth2-proxy/oauth2-proxy.yaml
@@ -74,7 +74,6 @@ spec:
         name: oauth2-proxy-values
     ingress:
       annotations:
-        kubernetes.io/ingress.class: traefik
         traefik.ingress.kubernetes.io/router.tls: "true"
       className: traefik
       enabled: true


### PR DESCRIPTION
```
oauth2-proxy           4d1h   False   Helm rollback failed: failed to create resource: Ingress.extensions "oauth2-proxy" is invalid: annotations.kubernetes.io/ingress.class: Invalid value: "traefik": can not be set when the class field is also set...
```

Manual change in cluster allowed successful upgrade, we also have this in CFT
**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###



### Change description ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
