### PR TITLE
Add base service accounts SDS

### DIFF
--- a/apps/admin/kured/kured.yaml
+++ b/apps/admin/kured/kured.yaml
@@ -19,6 +19,8 @@ spec:
         namespace: admin
   interval: 1m
   values:
+    serviceAccount:
+      create: false
     image:
       repository: ghcr.io/kubereboot/kured
       tag: 1.12.0

--- a/apps/base/kustomization.yaml
+++ b/apps/base/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - namespace.yaml
   - provider.yaml
   - tests-service-account.yaml
+  - service-account.yaml

--- a/apps/base/service-account.yaml
+++ b/apps/base/service-account.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ${NAMESPACE}
+  namespace: ${NAMESPACE}

--- a/apps/jenkins/jenkins/jenkins.yaml
+++ b/apps/jenkins/jenkins/jenkins.yaml
@@ -10,6 +10,8 @@ spec:
     timeout: 600s
   timeout: 600s
   values:
+    serviceAccount:
+      create: false
     controller:
       # Used for label app.kubernetes.io/component
       componentName: "jenkins-controller"


### PR DESCRIPTION
Chart changes include a base service account reference, but this was forgotten for SDS



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
