### PR TITLE
Remove external-dns binding after migration completed

### DIFF
--- a/apps/admin/external-dns/identity-binding.yaml
+++ b/apps/admin/external-dns/identity-binding.yaml
@@ -1,8 +1,0 @@
-apiVersion: "aadpodidentity.k8s.io/v1"
-kind: AzureIdentityBinding
-metadata:
-  name: external-dns-binding
-  namespace: admin
-spec:
-  azureIdentity: aks-pod-identity-mi
-  selector: external-dns

--- a/apps/admin/external-dns/kustomization.yaml
+++ b/apps/admin/external-dns/kustomization.yaml
@@ -4,4 +4,3 @@ kind: Kustomization
 resources:
   - external-dns-helmrepo.yaml
   - external-dns.yaml
-  - identity-binding.yaml


### PR DESCRIPTION
External-dns has been migrated to workload identity so no longer uses this

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
