### PR TITLE
Revert to working approach

### DIFF
--- a/apps/dynatrace/dynakube.yaml
+++ b/apps/dynatrace/dynakube.yaml
@@ -67,10 +67,10 @@ spec:
 
   namespaceSelector:
     matchExpressions:
-      - key: ignored-by-dynatrace
+      - key: kubernetes.io/metadata.name
         operator: NotIn
         values:
-          - yes
+          - mi
 
   # Configuration for OneAgent instances
   #


### PR DESCRIPTION
Reverting to ignoring MI namespace so their pods can start whilst we try and reach a solution to do this on an application basis with Dynatrace




**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
