### PR TITLE
Dtspo 12412 loki ingress

### DIFF
--- a/apps/monitoring/dev/01/kustomization.yaml
+++ b/apps/monitoring/dev/01/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
 
 patchesStrategicMerge:
   - ../../kube-prometheus-stack/dev/01.yaml
+  - ../../loki-stack/dev/01.yaml

--- a/apps/monitoring/kube-prometheus-stack/dev/01.yaml
+++ b/apps/monitoring/kube-prometheus-stack/dev/01.yaml
@@ -77,11 +77,9 @@ spec:
         enabled: true
         hosts:
           - sds-prometheus-01.dev.platform.hmcts.net
-          - sds-loki-01.dev.platform.hmcts.net
         tls:
           - hosts:
               - sds-prometheus-01.dev.platform.hmcts.net
-              - sds-loki-01.dev.platform.hmcts.net
     alertmanager:
       alertmanagerSpec:
         tolerations:

--- a/apps/monitoring/kube-prometheus-stack/dev/01.yaml
+++ b/apps/monitoring/kube-prometheus-stack/dev/01.yaml
@@ -77,9 +77,11 @@ spec:
         enabled: true
         hosts:
           - sds-prometheus-01.dev.platform.hmcts.net
+          - sds-loki-01.dev.platform.hmcts.net
         tls:
           - hosts:
               - sds-prometheus-01.dev.platform.hmcts.net
+              - sds-loki-01.dev.platform.hmcts.net
     alertmanager:
       alertmanagerSpec:
         tolerations:
@@ -119,3 +121,13 @@ spec:
                 title: 'SDS-dev-01 - {{ template "slack.default.title" . }}'
                 text: "{{ range .Alerts }}{{ .Annotations.message }}\n{{ end }}"
           - name: "null"
+    loki:
+      ingress:
+        annotations:
+          traefik.ingress.kubernetes.io/router.tls: "true"
+        enabled: true
+      hosts:
+        - sds-loki-01.dev.platform.hmcts.net
+      tls:
+        - hosts:
+            - sds-loki-01.dev.platform.hmcts.net

--- a/apps/monitoring/kube-prometheus-stack/dev/01.yaml
+++ b/apps/monitoring/kube-prometheus-stack/dev/01.yaml
@@ -119,13 +119,3 @@ spec:
                 title: 'SDS-dev-01 - {{ template "slack.default.title" . }}'
                 text: "{{ range .Alerts }}{{ .Annotations.message }}\n{{ end }}"
           - name: "null"
-    loki:
-      ingress:
-        annotations:
-          traefik.ingress.kubernetes.io/router.tls: "true"
-        enabled: true
-      hosts:
-        - sds-loki-01.dev.platform.hmcts.net
-      tls:
-        - hosts:
-            - sds-loki-01.dev.platform.hmcts.net

--- a/apps/monitoring/loki-stack/dev/01.yaml
+++ b/apps/monitoring/loki-stack/dev/01.yaml
@@ -1,0 +1,18 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: loki-stack
+  labels:
+    release: kube-prometheus-stack
+spec:
+  values:
+    loki:
+      ingress:
+        annotations:
+          traefik.ingress.kubernetes.io/router.tls: "true"
+        enabled: true
+      hosts:
+        - sds-loki-01.dev.platform.hmcts.net
+      tls:
+        - hosts:
+            - sds-loki-01.dev.platform.hmcts.net


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSPO-12412

### Change description ###

Adds ingress for loki to setup external datasource for loki logs on grafana"

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
