### PR TITLE
Tune idle timeout of agent

### DIFF
--- a/apps/jenkins/jenkins/ptl/jenkins-azure-vm-agent.yaml
+++ b/apps/jenkins/jenkins/ptl/jenkins-azure-vm-agent.yaml
@@ -60,7 +60,7 @@ spec:
               osType: "Linux"
               retentionStrategy:
                 azureVMCloudRetentionStrategy:
-                  idleTerminationMinutes: 60
+                  idleTerminationMinutes: 5
               storageAccountNameReferenceType: "existing"
               storageAccountType: "Standard_LRS"
               subnetName: "iaas"

--- a/apps/jenkins/jenkins/ptlsbox/jenkins-azure-vm-agent.yaml
+++ b/apps/jenkins/jenkins/ptlsbox/jenkins-azure-vm-agent.yaml
@@ -60,7 +60,7 @@ spec:
               osType: "Linux"
               retentionStrategy:
                 azureVMCloudRetentionStrategy:
-                  idleTerminationMinutes: 60
+                  idleTerminationMinutes: 2
               storageAccountNameReferenceType: "existing"
               storageAccountType: "Standard_LRS"
               subnetName: "iaas"


### PR DESCRIPTION
We pay per second used and I'm seeing a lot of idle agents sitting there after builds in the morning.

We can tune this as required to get a good balance but these should only take ~1 min to spawn a new one