### PR TITLE
Increase memory limits for dev ADF SHIR

### DIFF
--- a/apps/mi/mi-adf-shir/dev.yaml
+++ b/apps/mi/mi-adf-shir/dev.yaml
@@ -7,7 +7,7 @@ spec:
   releaseName: mi-adf-shir
   values:
     image: sdshmctspublic.azurecr.io/mi/adf-integration-runtime:prod-e9aaecf-20230116224816 #{"$imagepolicy": "flux-system:mi-adf-shir"}
-    replicaCount: 2
+    replicaCount: 4
     memoryLimits: '4096Mi'
     environment: "dev"
     resourceGroup: "mi-dev-rg"

--- a/apps/mi/mi-adf-shir/dev.yaml
+++ b/apps/mi/mi-adf-shir/dev.yaml
@@ -7,6 +7,8 @@ spec:
   releaseName: mi-adf-shir
   values:
     image: sdshmctspublic.azurecr.io/mi/adf-integration-runtime:prod-e9aaecf-20230116224816 #{"$imagepolicy": "flux-system:mi-adf-shir"}
+    replicaCount: 2
+    memoryLimits: '4096Mi'
     environment: "dev"
     resourceGroup: "mi-dev-rg"
     subscriptionId: "867a878b-cb68-4de5-9741-361ac9e178b6"


### PR DESCRIPTION
Set dev SHIR memory limit to 4GB (up from default 2GB)
Added replicaCount property set to use 4 node instead of the default 2 as there is only 1 dev cluster.