### PR TITLE
Rmi 2379 update api version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ k8s/charts/**/*.lock
 k8s/charts/**/*.tgz
 install_kustomize.sh
 kustomize
+*.DS_Store

--- a/apps/mi/mi-sftp-server/mi-sftp-server-secret-provider.yaml
+++ b/apps/mi/mi-sftp-server/mi-sftp-server-secret-provider.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: secrets-store.csi.x-k8s.io/v1
+apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
 kind: SecretProviderClass
 metadata:
   name: mi-sftp-server-secret-provider

--- a/apps/mi/mi-sftp-server/mi-sftp-server.yaml
+++ b/apps/mi/mi-sftp-server/mi-sftp-server.yaml
@@ -1,5 +1,5 @@
 kind: Deployment
-apiVersion: apps/v1
+apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
 metadata:
   name: mi-sftp-server
   namespace: mi

--- a/apps/mi/mi-sftp-server/mi-sftp-server.yaml
+++ b/apps/mi/mi-sftp-server/mi-sftp-server.yaml
@@ -1,5 +1,5 @@
 kind: Deployment
-apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
+apiVersion: apps/v1
 metadata:
   name: mi-sftp-server
   namespace: mi


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RMI-2379


### Change description ###
Revived the ticket because there was an issue with the sftp-server. Update the api version for the sftp server's secret provider


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
