### PR TITLE
DTSPO-13194 - set priority class name for traefik

### DIFF
--- a/apps/admin/traefik2/sbox/00-traefik2.yaml
+++ b/apps/admin/traefik2/sbox/00-traefik2.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace: admin
 spec:
   values:
-    priorityClassName: system-cluster-critical
     service:
       spec:
         loadBalancerIP: "10.140.15.250"

--- a/apps/admin/traefik2/traefik2.yaml
+++ b/apps/admin/traefik2/traefik2.yaml
@@ -70,3 +70,4 @@ spec:
                   operator: In
                   values:
                     - system
+    priorityClassName: system-cluster-critical


### PR DESCRIPTION
### Change description ###
Applying priorityClass to all traefik instances. I've suspended the admin kustomization on the prod clusters, even though it should be fine, I'll do one cluster at a time.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
