### PR TITLE
Add a patch for dev workload identity in admin namespace

### DIFF
--- a/apps/admin/base/workload-identity/kustomization.yaml
+++ b/apps/admin/base/workload-identity/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - workload-identity-federated-credential.yaml
+  - workload-identity-rg.yaml
+  - workload-identity-ua-identity.yaml

--- a/apps/admin/base/workload-identity/workload-identity-federated-credential.yaml
+++ b/apps/admin/base/workload-identity/workload-identity-federated-credential.yaml
@@ -1,0 +1,12 @@
+apiVersion: managedidentity.azure.com/v1beta20220131preview
+kind: FederatedIdentityCredential
+metadata:
+  name: ${WI_NAME}-${WI_CLUSTER}-fic
+  namespace: ${NAMESPACE}
+spec:
+  owner:
+    name: ${WI_NAME}-${ENVIRONMENT}-mi
+  audiences:
+    - api://AzureADTokenExchange
+  issuer: ${ISSUER_URL}
+  subject: system:serviceaccount:${NAMESPACE}:${NAMESPACE}

--- a/apps/admin/base/workload-identity/workload-identity-rg.yaml
+++ b/apps/admin/base/workload-identity/workload-identity-rg.yaml
@@ -1,0 +1,10 @@
+apiVersion: resources.azure.com/v1beta20200601
+kind: ResourceGroup
+metadata:
+  name: managed-identities-${ENVIRONMENT}-rg
+  namespace: ${NAMESPACE}
+  annotations:
+    serviceoperator.azure.com/reconcile-policy: detach-on-delete
+spec:
+  location: uksouth
+  azureName: managed-identities-${ENVIRONMENT}-rg

--- a/apps/admin/base/workload-identity/workload-identity-ua-identity.yaml
+++ b/apps/admin/base/workload-identity/workload-identity-ua-identity.yaml
@@ -1,0 +1,11 @@
+apiVersion: managedidentity.azure.com/v1beta20181130
+kind: UserAssignedIdentity
+metadata:
+  name: ${WI_NAME}-${ENVIRONMENT}-mi
+  namespace: ${NAMESPACE}
+  annotations:
+    serviceoperator.azure.com/reconcile-policy: skip
+spec:
+  location: uksouth
+  owner:
+    name: managed-identities-${ENVIRONMENT}-rg

--- a/apps/admin/dev/base/kustomization.yaml
+++ b/apps/admin/dev/base/kustomization.yaml
@@ -8,6 +8,8 @@ resources:
 - ../../traefik2
 - ../../external-dns/
 - ../../delete-hung-pods
+# Dev-specific workload identity resources
+- ../../base/workload-identity
 namespace: admin
 patches:
 - path: ../../aad-pod-identity/dev/azure-identity-patch.yaml

--- a/apps/admin/dev/base/kustomization.yaml
+++ b/apps/admin/dev/base/kustomization.yaml
@@ -1,7 +1,10 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ../../base
+- ../../../base
+- ../../kured
+- ../../kube-slack
+- ../aad-pod-identity
 - ../../kube-slack/dev/kube-slack-values.enc.yaml
 - ../../kured/dev/kured-values.enc.yaml
 - ../../../rbac/reader-clusterrole.yaml

--- a/apps/admin/dev/base/kustomization.yaml
+++ b/apps/admin/dev/base/kustomization.yaml
@@ -4,7 +4,7 @@ resources:
 - ../../../base
 - ../../kured
 - ../../kube-slack
-- ../aad-pod-identity
+- ../../aad-pod-identity
 - ../../kube-slack/dev/kube-slack-values.enc.yaml
 - ../../kured/dev/kured-values.enc.yaml
 - ../../../rbac/reader-clusterrole.yaml

--- a/apps/admin/dev/base/kustomization.yaml
+++ b/apps/admin/dev/base/kustomization.yaml
@@ -11,7 +11,7 @@ resources:
 - ../../traefik2
 - ../../external-dns/
 - ../../delete-hung-pods
-# Dev-specific workload identity resources
+# Dev-specific workload identity resources which uses ENVIRONMENT instead of WI_ENVIRONMENT
 - ../../base/workload-identity
 namespace: admin
 patches:


### PR DESCRIPTION
Usually dev uses stg infrastucture, MIs etc, but for traefik it is reading from acmedtsdev key vault -- without this change we would need role assignments to give the admin-stg-mi access to the above vault.

This change:
  - Overrides base workload identity resources in admin dev only, by changing the environment used when creating resources with ASO in dev from `stg` to `dev` -- so that the federated identity credentials are made on the admin-dev-mi for use by traefik instead
  - Mainly `WI_ENVIRONMENT` has been changed to `ENVIRONMENT` in workload identity resources


Will not affect any apps besides those using workload identity in admin namespace and on dev clusters. I have already added role assignments for external dns with the dev-mi as well

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
