### PR TITLE
Turn off more namespaces for container logs

### DIFF
--- a/apps/kube-system/container-azm-ms-agentconfig/container-azm-ms-agentconfig.yaml
+++ b/apps/kube-system/container-azm-ms-agentconfig/container-azm-ms-agentconfig.yaml
@@ -19,7 +19,7 @@ data:
           # kube-system,gatekeeper-system log collection are disabled by default in the absence of 'log_collection_settings.stdout' setting. If you want to enable kube-system,gatekeeper-system, remove them from the following setting.
           # If you want to continue to disable kube-system,gatekeeper-system log collection keep the namespaces in the following setting and add any other namespace you want to disable log collection to the array.
           # In the absense of this configmap, default value for exclude_namespaces = ["kube-system","gatekeeper-system"]
-          exclude_namespaces = ["kube-system","gatekeeper-system", "admin", "flux-system", "jd", "keda", "monitoring", "neuvector", "pip", "pre", "toffee"]
+          exclude_namespaces = ["kube-system","gatekeeper-system", "admin", "flux-system", "jd", "keda", "monitoring", "met", "mi", "neuvector", "pip", "pre", "toffee"]
        [log_collection_settings.stderr]
           # Default value for enabled is true
           enabled = true
@@ -27,7 +27,7 @@ data:
           # kube-system,gatekeeper-system log collection are disabled by default in the absence of 'log_collection_settings.stderr' setting. If you want to enable kube-system,gatekeeper-system, remove them from the following setting.
           # If you want to continue to disable kube-system,gatekeeper-system log collection keep the namespaces in the following setting and add any other namespace you want to disable log collection to the array.
           # In the absense of this configmap, default value for exclude_namespaces = ["kube-system","gatekeeper-system"]
-          exclude_namespaces = ["kube-system","gatekeeper-system", "admin", "flux-system", "jd", "keda", "monitoring", "neuvector", "pip", "pre", "toffee"]
+          exclude_namespaces = ["kube-system","gatekeeper-system", "admin", "flux-system", "jd", "keda", "monitoring", "met", "mi", "neuvector", "pip", "pre", "toffee"]
 
        [log_collection_settings.env_var]
           # In the absense of this configmap, default value for enabled is true


### PR DESCRIPTION
query showed these as logging a lot:


https://portal.azure.com#@531ff96d-0ae9-462a-8d2d-bec7c0b42082/blade/Microsoft_OperationsManagementSuite_Workspace/Logs.ReactView/resourceId/%2Fsubscriptions%2F8999dec3-0104-4a27-94ee-6588559729d1%2Fresourcegroups%2Foms-automation%2Fproviders%2Fmicrosoft.operationalinsights%2Fworkspaces%2Fhmcts-prod/source/LogsBlade.AnalyticsShareLinkToQuery/q/H4sIAAAAAAAAA1XNsQrCMBRG4d2nuHZqIYvuDtJBBCki0lXS5CcNNDdymyiKD286OLgfvtNGTtoz5BRdv1196DlCQOdoOx0w37UB0doz1dVjrJoSzDkELf4N2jsncDrB9nrKoB2ZmDnVDQ0vGjzXVx9wQMGXRtHGNora33Dx1d9I0e2COWYxONpyErCFFHTKgc2oJX0BQt6yRK4AAAA%253D/timespan/P3D