### PR TITLE
Disable Grafana on SDS

### DIFF
--- a/apps/monitoring/kube-prometheus-stack/kube-prometheus-stack.yaml
+++ b/apps/monitoring/kube-prometheus-stack/kube-prometheus-stack.yaml
@@ -35,7 +35,7 @@ spec:
         prometheusOperator: true
         time: true
     grafana:
-      enabled: true
+      enabled: false
       plugins:
         - grafana-kubernetes-app
         - camptocamp-prometheus-alertmanager-datasource


### PR DESCRIPTION
### JIRA link (if applicable) ###
N/A

### Change description ###
Spotted that it's possible to get to a Grafana login screen by triggering a crash via bad gateway on a persisted PR link.
Steps to reproduce:
- Create a passing PR with an easy means to kill your service.
- Wait for it to build
- Access the PR through github link / VPN
- Kill it
- Refresh page and get Grafana login screen.
This issue has been confirmed by @timja as unintended behaviour.

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
