### PR TITLE
Point to azure acr cache for traefik

### DIFF
--- a/apps/admin/traefik2/traefik2.yaml
+++ b/apps/admin/traefik2/traefik2.yaml
@@ -16,6 +16,10 @@ spec:
         namespace: admin
   interval: 1m
   values:
+    image:
+      registry: hmctspublic.azurecr.io
+      # Image Tag defaults to AppVersion
+      repository: imported/traefik
     providers:
       kubernetesIngress:
         publishedService:


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DTSPO-14808

Point to our ACR cache

Image tag defaults to appversion from helm chart https://github.com/traefik/traefik-helm-chart/commit/6df869b8e8bcd6757e7934b554b97d925350c9fa#diff-cb0545645bb355dbe0ab58bb31707a6527115c6337d2abf3e83f15dda8f21f35R780


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
