### PR TITLE
Revert "Test flag behaviour for backend application"

### DIFF
--- a/apps/toffee/recipe-backend/demo.yaml
+++ b/apps/toffee/recipe-backend/demo.yaml
@@ -9,6 +9,5 @@ spec:
       image: sdshmctspublic.azurecr.io/toffee/recipe-backend:prod-6207db6-20230217094513 #{"$imagepolicy": "flux-system:toffee-recipe-backend"}
       ingressHost: toffee-recipe-backend.demo.platform.hmcts.net
       ingressClass: traefik-private
-      disableTraefikTls: false
     global:
       environment: demo


### PR DESCRIPTION
Reverts hmcts/sds-flux-config#2570 -- This flag gives 502 error for backend apps from client machine