### PR TITLE
PRE prod - change key vault name

### DIFF
--- a/apps/pre/pre-api/prod.yaml
+++ b/apps/pre/pre-api/prod.yaml
@@ -8,5 +8,18 @@ spec:
   values:
     java:
       ingressHost: pre-api.platform.hmcts.net
-    keyvault:
-      name: pre-hmctskv-prod
+      keyvaults:
+        "pre-hmctskv":
+          secrets:
+            - name: api-POSTGRES-HOST
+              alias: POSTGRES_HOST
+            - name: api-POSTGRES-PORT
+              alias: POSTGRES_PORT
+            - name: api-POSTGRES-DATABASE
+              alias: POSTGRES_DATABASE
+            - name: api-POSTGRES-PASS
+              alias: POSTGRES_PASSWORD
+            - name: api-POSTGRES-USER
+              alias: POSTGRES_USER
+            - name: AppInsightsInstrumentationKey
+              alias: APPINSIGHTS_INSTRUMENTATIONKEY

--- a/apps/pre/pre-api/prod.yaml
+++ b/apps/pre/pre-api/prod.yaml
@@ -8,3 +8,5 @@ spec:
   values:
     java:
       ingressHost: pre-api.platform.hmcts.net
+    keyvault:
+      name: pre-hmctskv-prod


### PR DESCRIPTION
### Change description ###
our prod kv has a different naming convention to the lower environments. this change is to recognise that
