### PR TITLE
Set SHIR pod name as Node Name in ADF

### DIFF
--- a/apps/mi/mi-adf-shir/test.yaml
+++ b/apps/mi/mi-adf-shir/test.yaml
@@ -8,6 +8,7 @@ spec:
   values:
     image: sdshmctspublic.azurecr.io/mi/adf-integration-runtime:prod-0641eb6-20221206112502 #{"$imagepolicy": "flux-system:mi-adf-shir"}
     replicaCount: 2
+    memoryLimits: '4096Mi'
     environment: "test"
     resourceGroup: "mi-test-rg"
     subscriptionId: "3eec5bde-7feb-4566-bfb6-805df6e10b90"

--- a/k8s/release/mi/mi-adf-shir/Chart.yaml
+++ b/k8s/release/mi/mi-adf-shir/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: mi-adf-shir
 home: https://github.com/hmcts/mi-adf-integration-runtime/
-version: 1.0.4
+version: 1.0.5
 description: Node for a Azure Data Factory Self Hosted Integration Runtime
 maintainers:
   - name: HMCTS Management Information Platform

--- a/k8s/release/mi/mi-adf-shir/templates/deployment.yaml
+++ b/k8s/release/mi/mi-adf-shir/templates/deployment.yaml
@@ -51,8 +51,15 @@ spec:
             {{ end }}
             - name: ENABLE_HA
               value: "{{ .Values.haEnabled }}"
+            (( if .Values.nodeName }}
             - name: NODE_NAME
-              value: "{{ .Values.appName }}"
+              value: "{{ .Values.nodeName }}"
+            {{ else }}
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            {{ end }}
             - name: HA_PORT
               value: "{{ .Values.haPort }}"
           {{ if .Values.secretsMountPath }}

--- a/k8s/release/mi/mi-adf-shir/values.yaml
+++ b/k8s/release/mi/mi-adf-shir/values.yaml
@@ -20,6 +20,7 @@ keyVaultSecrets:
 authKeySecretName: mi-adf-auth
 secretsMountPath: 'C:\kvmnt'
 
+nodeName: ''
 haEnabled: "true"
 haPort: "8060"
 


### PR DESCRIPTION
If NodeName in the SHIR chart is not defined, default to using the pod's name as the node name for better identification.

Also updates test env SHIR to have a higher memory limit since the usage on that environment is high compared to all the others.