### PR TITLE
removing my time app to upgrade ithc cluster

### DIFF
--- a/clusters/ithc/base/kustomization.yaml
+++ b/clusters/ithc/base/kustomization.yaml
@@ -9,7 +9,7 @@ resources:
   - ../../../apps/toffee/base/kustomize.yaml
   - ../../../apps/neuvector/base/kustomize.yaml
   - ../../../apps/kube-system/base/kustomize.yaml
-  - ../../../apps/my-time/base/kustomize.yaml
+  # - ../../../apps/my-time/base/kustomize.yaml
   - ../../../apps/vh/base/kustomize.yaml
   - ../../../apps/hmi/base/kustomize.yaml
   - ../../../apps/monitoring/base/kustomize.yaml


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-15360


### Change description ###
Removing my time app to upgrade ithc cluster, my-frontend app broken and is no longer required.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
