### PR TITLE
added workload identity for prod and stg envs

### DIFF
--- a/apps/flux-system/prod/00/kustomize.yaml
+++ b/apps/flux-system/prod/00/kustomize.yaml
@@ -10,5 +10,6 @@ spec:
       ENVIRONMENT: "prod"
       WI_ENVIRONMENT: "prod"
       CLUSTER: '00'
+      ISSUER_URL: "https://uksouth.oic.prod-aks.azure.com/531ff96d-0ae9-462a-8d2d-bec7c0b42082/6e45dd08-5f2e-423e-8815-17bde4e21efc/"
       ENV_MONITOR_CHANNEL: "aks-monitor-sds-prod"
       KEYVAULT_ENVIRONMENT: "prod"

--- a/apps/flux-system/prod/01/kustomize.yaml
+++ b/apps/flux-system/prod/01/kustomize.yaml
@@ -10,5 +10,6 @@ spec:
       ENVIRONMENT: "prod"
       WI_ENVIRONMENT: "prod"
       CLUSTER: "01"
+      ISSUER_URL: "https://uksouth.oic.prod-aks.azure.com/531ff96d-0ae9-462a-8d2d-bec7c0b42082/cc29c7aa-e395-4ad5-96d0-a0567b05cfa4/"
       ENV_MONITOR_CHANNEL: "aks-monitor-sds-prod"
       KEYVAULT_ENVIRONMENT: "prod"

--- a/apps/flux-system/stg/00/kustomize.yaml
+++ b/apps/flux-system/stg/00/kustomize.yaml
@@ -10,5 +10,6 @@ spec:
       ENVIRONMENT: "stg"
       WI_ENVIRONMENT: "stg"
       CLUSTER: "00"
+      ISSUER_URL: "https://uksouth.oic.prod-aks.azure.com/531ff96d-0ae9-462a-8d2d-bec7c0b42082/6e047577-890d-4131-8b4e-39a28c7fea5e/"
       ENV_MONITOR_CHANNEL: "aks-monitor-ss-stg"
       KEYVAULT_ENVIRONMENT: "stg"

--- a/apps/flux-system/stg/01/kustomize.yaml
+++ b/apps/flux-system/stg/01/kustomize.yaml
@@ -10,5 +10,6 @@ spec:
       ENVIRONMENT: "stg"
       WI_ENVIRONMENT: "stg"
       CLUSTER: "01"
+      ISSUER_URL: "https://uksouth.oic.prod-aks.azure.com/531ff96d-0ae9-462a-8d2d-bec7c0b42082/d1bbded4-7740-4e75-b7f3-759b787106e0/"
       ENV_MONITOR_CHANNEL: "aks-monitor-ss-stg"
       KEYVAULT_ENVIRONMENT: "stg"

--- a/apps/toffee/frontend/prod.yaml
+++ b/apps/toffee/frontend/prod.yaml
@@ -10,6 +10,8 @@ spec:
       ingressHost: toffee.platform.hmcts.net
       environment:
         RECIPE_BACKEND_URL: http://toffee-recipe-backend.platform.hmcts.net
+      useWorkloadIdentity: true
+      workloadClientID: ${WORKLOAD_IDENTITY_ID}
       autoscaling:
         enabled: true
         maxReplicas: 5 # Required setting

--- a/apps/toffee/frontend/stg.yaml
+++ b/apps/toffee/frontend/stg.yaml
@@ -12,6 +12,8 @@ spec:
       ingressHost: toffee.staging.platform.hmcts.net
       environment:
         RECIPE_BACKEND_URL: http://toffee-recipe-backend.staging.platform.hmcts.net
+      useWorkloadIdentity: true
+      workloadClientID: ${WORKLOAD_IDENTITY_ID}
     global:
       environment: staging
     volumes:

--- a/apps/toffee/prod/base/kustomization.yaml
+++ b/apps/toffee/prod/base/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../../base
+- ../../../base/workload-identity
 namespace: toffee
 patches:
 - path: ../../identity/prod.yaml

--- a/apps/toffee/prod/base/kustomize.yaml
+++ b/apps/toffee/prod/base/kustomize.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: toffee
+  namespace: flux-system
+spec:
+  path: ./apps/toffee/prod/base
+  postBuild:
+    substitute:
+      WORKLOAD_IDENTITY_ID: "74b9420d-5d98-476b-adc9-a519a58b6f9e"

--- a/apps/toffee/prod/base/workload-identity.yaml
+++ b/apps/toffee/prod/base/workload-identity.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ${NAMESPACE}
+  namespace: ${NAMESPACE}
+  annotations:
+    azure.workload.identity/client-id: ${WORKLOAD_IDENTITY_ID}
+  labels:
+    azure.workload.identity/use: "true"

--- a/apps/toffee/recipe-backend/prod.yaml
+++ b/apps/toffee/recipe-backend/prod.yaml
@@ -8,6 +8,8 @@ spec:
     java:
       image: sdshmctspublic.azurecr.io/toffee/recipe-backend:prod-b934162-20230814062019 #{"$imagepolicy": "flux-system:toffee-recipe-backend"}
       ingressHost: toffee-recipe-backend.platform.hmcts.net
+      useWorkloadIdentity: true
+      workloadClientID: ${WORKLOAD_IDENTITY_ID}
       autoscaling:
         enabled: true
         maxReplicas: 5 # Required setting

--- a/apps/toffee/recipe-backend/stg.yaml
+++ b/apps/toffee/recipe-backend/stg.yaml
@@ -10,5 +10,7 @@ spec:
     java:
       image: sdshmctspublic.azurecr.io/toffee/recipe-backend:prod-b934162-20230814062019 #{"$imagepolicy": "flux-system:toffee-recipe-backend"}
       ingressHost: toffee-recipe-backend.staging.platform.hmcts.net
+      useWorkloadIdentity: true
+      workloadClientID: ${WORKLOAD_IDENTITY_ID}
     global:
       environment: staging

--- a/apps/toffee/stg/base/kustomization.yaml
+++ b/apps/toffee/stg/base/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../../base
+- ../../../base/workload-identity
 namespace: toffee
 patches:
 - path: ../../identity/stg.yaml

--- a/apps/toffee/stg/base/kustomize.yaml
+++ b/apps/toffee/stg/base/kustomize.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: toffee
+  namespace: flux-system
+spec:
+  path: ./apps/toffee/stg/base
+  postBuild:
+    substitute:
+      WORKLOAD_IDENTITY_ID: "6ff1ebbb-50cb-4f41-bdf7-8648a5c080d2"

--- a/apps/toffee/stg/base/workload-identity.yaml
+++ b/apps/toffee/stg/base/workload-identity.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ${NAMESPACE}
+  namespace: ${NAMESPACE}
+  annotations:
+    azure.workload.identity/client-id: ${WORKLOAD_IDENTITY_ID}
+  labels:
+    azure.workload.identity/use: "true"

--- a/clusters/prod/base/kustomization.yaml
+++ b/clusters/prod/base/kustomization.yaml
@@ -22,3 +22,4 @@ patches:
     target:
       kind: Kustomization
       annotationSelector: hmcts.github.com/kustomize-defaults != disabled
+  - path: ../../../apps/toffee/prod/base/kustomize.yaml

--- a/clusters/stg/base/kustomization.yaml
+++ b/clusters/stg/base/kustomization.yaml
@@ -22,3 +22,4 @@ patches:
     target:
       kind: Kustomization
       annotationSelector: hmcts.github.com/kustomize-defaults != disabled
+  - path: ../../../apps/toffee/stg/base/kustomize.yaml


### PR DESCRIPTION


Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSPO-14747

### Change description ###

moved toffee to use workload identity for prod and staging environments..

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X ] No
```
