### PR TITLE
Point to azure ACR for image

### DIFF
--- a/apps/dynatrace/dynatrace-operator.yaml
+++ b/apps/dynatrace/dynatrace-operator.yaml
@@ -16,6 +16,9 @@ spec:
         kind: HelmRepository
         namespace: dynatrace
   values:
+    imageRef:
+      # Tag defaults to defined chart version, prepended with "v"
+      repository: hmctspublic.azurecr.io/imported/dynatrace/dynatrace-operator
     csidriver:
       enabled: true
       tolerations:


### PR DESCRIPTION
Done for CFT in https://github.com/hmcts/cnp-flux-config/pull/24349/files

Update to point to azure ACR for cached image instead of docker.io


https://tools.hmcts.net/jira/browse/DTSPO-14808

Point to Azure ACR to fetch image instead

Image tag defaults to chart app version - https://github.com/Dynatrace/dynatrace-operator/blob/9c7cf5e2fe953d4838cd43ab7260ca7c4d2aea1c/config/helm/chart/default/templates/_helpers.tpl#L31 with v prepended.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
