### PR TITLE
Script to check if apiVersion entry is there in all files in apps/*

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,6 +19,8 @@ jobs:
           sudo apt-get install -y yamllint
       - name: Install yq
         run: ./tests/install-yq.sh
+      - name: Static File checks
+        run: ./tests/static-file-checks.sh
       - name: Kustomize Tests v2
         run: ./tests/test-kustomize-v2.sh
       - name: Lint Tests

--- a/tests/static-file-checks.sh
+++ b/tests/static-file-checks.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+# Script to check if apiVersion is present in all yaml files in apps/
+
+for FILE in $(find apps/* -type f -name "*.yaml"); do
+
+    if [[ ! $(grep -E "apiVersion:" $FILE) ]]
+    then
+        echo "apiVersion: missing in $FILE" && exit 1
+    fi
+done

--- a/tests/static-file-checks.sh
+++ b/tests/static-file-checks.sh
@@ -3,9 +3,12 @@
 # Script to check if apiVersion is present in all yaml files in apps/
 
 for FILE in $(find apps/* -type f -name "*.yaml"); do
-
-    if [[ ! $(grep -E "apiVersion:" $FILE) ]]
+    
+    API_VERSION_CHECK=$(yq eval -N '.apiVersion' $FILE -N)
+    
+    if [ "$API_VERSION_CHECK" == "null" ]
     then
         echo "apiVersion: missing in $FILE" && exit 1
     fi
+
 done


### PR DESCRIPTION
### Change description ###
Did attempt to use something more sophisticated like kubeconform and kubeval, but it will add quite a few minutes to the pipeline. For now, a simple bash script.

Test failure example run https://github.com/hmcts/cnp-flux-config/actions/runs/4797543679/jobs/8534663328
(using commit: https://github.com/hmcts/cnp-flux-config/commit/1f244a2633140b033b6c0b371090f70eecf8cd1d )

Fixes trello request: https://trello.com/c/E6s54kks/160-flux-check-var-substitution-failed-for-jenkins-yamltojson-yamltojson-yaml-line-542-found-unknown-escape-character

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X] No
```
