### PR TITLE
Set order of policy to load repo setup first for MI

### DIFF
--- a/apps/mi/automation/kustomization.yaml
+++ b/apps/mi/automation/kustomization.yaml
@@ -1,9 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ../mi-adf-shir/image-policy.yaml
   - ../mi-adf-shir/image-repo.yaml
-  - ../mi-azure-functions/image-policy.yaml
+  - ../mi-adf-shir/image-policy.yaml
   - ../mi-azure-functions/image-repo.yaml
-  - ../mi-house-keeping-service/image-policy.yaml
+  - ../mi-azure-functions/image-policy.yaml
   - ../mi-house-keeping-service/image-repo.yaml
+  - ../mi-house-keeping-service/image-policy.yaml


### PR DESCRIPTION
Potential issue, we see other namespaces use repo the policy in that order, whilst we are not seeing our imagepolicies apply. So testing a change in the load order.