### PR TITLE
Fix wrong source by adding registry

### DIFF
--- a/apps/neuvector/neuvector/neuvector.yaml
+++ b/apps/neuvector/neuvector/neuvector.yaml
@@ -96,7 +96,8 @@ spec:
                       values:
                         - system
         image:
-          repository: hmctspublic.azurecr.io/imported/neuvector/controller
+          registry: hmctspublic.azurecr.io
+          repository: imported/neuvector/controller
         replicas: 3
         azureFileShare:
           enabled: true
@@ -105,7 +106,8 @@ spec:
           enabled: true
       enforcer:
         image:
-          repository: hmctspublic.azurecr.io/imported/neuvector/controller
+          registry: hmctspublic.azurecr.io
+          repository: imported/neuvector/controller
       manager:
         tolerations:
           - key: "CriticalAddonsOnly"
@@ -134,7 +136,8 @@ spec:
                       values:
                         - system
         image:
-          repository: hmctspublic.azurecr.io/imported/neuvector/manager
+          registry: hmctspublic.azurecr.io
+          repository: imported/neuvector/manager
         env:
           ssl: false
         ingress:
@@ -174,7 +177,8 @@ spec:
           # If false, cve updater will not be installed
           enabled: true
           image:
-            repository: hmctspublic.azurecr.io/imported/neuvector/updater
+            registry: hmctspublic.azurecr.io
+            repository: imported/neuvector/updater
             tag: latest
           schedule: "0 0 * * *"
   chart:

--- a/apps/neuvector/neuvector/neuvector.yaml
+++ b/apps/neuvector/neuvector/neuvector.yaml
@@ -8,6 +8,7 @@ spec:
   releaseName: neuvector
   timeout: "900s"
   values:
+    registry: hmctspublic.azurecr.io
     config:
       autoScan: true
     rules:
@@ -96,7 +97,6 @@ spec:
                       values:
                         - system
         image:
-          registry: hmctspublic.azurecr.io
           repository: imported/neuvector/controller
         replicas: 3
         azureFileShare:
@@ -106,7 +106,6 @@ spec:
           enabled: true
       enforcer:
         image:
-          registry: hmctspublic.azurecr.io
           repository: imported/neuvector/controller
       manager:
         tolerations:
@@ -136,7 +135,6 @@ spec:
                       values:
                         - system
         image:
-          registry: hmctspublic.azurecr.io
           repository: imported/neuvector/manager
         env:
           ssl: false
@@ -177,7 +175,6 @@ spec:
           # If false, cve updater will not be installed
           enabled: true
           image:
-            registry: hmctspublic.azurecr.io
             repository: imported/neuvector/updater
             tag: latest
           schedule: "0 0 * * *"

--- a/apps/neuvector/neuvector/neuvector.yaml
+++ b/apps/neuvector/neuvector/neuvector.yaml
@@ -106,7 +106,7 @@ spec:
           enabled: true
       enforcer:
         image:
-          repository: imported/neuvector/controller
+          repository: imported/neuvector/enforcer
       manager:
         tolerations:
           - key: "CriticalAddonsOnly"


### PR DESCRIPTION
https://github.com/hmcts/sds-flux-config/pull/3368

Was giving image source as `docker.io/hmctspublic...`  --- registry is defined at top level instead https://github.com/neuvector/neuvector-helm/blob/master/charts/core/values.yaml#L7

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ ] No
```
