### PR TITLE
Remove darts-modernisation from test environment

### DIFF
--- a/clusters/test/base/kustomization.yaml
+++ b/clusters/test/base/kustomization.yaml
@@ -11,7 +11,7 @@ resources:
   - ../../../apps/kube-system/base/kustomize.yaml
   - ../../../apps/met/base/kustomize.yaml
   - ../../../apps/toffee/base/kustomize.yaml
-  # error looking up service account darts-modernisation/darts-portal-nodejs: serviceaccount "darts-portal-nodejs" not found
+  # error looking up service account darts-modernisation/darts-portal-nodejs: serviceaccount "darts-portal-nodejs" not found (stopping AKS version upgrade)
   #- ../../../apps/darts-modernisation/base/kustomize.yaml
   - ../../../apps/hmi/base/kustomize.yaml
   - ../../../apps/monitoring/base/kustomize.yaml

--- a/clusters/test/base/kustomization.yaml
+++ b/clusters/test/base/kustomization.yaml
@@ -11,7 +11,7 @@ resources:
   - ../../../apps/kube-system/base/kustomize.yaml
   - ../../../apps/met/base/kustomize.yaml
   - ../../../apps/toffee/base/kustomize.yaml
-  # deployment to env non-functional, not sure if team want to deploy to test or not (stopping AKS version upgrade)
+  # error looking up service account darts-modernisation/darts-portal-nodejs: serviceaccount "darts-portal-nodejs" not found
   #- ../../../apps/darts-modernisation/base/kustomize.yaml
   - ../../../apps/hmi/base/kustomize.yaml
   - ../../../apps/monitoring/base/kustomize.yaml

--- a/clusters/test/base/kustomization.yaml
+++ b/clusters/test/base/kustomization.yaml
@@ -11,7 +11,8 @@ resources:
   - ../../../apps/kube-system/base/kustomize.yaml
   - ../../../apps/met/base/kustomize.yaml
   - ../../../apps/toffee/base/kustomize.yaml
-  - ../../../apps/darts-modernisation/base/kustomize.yaml
+  # deployment to env non-functional, not sure if team want to deploy to test or not (stopping AKS version upgrade)
+  #- ../../../apps/darts-modernisation/base/kustomize.yaml
   - ../../../apps/hmi/base/kustomize.yaml
   - ../../../apps/monitoring/base/kustomize.yaml
 patches:


### PR DESCRIPTION
### Change description ###

* darts-modernisation namespace has containers which do not deploy properly
* stopping AKS version upgrade
* Have spoken to team, they're unsure if they need to deploy to test or not


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
