### PR TITLE
Upgrade external-dns in inactive demo

### DIFF
--- a/apps/admin/external-dns/demo/01-external-dns-private.yaml
+++ b/apps/admin/external-dns/demo/01-external-dns-private.yaml
@@ -5,6 +5,10 @@ metadata:
   namespace: admin 
 spec:
   releaseName: external-dns-private
+  chart:
+    spec:
+      chart: external-dns
+      version: 6.13.0
   values:
     logLevel: debug
     txtOwnerId: sds-demo-aks-inactive

--- a/apps/admin/external-dns/demo/01-external-dns.yaml
+++ b/apps/admin/external-dns/demo/01-external-dns.yaml
@@ -5,6 +5,10 @@ metadata:
   namespace: admin 
 spec:
   releaseName: external-dns
+  chart:
+    spec:
+      chart: external-dns
+      version: 6.13.0
   values:
     logLevel: debug
     txtOwnerId: sds-demo-aks-inactive


### PR DESCRIPTION
ERROR 
```
41m         Warning   InvalidChartReference        helmchart/admin-external-dns           invalid chart reference: failed to get chart version for remote reference: no 'external-dns' chart with version matching '6.1.4' found
41m         Warning   InvalidChartReference        helmchart/admin-external-dns-private   invalid chart reference: failed to get chart version for remote reference: no 'external-dns' chart with version matching '6.1.4' found
```

This moves to the latest version, testing inactive cluster to validate before adding to base

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
