### PR TITLE
DTSPO-12090 - Update mi job chart

### DIFF
--- a/k8s/release/mi/mi-house-keeping-service/Chart.yaml
+++ b/k8s/release/mi/mi-house-keeping-service/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: mi-house-keeping-service
 home: https://github.com/hmcts/mi-house-keeping-service
-version: 1.1.5
+version: 1.1.6
 appVersion: "1.0.0"
 type: application
 description: MI House Keeping Service

--- a/k8s/release/mi/mi-house-keeping-service/Chart.yaml
+++ b/k8s/release/mi/mi-house-keeping-service/Chart.yaml
@@ -9,5 +9,5 @@ maintainers:
   - name: HMCTS MI platform
 dependencies:
   - name: job
-    version: ~0.6.3
+    version: ~0.7.11
     repository: 'file://../common/job'


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-12090

### Change description ###
Update mi job to use chart-job 0.7.11
Enables compatibility with kubernetes 1.25 on aks

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
