### PR TITLE
Reduce dev count of MI SHIR 2 to 2 nodes

### DIFF
--- a/apps/mi/mi-adf-shir-2/dev.yaml
+++ b/apps/mi/mi-adf-shir-2/dev.yaml
@@ -7,7 +7,7 @@ spec:
   releaseName: mi-adf-shir-2
   values:
     image: sdshmctspublic.azurecr.io/mi/adf-integration-runtime:prod-c3ee127-20230504091908 #{"$imagepolicy": "flux-system:mi-adf-shir"}
-    replicaCount: 4
+    replicaCount: 2
     memoryLimits: '4096Mi'
     environment: "dev"
     resourceGroup: "mi-dev-rg"


### PR DESCRIPTION
As all SHIR nodes run on 1 cluster, we use SHIR 2 less than the first SHIR so we can reduce the number of nodes being used to save on resource contention.