### PR TITLE
Add nodeSelector to dynatrace csi driver

### DIFF
--- a/apps/dynatrace/dynatrace-operator.yaml
+++ b/apps/dynatrace/dynatrace-operator.yaml
@@ -27,6 +27,8 @@ spec:
           key: kubernetes.io/os
           operator: Equal
           value: "windows"
+      nodeSelector:
+        agentpool: linux
     operator:
       tolerations:
         - effect: NoSchedule


### PR DESCRIPTION
### Change description ###
After updating to 0.12.1, the dynatrace helm chart is trying to schedule the csi driver on the windows nodes as well as linux
It's incompatible with windows so it does not work
There is a toleration in the code at the moment but this seems to be being ignored

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
