### PR TITLE
Remove disableTraefik flag to stop apps breaking on appgw

### DIFF
--- a/apps/c100/c100-application/demo.yaml
+++ b/apps/c100/c100-application/demo.yaml
@@ -7,4 +7,3 @@ spec:
   values:
     base:
       ingressClass: traefik-private
-      disableTraefikTls: false

--- a/apps/my-time/my-time-api/demo.yaml
+++ b/apps/my-time/my-time-api/demo.yaml
@@ -8,6 +8,5 @@ spec:
   values:
     image: sdshmctspublic.azurecr.io/my-time/api:latest #{"$imagepolicy": "flux-system:my-time-api"}
     java:
-      disableTraefikTls: false
       ingressClass: traefik-no-proxy
       environment:

--- a/apps/my-time/my-time-frontend/demo.yaml
+++ b/apps/my-time/my-time-frontend/demo.yaml
@@ -8,6 +8,5 @@ spec:
   values:
     image: sdshmctspublic.azurecr.io/my-time/frontend:latest #{"$imagepolicy": "flux-system:my-time-frontend"}
     nodejs:
-      disableTraefikTls: false
       ingressClass: traefik-no-proxy
       environment:

--- a/apps/pip/account-management/demo.yaml
+++ b/apps/pip/account-management/demo.yaml
@@ -8,5 +8,4 @@ spec:
   values:
     image: sdshmctspublic.azurecr.io/pip/data-management:prod-92b1034-20230216142926 #{"$imagepolicy": "flux-system:pip-data-management"}
     java:
-      disableTraefikTls: false
       ingressClass: traefik-no-proxy

--- a/apps/pip/channel-management/demo.yaml
+++ b/apps/pip/channel-management/demo.yaml
@@ -8,7 +8,6 @@ spec:
   values:
     image: sdshmctspublic.azurecr.io/pip/channel-management:prod-7fe502f-20230214140428 #{"$imagepolicy": "flux-system:pip-channel-management"}
     java:
-      disableTraefikTls: false
       ingressClass: traefik-no-proxy
       environment:
         ACCOUNT_MANAGEMENT_URL: https://pip-account-management.demo.platform.hmcts.net

--- a/apps/pip/data-management/demo.yaml
+++ b/apps/pip/data-management/demo.yaml
@@ -8,7 +8,6 @@ spec:
   values:
     image: sdshmctspublic.azurecr.io/pip/data-management:prod-92b1034-20230216142926 #{"$imagepolicy": "flux-system:pip-data-management"}
     java:
-      disableTraefikTls: false
       ingressClass: traefik-no-proxy
       environment:
         SUBSCRIPTION_MANAGEMENT_URL: https://pip-subscription-management.demo.platform.hmcts.net

--- a/apps/pip/frontend/demo.yaml
+++ b/apps/pip/frontend/demo.yaml
@@ -8,7 +8,6 @@ spec:
   values:
     image: sdshmctspublic.azurecr.io/pip/frontend:prod-151ddd1-20230216140351 #{"$imagepolicy": "flux-system:pip-frontend"}
     nodejs:
-      disableTraefikTls: false
       ingressClass: traefik-no-proxy
       environment:
         DATA_MANAGEMENT_URL: https://pip-data-management.demo.platform.hmcts.net

--- a/apps/pip/publication-services/demo.yaml
+++ b/apps/pip/publication-services/demo.yaml
@@ -8,7 +8,6 @@ spec:
   values:
     image: sdshmctspublic.azurecr.io/pip/publication-services:prod-99b8050-20230207112822 #{"$imagepolicy": "flux-system:pip-publication-services"}
     java:
-      disableTraefikTls: false
       ingressClass: traefik-no-proxy
       environment:
         DATA_MANAGEMENT_URL: https://pip-data-management.demo.platform.hmcts.net

--- a/apps/pip/subscription-management/demo.yaml
+++ b/apps/pip/subscription-management/demo.yaml
@@ -8,7 +8,6 @@ spec:
   values:
     image: sdshmctspublic.azurecr.io/pip/subscription-management:prod-df9469b-20230214122040 #{"$imagepolicy": "flux-system:pip-subscription-management"}
     java:
-      disableTraefikTls: false
       ingressClass: traefik-no-proxy
       environment:
         DATA_MANAGEMENT_URL: 'https://pip-data-management.demo.platform.hmcts.net'

--- a/apps/vh/admin-web/demo.yaml
+++ b/apps/vh/admin-web/demo.yaml
@@ -10,4 +10,3 @@ spec:
       ingressHost: vh-admin-web.demo.platform.hmcts.net
       image: sdshmctspublic.azurecr.io/vh/admin-web:prod-c73e600-202302071705 #{"$imagepolicy": "flux-system:vh-admin-web-prod"}
       ingressClass: traefik-no-proxy
-      disableTraefikTls: false

--- a/apps/vh/bookings-api/demo.yaml
+++ b/apps/vh/bookings-api/demo.yaml
@@ -10,4 +10,3 @@ spec:
       ingressHost: vh-bookings-api.demo.platform.hmcts.net
       image: sdshmctspublic.azurecr.io/vh/bookings-api:prod-dbbc0bb-202302081029 #{"$imagepolicy": "flux-system:vh-bookings-api-prod"}
       ingressClass: traefik-private
-      disableTraefikTls: false

--- a/apps/vh/notification-api/demo.yaml
+++ b/apps/vh/notification-api/demo.yaml
@@ -10,4 +10,3 @@ spec:
       ingressHost: vh-notification-api.demo.platform.hmcts.net
       image: sdshmctspublic.azurecr.io/vh/notification-api:prod-8086547-202302081045 #{"$imagepolicy": "flux-system:vh-notification-api-prod"}
       ingressClass: traefik-private
-      disableTraefikTls: false

--- a/apps/vh/test-api/demo.yaml
+++ b/apps/vh/test-api/demo.yaml
@@ -9,5 +9,3 @@ spec:
     java:
       ingressHost: vh-test-api.demo.platform.hmcts.net
       image: sdshmctspublic.azurecr.io/vh/test-api:staging-b735d39-202212150925 #{"$imagepolicy": "flux-system:vh-test-api-prod"}
-      ingressClass: traefik-private
-      disableTraefikTls: false

--- a/apps/vh/test-web/demo.yaml
+++ b/apps/vh/test-web/demo.yaml
@@ -10,4 +10,3 @@ spec:
       ingressHost: vh-test-web.demo.platform.hmcts.net
       image: sdshmctspublic.azurecr.io/vh/test-web:staging-22ea6ef-202212141559 # {"$imagepolicy": "flux-system:vh-test-web-prod"}
       ingressClass: traefik-no-proxy
-      disableTraefikTls: false

--- a/apps/vh/user-api/demo.yaml
+++ b/apps/vh/user-api/demo.yaml
@@ -10,4 +10,3 @@ spec:
       ingressHost: vh-user-api.demo.platform.hmcts.net
       image: sdshmctspublic.azurecr.io/vh/user-api:prod-312cf6b-202302081051 #{"$imagepolicy": "flux-system:vh-user-api-prod"}
       ingressClass: traefik-private
-      disableTraefikTls: false

--- a/apps/vh/video-api/demo.yaml
+++ b/apps/vh/video-api/demo.yaml
@@ -10,7 +10,6 @@ spec:
       ingressHost: vh-video-api.demo.platform.hmcts.net
       image: sdshmctspublic.azurecr.io/vh/video-api:prod-be24715-202302081106 #{"$imagepolicy": "flux-system:vh-video-api-prod"}
       ingressClass: traefik-private
-      disableTraefikTls: false
       keyVaults:
         vh-infra-core:
           excludeEnvironmentSuffix: false

--- a/apps/vh/video-web/demo.yaml
+++ b/apps/vh/video-web/demo.yaml
@@ -10,4 +10,3 @@ spec:
       ingressHost: vh-video-web.demo.platform.hmcts.net
       image: sdshmctspublic.azurecr.io/vh/video-web:prod-b413531-202302080955 # {"$imagepolicy": "flux-system:vh-video-web-prod"}
       ingressClass: traefik-no-proxy
-      disableTraefikTls: false


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DTSPO-12425

Tested with toffee backend, that apps are not reachable when DNS is updated and they're in active/active set up with this flag included

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
