### PR TITLE
Update to use STG-MI to avoid traefik issues

### DIFF
--- a/apps/admin/dev/base/kustomize.yaml
+++ b/apps/admin/dev/base/kustomize.yaml
@@ -6,4 +6,4 @@ metadata:
 spec:
   postBuild:
     substitute:
-      WORKLOAD_IDENTITY_ID: "5841b1d5-949c-43e3-884a-87787eb77f38"
+      WORKLOAD_IDENTITY_ID: "354c7107-f52e-4e4e-a07f-e2403d90c865"


### PR DESCRIPTION
Originally set this as external-dns was using it -- external-dns role assignments etc also exist for stg-mi which I think is the correct one to be using. Updating this switches dev to use the stg-mi.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
