### PR TITLE
Set dev subscription ID

### DIFF
--- a/apps/jenkins/jenkins/ptl/jenkins.yaml
+++ b/apps/jenkins/jenkins/ptl/jenkins.yaml
@@ -92,6 +92,8 @@ spec:
                         value: 3eec5bde-7feb-4566-bfb6-805df6e10b90
                       - key: AKS_PREVIEW_SUBSCRIPTION_NAME
                         value: DTS-SHAREDSERVICES-DEV
+                      - key: AKS_PREVIEW_SUBSCRIPTION_ID
+                        value: 867a878b-cb68-4de5-9741-361ac9e178b6
                       - key: AKS_AAT_SUBSCRIPTION_NAME
                         value: DTS-SHAREDSERVICES-STG
                       - key: AKS_AAT_SUBSCRIPTION_ID


### PR DESCRIPTION
### Change description ###
Setting the Preview/Dev subscription ID as its missing and is using DCD-CFTAPPS-DEV

PRE reported this after trying to use the Postgres flexible server TF module

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
