### PR TITLE
Revert "Update neuvector & fluentbit ACR repo locations"

### DIFF
--- a/apps/neuvector/fluentbit-log/fluentbit-log.yaml
+++ b/apps/neuvector/fluentbit-log/fluentbit-log.yaml
@@ -8,8 +8,8 @@ spec:
   releaseName: fluentbit-log
   values:
     image:
-      registry: hmctspublic.azurecr.io
-      repository: imported/fluent/fluent-bit
+      registry: docker.io
+      repository: fluent/fluent-bit
       tag: 2.0.9
       imagePullPolicy: IfNotPresent
       logLevel: debug

--- a/apps/neuvector/neuvector/neuvector.yaml
+++ b/apps/neuvector/neuvector/neuvector.yaml
@@ -96,7 +96,7 @@ spec:
                       values:
                         - system
         image:
-          repository: hmctspublic.azurecr.io/imported/neuvector/controller
+          repository: neuvector/controller
         replicas: 3
         azureFileShare:
           enabled: true
@@ -105,7 +105,7 @@ spec:
           enabled: true
       enforcer:
         image:
-          repository: hmctspublic.azurecr.io/imported/neuvector/controller
+          repository: neuvector/enforcer
       manager:
         tolerations:
           - key: "CriticalAddonsOnly"
@@ -134,7 +134,7 @@ spec:
                       values:
                         - system
         image:
-          repository: hmctspublic.azurecr.io/imported/neuvector/manager
+          repository: neuvector/manager
         env:
           ssl: false
         ingress:
@@ -174,7 +174,7 @@ spec:
           # If false, cve updater will not be installed
           enabled: true
           image:
-            repository: hmctspublic.azurecr.io/imported/neuvector/updater
+            repository: neuvector/updater
             tag: latest
           schedule: "0 0 * * *"
   chart:


### PR DESCRIPTION
Reverts hmcts/sds-flux-config#3368

For some reason, image source is being set as `docker.io/hmctspublic.azurecr.io/imported/neuvector/controller:5.1.1"`