### PR TITLE
Remove darts-modernisation from sds-prod

### DIFF
--- a/clusters/prod/base/kustomization.yaml
+++ b/clusters/prod/base/kustomization.yaml
@@ -15,7 +15,6 @@ resources:
   - ../../../apps/neuvector/base/kustomize.yaml
   - ../../../apps/vh/base/kustomize.yaml
   - ../../../apps/kube-system/base/kustomize.yaml
-  - ../../../apps/darts-modernisation/base/kustomize.yaml
 patches:
   - path: ../../../apps/base/kustomize.yaml
     target:


### PR DESCRIPTION
Doing checks before AKS-SDS prod upgrades and all applications in this namespace are unhealthy which could cause issues. Spoke with @scott-robertson1 about this and these applications are not in use yet in prod and the issue can not be reasonably solved in a short period of time, so the plan is to remove these from sds-prod temporarily.



**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
