### PR TITLE
Revert "Re-add windows tolerations dynatrace"

### DIFF
--- a/apps/dynatrace/dynatrace-operator.yaml
+++ b/apps/dynatrace/dynatrace-operator.yaml
@@ -23,19 +23,11 @@ spec:
           key: CriticalAddonsOnly
           operator: Equal
           value: "true"
-        - effect: NoSchedule
-          key: kubernetes.io/os
-          operator: Equal
-          value: "windows"
     operator:
       tolerations:
         - effect: NoSchedule
           key: CriticalAddonsOnly
           operator: Equal
           value: "true"
-        - effect: NoSchedule
-          key: kubernetes.io/os
-          operator: Equal
-          value: "windows"
       nodeSelector:
         agentpool: system


### PR DESCRIPTION
Reverts hmcts/sds-flux-config#3034 -- causing dynatrace-oneagent pods to not start with message 
```
Not supported by windows
```