### PR TITLE
DTSPO-14148: List rbac on helmrepositories needed

### DIFF
--- a/apps/monitoring/version-reporter/rbac.yaml
+++ b/apps/monitoring/version-reporter/rbac.yaml
@@ -23,6 +23,9 @@ rules:
   - apiGroups: ['source.toolkit.fluxcd.io']
     resources: ['helmcharts']
     verbs: ['list', 'get']
+  - apiGroups: ['source.toolkit.fluxcd.io']
+    resources: ['helmrepositories']
+    verbs: ['list', 'get']
 
 ---
 apiVersion: v1


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-14148


### Change description ###
Getting the following errors in the report logs
`Error from server (Forbidden): helmrepositories.source.toolkit.fluxcd.io is forbidden: User "system:serviceaccount:monitoring:version-reporter-service-sa" cannot list resource "helmrepositories" in API group "source.toolkit.fluxcd.io" at the cluster scope`

and 

`23/07/26 13:20:01 There was an error while executing the Command: list: failed to list: secrets is forbidden: User "system:serviceaccount:monitoring:version-reporter-service-sa" cannot list resource "secrets" in API group "" at the cluster scope`

This is an attempt to rectify


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
