### PR TITLE
DTSPO-12090 - Update mi job chart - 2

### DIFF
--- a/k8s/release/mi/common/job/Chart.yaml
+++ b/k8s/release/mi/common/job/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for HMCTS Kubernetes Job / CronJob
 name: job
-version: 0.6.3
+version: 0.6.4
 keywords:
   - Job
   - CronJob

--- a/k8s/release/mi/common/job/templates/CronJob.yaml
+++ b/k8s/release/mi/common/job/templates/CronJob.yaml
@@ -1,7 +1,7 @@
 {{- $jobKind := (default .Values.kind  .Values.global.jobKind) -}}
 {{ if (and $jobKind (eq $jobKind "CronJob")) }}
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 {{ include "job.metadata" .}}
 spec:

--- a/k8s/release/mi/mi-house-keeping-service/Chart.yaml
+++ b/k8s/release/mi/mi-house-keeping-service/Chart.yaml
@@ -9,5 +9,5 @@ maintainers:
   - name: HMCTS MI platform
 dependencies:
   - name: job
-    version: ~0.7.11
+    version: ~0.6.4
     repository: 'file://../common/job'


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-12090

### Change description ###
Update mi job
Enables compatibility with kubernetes 1.25 on aks

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```

