### PR TITLE
Migrate sbox traefik to workload identity

### DIFF
--- a/apps/admin/traefik2/sbox/00-traefik2.yaml
+++ b/apps/admin/traefik2/sbox/00-traefik2.yaml
@@ -10,4 +10,6 @@ spec:
         loadBalancerIP: "10.140.15.250"
     deployment:
       podLabels:
-        aadpodidbinding: traefik
+        useWorkloadIdentity: "true"
+    serviceAccount:
+      name: admin

--- a/apps/admin/traefik2/sbox/01-traefik2.yaml
+++ b/apps/admin/traefik2/sbox/01-traefik2.yaml
@@ -10,4 +10,6 @@ spec:
         loadBalancerIP: "10.140.31.250"
     deployment:
       podLabels:
-        aadpodidbinding: traefik
+        useWorkloadIdentity: "true"
+    serviceAccount:
+      name: admin

--- a/apps/admin/traefik2/sbox/secret-provider.yaml
+++ b/apps/admin/traefik2/sbox/secret-provider.yaml
@@ -5,8 +5,8 @@ metadata:
   namespace: admin
 spec:
   parameters:
-    # usePodIdentity: "false"
-    # clientID: ${WORKLOAD_IDENTITY_ID}
+    usePodIdentity: "false"
+    clientID: ${WORKLOAD_IDENTITY_ID}
     keyvaultName: acmedtssdssbox
     objects: |
       array:


### PR DESCRIPTION
[DTSPO-12677](https://tools.hmcts.net/jira/browse/DTSPO-12677)

Role assignment for acme already added as pre-req

This change:
  - Updates traefik in sbox to use workload identity


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
