### PR TITLE
DTSPO-14224 - Revert netbox to 5.0.9

### DIFF
--- a/apps/netbox/netbox/ptlsbox/netbox.yaml
+++ b/apps/netbox/netbox/ptlsbox/netbox.yaml
@@ -8,7 +8,7 @@ spec:
   chart:
     spec:
       chart: netbox
-      version: 5.1.0
+      version: 5.0.9
       sourceRef:
         kind: HelmRepository
         name: hmctspublic


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-14224

### Change description ###
Revert to 5.0.9

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
