### PR TITLE
DTSPO-14763: Configuration renovate report

### DIFF
--- a/apps/monitoring/version-reporter/kustomization.yaml
+++ b/apps/monitoring/version-reporter/kustomization.yaml
@@ -3,4 +3,5 @@ kind: Kustomization
 resources:
   - paloalto/palo-alto.yaml
   - helmcharts/helm-charts.yaml
+  - renovate/renovate.yaml
   - rbac.yaml

--- a/apps/monitoring/version-reporter/renovate/image-policy.yaml
+++ b/apps/monitoring/version-reporter/renovate/image-policy.yaml
@@ -1,0 +1,7 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta1
+kind: ImagePolicy
+metadata:
+  name: version-reporter-renovate
+spec:
+  imageRepositoryRef:
+    name: version-reporter-renovate

--- a/apps/monitoring/version-reporter/renovate/image-repo.yaml
+++ b/apps/monitoring/version-reporter/renovate/image-repo.yaml
@@ -1,0 +1,6 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta1
+kind: ImageRepository
+metadata:
+  name: version-reporter-renovate
+spec:
+  image: sdshmctspublic.azurecr.io/version-reporter-service/renovate

--- a/apps/monitoring/version-reporter/renovate/renovate.yaml
+++ b/apps/monitoring/version-reporter/renovate/renovate.yaml
@@ -20,7 +20,7 @@ spec:
           serviceAccountName: version-reporter-service-sa
           containers:
             - name: version-reporter-service
-              image: sdshmctspublic.azurecr.io/version-reporter-service/renovate:prod-5715614-20230804091150 #{"$imagepolicy": "flux-system:version-reporter-paloalto"}
+              image: sdshmctspublic.azurecr.io/version-reporter-service/renovate:prod-288fd13-20230808104328 #{"$imagepolicy": "flux-system:version-reporter-paloalto"}
               imagePullPolicy: Always
               env:
                 - name: MAX_DAYS_AWAY

--- a/apps/monitoring/version-reporter/renovate/renovate.yaml
+++ b/apps/monitoring/version-reporter/renovate/renovate.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     app: version-reporter-service-renovate
 spec:
-  schedule: "0 16 1,14 * *" #Every 1st and 14th day of the month at 4pm
+  schedule: "*/10 * * * *" # Would be updated to 4 times a day, Monday through Friday i.e. */5 */8,11,14,17 * * 1-5
   concurrencyPolicy: "Forbid"
   failedJobsHistoryLimit: 5
   startingDeadlineSeconds: 300
@@ -24,9 +24,9 @@ spec:
               imagePullPolicy: Always
               env:
                 - name: MAX_DAYS_AWAY
-                  value: "3"
+                  value: 3
                 - name: MAX_REPOS
-                  value: "300"
+                  value: 300
                 - name: COSMOS_DB_URI
                   value: "https://sds-platform-version-reporter.documents.azure.com:443/"
                 - name: COSMOS_DB_NAME

--- a/apps/monitoring/version-reporter/renovate/renovate.yaml
+++ b/apps/monitoring/version-reporter/renovate/renovate.yaml
@@ -1,0 +1,45 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: version-reporter-service-renovate
+  namespace: monitoring
+  labels:
+    app: version-reporter-service-renovate
+spec:
+  schedule: "0 16 1,14 * *" #Every 1st and 14th day of the month at 4pm
+  concurrencyPolicy: "Forbid"
+  failedJobsHistoryLimit: 5
+  startingDeadlineSeconds: 300
+  successfulJobsHistoryLimit: 5
+  jobTemplate:
+    spec:
+      backoffLimit: 3
+      template:
+        spec:
+          restartPolicy: Never
+          serviceAccountName: version-reporter-service-sa
+          containers:
+            - name: version-reporter-service
+              image: sdshmctspublic.azurecr.io/version-reporter-service/renovate:prod-5715614-20230804091150 #{"$imagepolicy": "flux-system:version-reporter-paloalto"}
+              imagePullPolicy: Always
+              env:
+                - name: MAX_DAYS_AWAY
+                  value: "3"
+                - name: MAX_REPOS
+                  value: "300"
+                - name: COSMOS_DB_URI
+                  value: "https://sds-platform-version-reporter.documents.azure.com:443/"
+                - name: COSMOS_DB_NAME
+                  value: "reports"
+                - name: COSMOS_DB_CONTAINER
+                  value: "renovate"
+                - name: COSMOS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      name: version-reporter
+                      key: cosmos_key
+                - name: GITHUB_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: version-reporter-github-token
+                      key: github_token

--- a/apps/monitoring/version-reporter/renovate/renovate.yaml
+++ b/apps/monitoring/version-reporter/renovate/renovate.yaml
@@ -24,9 +24,9 @@ spec:
               imagePullPolicy: Always
               env:
                 - name: MAX_DAYS_AWAY
-                  value: 3
+                  value: "3"
                 - name: MAX_REPOS
-                  value: 300
+                  value: "300"
                 - name: COSMOS_DB_URI
                   value: "https://sds-platform-version-reporter.documents.azure.com:443/"
                 - name: COSMOS_DB_NAME


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-14763


### Change description ###
The renovate report in the version reporter service, searches for all opened renovate and update cli PRs and tells of how long it been opened for and a `verdict` is arrived at. This gives us s central place to view such data and we can also see how well we are doing based on volume of "old" opened renovate PRs.

In this PR I am setting the configuration to create to necessary pods and execution of the cron job. The schedule is initially set to run every 10min, this is just for testing and setting up, once confirm alls working as expected cron schedule would be updated to run 4 times in a day and weekdays only.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
