### PR TITLE
testing of promethus is issue

### DIFF
--- a/apps/mailrelay/mailrelay/prod/00.yaml
+++ b/apps/mailrelay/mailrelay/prod/00.yaml
@@ -9,3 +9,5 @@ spec:
     service:
       type: LoadBalancer
       loadBalancerIP: "10.144.15.15"
+    prometheus:
+      enabled: false


### PR DESCRIPTION
### Change description ###
Current error found during redeploy of cluster - 
`n desc = failed to mount secrets store objects for pod mailrelay/mailrelay-exim-0, err: rpc error: code = Unknown desc = failed to mount objects, error: failed to create auth config, error: failed to get credentials, nodePublishSecretRef secret is not set`

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
