### PR TITLE
DTSPO-7962: Setting the "desired version" for report

### DIFF
--- a/apps/monitoring/version-reporter/version-reporter.yaml
+++ b/apps/monitoring/version-reporter/version-reporter.yaml
@@ -23,6 +23,8 @@ spec:
               image: sdshmctspublic.azurecr.io/hmcts/version-reporter-services:paloalto-master #{"$imagepolicy": "flux-system:version-reporter"}
               imagePullPolicy: Always
               env:
+                - name: DESIRED_VERSION
+                  value: "10.2.0"
                 - name: COSMOS_DB_URI
                   value: "https://sds-platform-version-reporter.documents.azure.com:443/"
                 - name: COSMOS_DB_NAME


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-7962


### Change description ###
The `paloalto` report uses a `desired version` variable as part of its ETL process to determine how far off we are from where our desired version is and the current version. It creates a verdict which is part of the report.

This variable would be fairly stable but would need updating from time to time depending on us. Adding it as an env so we don't have to touch the actual code when this needs to be updated in the future.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
