### PR TITLE
DTSPO-13992 - Update ptl jenkins webhook relay connection url

### DIFF
--- a/apps/jenkins/jenkins-webhook-relay/ptl/jenkins-webhook-relay.yaml
+++ b/apps/jenkins/jenkins-webhook-relay/ptl/jenkins-webhook-relay.yaml
@@ -24,6 +24,8 @@ spec:
           serviceBusName: github-jenkins-sds-ptl
           queueName: "jenkins"
           queueLength: "5"
+      environment:
+        CONNECTION_URL: "https://sds-build.platform.hmcts.net"
       secrets:
         SERVICE_BUS_CONNECTION_STR:
           secretRef: jenkins-webhook-relay


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/DTSPO-13992

### Change description ###
Update connection url to main jenkins url instead of kubernetes service
Successfully triggered builds on master/main seem to be using this url instead of the kubernetes service so testing if this will fix the issue across the board

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
