### PR TITLE
Increase SHIR memory limit to 8GB

### DIFF
--- a/apps/mi/mi-adf-shir/prod.yaml
+++ b/apps/mi/mi-adf-shir/prod.yaml
@@ -10,6 +10,7 @@ spec:
       app.kubernetes.io/name: mi-adf-shir-deployment
     image: sdshmctspublic.azurecr.io/mi/adf-integration-runtime:prod-552c219-20230309085836 #{"$imagepolicy": "flux-system:mi-adf-shir"}
     replicaCount: 4
+    memoryRequests: '2048Mi'
     memoryLimits: '8192Mi'
     resourceGroup: "mi-prod-rg"
     subscriptionId: "5ca62022-6aa2-4cee-aaa7-e7536c8d566c"

--- a/apps/mi/mi-adf-shir/prod.yaml
+++ b/apps/mi/mi-adf-shir/prod.yaml
@@ -10,8 +10,8 @@ spec:
       app.kubernetes.io/name: mi-adf-shir-deployment
     image: sdshmctspublic.azurecr.io/mi/adf-integration-runtime:prod-552c219-20230309085836 #{"$imagepolicy": "flux-system:mi-adf-shir"}
     replicaCount: 4
-    memoryRequests: '2048Mi'
     memoryLimits: '8192Mi'
+    cpuLimits: '4000m'
     resourceGroup: "mi-prod-rg"
     subscriptionId: "5ca62022-6aa2-4cee-aaa7-e7536c8d566c"
     tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"

--- a/apps/mi/mi-adf-shir/prod.yaml
+++ b/apps/mi/mi-adf-shir/prod.yaml
@@ -10,7 +10,7 @@ spec:
       app.kubernetes.io/name: mi-adf-shir-deployment
     image: sdshmctspublic.azurecr.io/mi/adf-integration-runtime:prod-552c219-20230309085836 #{"$imagepolicy": "flux-system:mi-adf-shir"}
     replicaCount: 4
-    memoryLimits: '4096Mi'
+    memoryLimits: '8192Mi'
     resourceGroup: "mi-prod-rg"
     subscriptionId: "5ca62022-6aa2-4cee-aaa7-e7536c8d566c"
     tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"


### PR DESCRIPTION
We are encountering Out of memory issues for our SHIR nodes.
The pods don't seem to be maxing out on memory however, but will try to allocate 8GB for prod per recommended specs https://www.microsoft.com/en-us/download/details.aspx?id=39717