### PR TITLE
allow aso namespaces on neuvector

### DIFF
--- a/apps/neuvector/neuvector/neuvector.yaml
+++ b/apps/neuvector/neuvector/neuvector.yaml
@@ -16,7 +16,7 @@ spec:
         mode: "protect" # one of: monitor, protect
         rules:
           - '{"config":{"id":1000,"category":"Kubernetes","comment":"Allow system namespaces","criteria":[{"name":"namespace","op":"containsAny","value":"neuvector,kube-system,knode-system"}],"disable":false,"rule_type": "exception","cfg_type":"user_created"}}'
-          - '{"config":{"id":1001,"category":"Kubernetes","comment":"Allow admin namespaces","criteria":[{"name":"namespace","op":"containsAny","value":"admin,kured,monitoring,flux-system,dynatrace"}],"disable":false,"rule_type": "exception","cfg_type":"user_created"}}'
+          - '{"config":{"id":1001,"category":"Kubernetes","comment":"Allow admin namespaces","criteria":[{"name":"namespace","op":"containsAny","value":"admin,kured,monitoring,flux-system,dynatrace,azureserviceoperator-system,cert-manager"}],"disable":false,"rule_type": "exception","cfg_type":"user_created"}}'
           - '{"config":{"id":1002,"category":"Kubernetes","comment":"Allow HMCTS registries","criteria":[{"name":"imageRegistry","op":"containsAny","value":"https://hmctspublic.azurecr.io/,https://hmctsprivate.azurecr.io/,https://sdshmctsprivate.azurecr.io/,https://sdshmctspublic.azurecr.io/"}],"disable":false,"rule_type": "exception","cfg_type":"user_created"}}'
           - '{"config":{"id":1003,"category":"Kubernetes","comment":"Default deny","criteria":[{"name":"imageRegistry","op":"containsAny","value":"https://localhost/,https://*.*/"}],"disable":false,"rule_type": "deny","cfg_type":"user_created"}}'
         defaultAction: "allow"


### PR DESCRIPTION

Please remove this line and everything above and fill the following sections:





### Change description ###

This change will allow azureserviceoperator-system,cert-manager to deploy the deployments.
Similar change done here on CNP - https://github.com/hmcts/cnp-flux-config/pull/24336/files 

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ X ] No
```
