### PR TITLE
Remove neuvector image tags for stg env to match CFT cluster

### DIFF
--- a/apps/neuvector/neuvector/neuvector.yaml
+++ b/apps/neuvector/neuvector/neuvector.yaml
@@ -59,7 +59,6 @@ spec:
       - '{"config":{"name":"Mta","criteria":[{"key": "address", "value": "mta.reform.hmcts.net", "op": "="}]}}'
       - '{"config":{"name":"Idam","criteria":[{"key": "address", "value": "idam-api.platform.hmcts.net", "op": "="}]}}'
     neuvector:
-      tag: 5.1.1
       resources:
         requests:
           cpu: "100m"

--- a/apps/neuvector/neuvector/prod/prod.yaml
+++ b/apps/neuvector/neuvector/prod/prod.yaml
@@ -6,6 +6,8 @@ metadata:
   namespace: neuvector
 spec:
   values:
+    neuvector:
+      tag: 5.1.1
     keyvault: 
       name: sdsneuvector
       licensesecretname: neuvector-license

--- a/apps/neuvector/neuvector/stg/00.yaml
+++ b/apps/neuvector/neuvector/stg/00.yaml
@@ -7,7 +7,6 @@ metadata:
 spec:
   values:
     neuvector:
-      tag: 5.1.1
       controller:
         azureFileShare:
           secretName: nv-storage-secret

--- a/apps/neuvector/neuvector/stg/01.yaml
+++ b/apps/neuvector/neuvector/stg/01.yaml
@@ -7,7 +7,6 @@ metadata:
 spec:
   values:
     neuvector:
-      tag: 5.1.1
       controller:
         azureFileShare:
           secretName: nv-storage-secret


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSPO-12488


### Change description ###

Remove the image tag for neuvector to match CFT cluster. Image version will now be dictated by release version of hmcts/chart-neuvector that is specified in config.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
