### PR TITLE
Jenkins: Add daily label to VM Template for PTL

### DIFF
--- a/apps/jenkins/jenkins/ptl/jenkins-azure-vm-agent.yaml
+++ b/apps/jenkins/jenkins/ptl/jenkins-azure-vm-agent.yaml
@@ -92,6 +92,7 @@ spec:
                         subnetName: "iaas"
                         templateDesc: "Jenkins build agents for HMCTS"
                         templateName: "cnp-jenkins-builders"
+                        labels: "daily"
                         uamiID: /subscriptions/6c4d2513-a873-41b4-afdd-b05a33206631/resourceGroups/managed-identities-ptl-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/jenkins-ptl-mi
                         usageMode: NORMAL
                         usePrivateIP: true


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSPO-14661


### Change description ###

* Add daily label to VM Template allowing daily pipeline to run on standard SDS agents from the singular VM Template
* This is needed as the the jenkins config is shared across CFT/SDS and CFT now has segregation of daily/ad-hoc builds through separate VM Templates selected using the label
* As the standard SDS VM Template is set to NORMAL & not EXCLUSIVE the label adding the label allows both daily/ad-hoc builds to run on the standard SDS agents from the singular VM Template


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```