### PR TITLE
DTSPO-13194 - set priority class name for traefik in sbox 00

### DIFF
--- a/apps/admin/traefik2/sbox/00-traefik2.yaml
+++ b/apps/admin/traefik2/sbox/00-traefik2.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: admin
 spec:
   values:
+    priorityClassName: system-cluster-critical
     service:
       spec:
         loadBalancerIP: "10.140.15.250"


### PR DESCRIPTION
### Change description ###
Adding Priority to Traefik deployment so it's started first.

Testing on sbox 00 first. 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
