### PR TITLE
DTSPO-15146-Create chart-job-test-gitrepo.yaml

### DIFF
--- a/apps/flux-system/base/chart-job-test-gitrepo.yaml
+++ b/apps/flux-system/base/chart-job-test-gitrepo.yaml
@@ -1,0 +1,17 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: GitRepository
+metadata:
+  name: chart-job-test-tyler
+  namespace: flux-system
+spec:
+  interval: 5m
+  url: ssh://github.com/hmcts/chart-job
+  ref:
+    branch: https://github.com/hmcts/chart-job/tree/DTSPO-15287-Add-tolerations-to-chart-job4
+  secretRef:
+    name: git-credentials
+  ignore: |
+    # exclude all
+    /*
+    # include charts directory
+    !/job/

--- a/apps/flux-system/base/kustomization.yaml
+++ b/apps/flux-system/base/kustomization.yaml
@@ -22,3 +22,4 @@ resources:
 - toffee-recipe-receiver-gitrepo.yaml
 - chart-job-gitrepo.yaml
 - jenkins-webhook-relay-gitrepo.yaml
+- chart-job-test-gitrepo.yaml


### PR DESCRIPTION
### Jira link (if applicable)

[DTSPO-15146](https://tools.hmcts.net/jira/browse/DTSPO-15146)

### Change description ###
adding another git repo for chart-job to run test on helm releases without having to constantly merge into master chart-job repo.