### PR TITLE
DTSPO-10575 - add enableOAuth to toffee demo

### DIFF
--- a/apps/toffee/frontend/demo.yaml
+++ b/apps/toffee/frontend/demo.yaml
@@ -11,6 +11,7 @@ spec:
       environment:
         RECIPE_BACKEND_URL: http://toffee-recipe-backend.demo.platform.hmcts.net
       ingressClass: traefik
+      enableOAuth: true
     global:
       environment: demo
     volumes:


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-10575

### Change description ###
Add enableOAuth to ensure toffee is being procxied behind oauth before upgrading


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
