### PR TITLE
Revert "Remove potential client id overrid"

### DIFF
--- a/apps/admin/external-dns/dev/00-external-dns.yaml
+++ b/apps/admin/external-dns/dev/00-external-dns.yaml
@@ -9,3 +9,5 @@ spec:
     txtOwnerId: sds-dev-aks-inactive
     domainFilters:
       - dev.platform.hmcts.net
+    azure:
+      userAssignedIdentityID: b86d64c4-ec90-451a-ab22-77cea15aeb68

--- a/apps/admin/external-dns/dev/01-external-dns.yaml
+++ b/apps/admin/external-dns/dev/01-external-dns.yaml
@@ -9,3 +9,5 @@ spec:
     txtOwnerId: sds-dev-aks-active
     domainFilters:
       - dev.platform.hmcts.net
+    azure:
+      userAssignedIdentityID: b86d64c4-ec90-451a-ab22-77cea15aeb68


### PR DESCRIPTION
Reverts hmcts/sds-flux-config#3646 - didn't fix the error so reverting to bring pods back up