### PR TITLE
Setup managed identity and secret mount path for SHIR

### DIFF
--- a/apps/mi/mi-adf-shir/dev.yaml
+++ b/apps/mi/mi-adf-shir/dev.yaml
@@ -7,11 +7,8 @@ spec:
   releaseName: mi-adf-shir
   values:
     image: sdshmctspublic.azurecr.io/mi/adf-integration-runtime:prod-1da27af-20221116104338 #{"$imagepolicy": "flux-system:mi-adf-shir"}
-    secretsMountPath: ''
     environment: "dev"
     resourceGroup: "mi-dev-rg"
     subscriptionId: "867a878b-cb68-4de5-9741-361ac9e178b6"
     tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
     managedIdentityClientId: "47b18d2f-9a02-4f45-a87c-bacd17ea3583"
-    keyVaultSecrets:
-    - mi-adf-auth-key

--- a/apps/mi/mi-adf-shir/ithc.yaml
+++ b/apps/mi/mi-adf-shir/ithc.yaml
@@ -7,11 +7,8 @@ spec:
   releaseName: mi-adf-shir
   values:
     image: sdshmctspublic.azurecr.io/mi/adf-integration-runtime:prod-1da27af-20221116104338 #{"$imagepolicy": "flux-system:mi-adf-shir"}
-    secretsMountPath: ''
     environment: "ithc"
     resourceGroup: "mi-ithc-rg"
     subscriptionId: "ba71a911-e0d6-4776-a1a6-079af1df7139"
     tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
     managedIdentityClientId: "9106f8ad-3189-4053-925d-0d4579c4e0d9"
-    keyVaultSecrets:
-    - mi-adf-auth-key

--- a/apps/mi/mi-adf-shir/mi-adf-shir.yaml
+++ b/apps/mi/mi-adf-shir/mi-adf-shir.yaml
@@ -12,7 +12,8 @@ spec:
       app.kubernetes.io/name: mi-adf-shir-deployment
     keyVaultSecrets:
       - mi-adf-auth-key
-    secretsMountPath: ''
+      - cgi-tec-tns-descriptor
+    secretsMountPath: 'C:\kvmnt'
     tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
   chart:
     spec:

--- a/apps/mi/mi-adf-shir/prod.yaml
+++ b/apps/mi/mi-adf-shir/prod.yaml
@@ -11,8 +11,8 @@ spec:
     image: sdshmctspublic.azurecr.io/mi/adf-integration-runtime:prod-1da27af-20221116104338 #{"$imagepolicy": "flux-system:mi-adf-shir"}
     replicaCount: 4
     memoryLimits: '4096Mi'
-    secretsMountPath: ''
     resourceGroup: "mi-prod-rg"
     subscriptionId: "5ca62022-6aa2-4cee-aaa7-e7536c8d566c"
     tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
     environment: "prod"
+    managedIdentityClientId: "ee31a18f-45e9-41db-881d-5976695188fb"

--- a/apps/mi/mi-adf-shir/sbox.yaml
+++ b/apps/mi/mi-adf-shir/sbox.yaml
@@ -7,11 +7,8 @@ spec:
   releaseName: mi-adf-shir
   values:
     image: sdshmctspublic.azurecr.io/mi/adf-integration-runtime:prod-1da27af-20221116104338 #{"$imagepolicy": "flux-system:mi-adf-shir"}
-    secretsMountPath: ''
     environment: "sbox"
     resourceGroup: "mi-sbox-rg"
     subscriptionId: "a8140a9e-f1b0-481f-a4de-09e2ee23f7ab"
     tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
     managedIdentityClientId: "9278a876-6f8a-489d-9053-01c996a7b6f6"
-    keyVaultSecrets:
-    - mi-adf-auth-key

--- a/apps/mi/mi-adf-shir/stg.yaml
+++ b/apps/mi/mi-adf-shir/stg.yaml
@@ -7,11 +7,8 @@ spec:
   releaseName: mi-adf-shir
   values:
     image: sdshmctspublic.azurecr.io/mi/adf-integration-runtime:prod-1da27af-20221116104338 #{"$imagepolicy": "flux-system:mi-adf-shir"}
-    secretsMountPath: ''
     environment: "stg"
     resourceGroup: "mi-stg-rg"
     subscriptionId: "74dacd4f-a248-45bb-a2f0-af700dc4cf68"
     tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
-    managedIdentityClientId: "9278a876-6f8a-489d-9053-01c996a7b6f6"
-    keyVaultSecrets:
-    - mi-adf-auth-key
+    managedIdentityClientId: "dfdc9e79-b5a5-44a9-892b-e02ebc31358f"

--- a/apps/mi/mi-adf-shir/test.yaml
+++ b/apps/mi/mi-adf-shir/test.yaml
@@ -8,10 +8,8 @@ spec:
   values:
     image: sdshmctspublic.azurecr.io/mi/adf-integration-runtime:prod-1da27af-20221116104338 #{"$imagepolicy": "flux-system:mi-adf-shir"}
     replicaCount: 2
-    secretsMountPath: ''
     environment: "test"
     resourceGroup: "mi-test-rg"
     subscriptionId: "3eec5bde-7feb-4566-bfb6-805df6e10b90"
     tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
-    keyVaultSecrets:
-    - mi-adf-auth-key
+    managedIdentityClientId: "4b4479ac-2998-4353-b202-675df08389f5"


### PR DESCRIPTION
Default service account from Windows node can access the vault using managed identity now.
We no longer need sops but can pull values from vault now.