### PR TITLE
feat: increase ado agents max replica count to 6 in ptl

### DIFF
--- a/apps/azure-devops/azure-devops-agent-keda/ithc.yaml
+++ b/apps/azure-devops/azure-devops-agent-keda/ithc.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: azure-devops
 spec:
   values:
+    maxReplicaCount: 6
     environment:
       AZP_POOL: hmcts-ss-ithc
     triggers:


### PR DESCRIPTION
### Jira link (if applicable)
N/A


### Change description ###
We are using the PTL ADO agents for several DLRM projects, as they are getting used more we are frequently seeing queues. Increase the max replica count to 6 should help reduce waiting time.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
