### PR TITLE
Fix broken kustomization

### DIFF
--- a/apps/darts-modernisation/demo/base/kustomization.yaml
+++ b/apps/darts-modernisation/demo/base/kustomization.yaml
@@ -3,5 +3,4 @@ kind: Kustomization
 resources:
   - ../../base
   - ../../darts-portal/darts-portal.yaml
-  - ../../darts-api/darts-api.yaml
 namespace: darts-modernisation


### PR DESCRIPTION
### Change description ###
darts-api is already referenced in base, removing it from the demo kustomization


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
