### PR TITLE
Update to use stg mi

### DIFF
--- a/apps/admin/serviceaccount/dev.yaml
+++ b/apps/admin/serviceaccount/dev.yaml
@@ -4,4 +4,5 @@ metadata:
   name: ${NAMESPACE}
   namespace: ${NAMESPACE}
   annotations:
-    azure.workload.identity/client-id: "5841b1d5-949c-43e3-884a-87787eb77f38"
+    # Uses stg MI
+    azure.workload.identity/client-id: "354c7107-f52e-4e4e-a07f-e2403d90c865"


### PR DESCRIPTION
The federated identity credentials on the cluster are using stg-mi, but the one i added in code was the dev-mi - leading to an error that no federated credentials were found


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
