### PR TITLE
Revert "Test FD connectivity with TLS flag"

### DIFF
--- a/apps/toffee/frontend/demo.yaml
+++ b/apps/toffee/frontend/demo.yaml
@@ -6,7 +6,6 @@ metadata:
 spec:
   values:
     nodejs:
-      disableTraefikTls: false
       image: sdshmctspublic.azurecr.io/toffee/frontend:prod-df595c5-20230214122146 #{"$imagepolicy": "flux-system:toffee-frontend"}
       ingressHost: toffee.demo.platform.hmcts.net
       environment:


### PR DESCRIPTION
Reverts hmcts/sds-flux-config#2560 -- this does cause a drop in health for backend 