### PR TITLE
DTSPO-12677 Move podidbinding label out of base traefik

### DIFF
--- a/apps/admin/sbox/base/kustomize.yaml
+++ b/apps/admin/sbox/base/kustomize.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: admin
+  namespace: flux-system
+spec:
+  postBuild:
+    substitute:
+      WORKLOAD_IDENTITY_ID: "f7c1f6ca-a85f-4a03-8adc-13623bcb1c55"

--- a/apps/admin/traefik2/demo/00-traefik2.yaml
+++ b/apps/admin/traefik2/demo/00-traefik2.yaml
@@ -8,3 +8,6 @@ spec:
     service:
       spec:
         loadBalancerIP: "10.51.79.250"
+    deployment:
+      podLabels:
+        aadpodidbinding: traefik

--- a/apps/admin/traefik2/demo/01-traefik2.yaml
+++ b/apps/admin/traefik2/demo/01-traefik2.yaml
@@ -8,3 +8,6 @@ spec:
     service:
       spec:
         loadBalancerIP: "10.51.95.250"
+    deployment:
+      podLabels:
+        aadpodidbinding: traefik

--- a/apps/admin/traefik2/dev/00-traefik2.yaml
+++ b/apps/admin/traefik2/dev/00-traefik2.yaml
@@ -8,3 +8,6 @@ spec:
     service:
       spec:
         loadBalancerIP: "10.145.15.250"
+    deployment:
+      podLabels:
+        aadpodidbinding: traefik

--- a/apps/admin/traefik2/dev/01-traefik2.yaml
+++ b/apps/admin/traefik2/dev/01-traefik2.yaml
@@ -8,3 +8,6 @@ spec:
     service:
       spec:
         loadBalancerIP: "10.145.31.250"
+    deployment:
+      podLabels:
+        aadpodidbinding: traefik

--- a/apps/admin/traefik2/ithc/00-traefik2.yaml
+++ b/apps/admin/traefik2/ithc/00-traefik2.yaml
@@ -8,3 +8,6 @@ spec:
     service:
       spec:
         loadBalancerIP: "10.143.15.250"
+    deployment:
+      podLabels:
+        aadpodidbinding: traefik

--- a/apps/admin/traefik2/ithc/01-traefik2.yaml
+++ b/apps/admin/traefik2/ithc/01-traefik2.yaml
@@ -8,3 +8,6 @@ spec:
     service:
       spec:
         loadBalancerIP: "10.143.31.250"
+    deployment:
+      podLabels:
+        aadpodidbinding: traefik

--- a/apps/admin/traefik2/prod/00-traefik2.yaml
+++ b/apps/admin/traefik2/prod/00-traefik2.yaml
@@ -8,3 +8,6 @@ spec:
     service:
       spec:
         loadBalancerIP: "10.144.15.250"
+    deployment:
+      podLabels:
+        aadpodidbinding: traefik

--- a/apps/admin/traefik2/prod/01-traefik2.yaml
+++ b/apps/admin/traefik2/prod/01-traefik2.yaml
@@ -8,3 +8,6 @@ spec:
     service:
       spec:
         loadBalancerIP: "10.144.31.250"
+    deployment:
+      podLabels:
+        aadpodidbinding: traefik

--- a/apps/admin/traefik2/ptl/00-traefik.yaml
+++ b/apps/admin/traefik2/ptl/00-traefik.yaml
@@ -8,3 +8,6 @@ spec:
     service:
       spec:
         loadBalancerIP: "10.147.79.250"
+    deployment:
+      podLabels:
+        aadpodidbinding: traefik

--- a/apps/admin/traefik2/ptlsbox/00-traefik.yaml
+++ b/apps/admin/traefik2/ptlsbox/00-traefik.yaml
@@ -11,3 +11,6 @@ spec:
     service:
       spec:
         loadBalancerIP: "10.147.15.250"
+    deployment:
+      podLabels:
+        aadpodidbinding: traefik

--- a/apps/admin/traefik2/sbox/00-traefik2.yaml
+++ b/apps/admin/traefik2/sbox/00-traefik2.yaml
@@ -8,3 +8,6 @@ spec:
     service:
       spec:
         loadBalancerIP: "10.140.15.250"
+    deployment:
+      podLabels:
+        aadpodidbinding: traefik

--- a/apps/admin/traefik2/sbox/01-traefik2.yaml
+++ b/apps/admin/traefik2/sbox/01-traefik2.yaml
@@ -8,3 +8,6 @@ spec:
     service:
       spec:
         loadBalancerIP: "10.140.31.250"
+    deployment:
+      podLabels:
+        aadpodidbinding: traefik

--- a/apps/admin/traefik2/sbox/secret-provider.yaml
+++ b/apps/admin/traefik2/sbox/secret-provider.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: admin
 spec:
   parameters:
+    # usePodIdentity: "false"
+    # clientID: ${WORKLOAD_IDENTITY_ID}
     keyvaultName: acmedtssdssbox
     objects: |
       array:

--- a/apps/admin/traefik2/stg/00-traefik2.yaml
+++ b/apps/admin/traefik2/stg/00-traefik2.yaml
@@ -8,3 +8,6 @@ spec:
     service:
       spec:
         loadBalancerIP: "10.148.15.250"
+    deployment:
+      podLabels:
+        aadpodidbinding: traefik

--- a/apps/admin/traefik2/stg/01-traefik2.yaml
+++ b/apps/admin/traefik2/stg/01-traefik2.yaml
@@ -8,3 +8,6 @@ spec:
     service:
       spec:
         loadBalancerIP: "10.148.31.250"
+    deployment:
+      podLabels:
+        aadpodidbinding: traefik

--- a/apps/admin/traefik2/test/00-traefik2.yaml
+++ b/apps/admin/traefik2/test/00-traefik2.yaml
@@ -8,3 +8,6 @@ spec:
     service:
       spec:
         loadBalancerIP: "10.141.15.250"
+    deployment:
+      podLabels:
+        aadpodidbinding: traefik

--- a/apps/admin/traefik2/test/01-traefik2.yaml
+++ b/apps/admin/traefik2/test/01-traefik2.yaml
@@ -8,3 +8,6 @@ spec:
     service:
       spec:
         loadBalancerIP: "10.141.31.250"
+    deployment:
+      podLabels:
+        aadpodidbinding: traefik

--- a/apps/admin/traefik2/traefik2.yaml
+++ b/apps/admin/traefik2/traefik2.yaml
@@ -28,8 +28,6 @@ spec:
       enabled: true
       isDefaultClass: true
     deployment:
-      podLabels:
-        aadpodidbinding: traefik
       additionalVolumes:
         - name: traefik-default-cert
           csi:

--- a/clusters/sbox/base/kustomization.yaml
+++ b/clusters/sbox/base/kustomization.yaml
@@ -22,3 +22,5 @@ patches:
       kind: Kustomization
       annotationSelector: hmcts.github.com/kustomize-defaults != disabled
   - path: ../../../apps/toffee/sbox/base/kustomize.yaml
+  - path: ../../../apps/admin/sbox/base/kustomize.yaml
+

--- a/clusters/sbox/base/kustomization.yaml
+++ b/clusters/sbox/base/kustomization.yaml
@@ -23,4 +23,3 @@ patches:
       annotationSelector: hmcts.github.com/kustomize-defaults != disabled
   - path: ../../../apps/toffee/sbox/base/kustomize.yaml
   - path: ../../../apps/admin/sbox/base/kustomize.yaml
-


### PR DESCRIPTION
Enables me to disable this per env for migrating to workload identity
Also adds sbox kustomize needed for that env in this PR


Similar done in CFT

https://github.com/hmcts/cnp-flux-config/pull/25193/files

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
