### PR TITLE
Minor changes for darts-portal

### DIFF
--- a/apps/darts-modernisation/darts-portal/demo.yaml
+++ b/apps/darts-modernisation/darts-portal/demo.yaml
@@ -7,5 +7,3 @@ spec:
   releaseName: darts-portal
   values:
     nodejs:
-      ingressHost: darts-portal.demo.platform.hmcts.net
-      image: sdshmctspublic.azurecr.io/darts/portal:prod-b6f465c-20230328115923 # {"$imagepolicy": "flux-system:darts-portal"}

--- a/apps/darts-modernisation/darts-portal/stg.yaml
+++ b/apps/darts-modernisation/darts-portal/stg.yaml
@@ -7,4 +7,4 @@ spec:
   releaseName: darts-portal
   values:
     nodejs:
-
+      ingressHost: darts-portal.staging.platform.hmcts.net


### PR DESCRIPTION
Overriding staging `ingressHost` to match the public DNS record, otherwise the chart in the darts-portal repo uses `darts-portal.stg.platform.hmcts.net` which doesn't match.

**Before creating a pull request make sure that:**

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)

Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###



### Change description ###



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
