### PR TITLE
added resources for ptl and ptlsbox

### DIFF
--- a/apps/flux-system/ptl/00/kustomize.yaml
+++ b/apps/flux-system/ptl/00/kustomize.yaml
@@ -10,5 +10,6 @@ spec:
       ENVIRONMENT: "ptl"
       WI_ENVIRONMENT: "ptl"
       CLUSTER: "00"
+      ISSUER_URL: "https://uksouth.oic.prod-aks.azure.com/531ff96d-0ae9-462a-8d2d-bec7c0b42082/0ccbba87-f0d7-44fc-9688-9a3853929371/"
       ENV_MONITOR_CHANNEL: "aks-monitor-ss-ptl"
       KEYVAULT_ENVIRONMENT: "ptl"

--- a/apps/flux-system/ptlsbox/00/kustomize.yaml
+++ b/apps/flux-system/ptlsbox/00/kustomize.yaml
@@ -10,5 +10,6 @@ spec:
       ENVIRONMENT: "ptlsbox"
       WI_ENVIRONMENT: "ptlsbox"
       CLUSTER: "00"
+      ISSUER_URL: "https://uksouth.oic.prod-aks.azure.com/531ff96d-0ae9-462a-8d2d-bec7c0b42082/6521fa74-1017-41c0-ae93-a48fd6a4fd9e/"
       ENV_MONITOR_CHANNEL: "aks-monitor-ss-ptlsbox"
       KEYVAULT_ENVIRONMENT: "ptlsbox"


### PR DESCRIPTION

### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/DTSPO-14747

### Change description ###
Toffee app is not there for ptl and ptlsbox envs so added issuer url for it to be ready in order if other apps on those envs need to move to use workload identity


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[X ] No
```
