### PR TITLE
upgrade HelmRelease apiVersion to v2beta2 introudced in flux 2.2.0

### DIFF
--- a/apps/admin/delete-hung-pods/cron.yaml
+++ b/apps/admin/delete-hung-pods/cron.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: restart-pods

--- a/apps/admin/external-dns/dev/00-external-dns.yaml
+++ b/apps/admin/external-dns/dev/00-external-dns.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: external-dns

--- a/apps/admin/external-dns/dev/01-external-dns.yaml
+++ b/apps/admin/external-dns/dev/01-external-dns.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: external-dns

--- a/apps/admin/external-dns/external-dns.yaml
+++ b/apps/admin/external-dns/external-dns.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: external-dns

--- a/apps/admin/kube-slack/demo/00.yaml
+++ b/apps/admin/kube-slack/demo/00.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: kube-slack

--- a/apps/admin/kube-slack/demo/01.yaml
+++ b/apps/admin/kube-slack/demo/01.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: kube-slack

--- a/apps/admin/kube-slack/kube-slack.yaml
+++ b/apps/admin/kube-slack/kube-slack.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: kube-slack

--- a/apps/admin/kured/kured.yaml
+++ b/apps/admin/kured/kured.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: kured

--- a/apps/admin/traefik2/demo/00-traefik2.yaml
+++ b/apps/admin/traefik2/demo/00-traefik2.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: traefik2

--- a/apps/admin/traefik2/demo/01-traefik2.yaml
+++ b/apps/admin/traefik2/demo/01-traefik2.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: traefik2

--- a/apps/admin/traefik2/dev/00-traefik2.yaml
+++ b/apps/admin/traefik2/dev/00-traefik2.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: traefik2

--- a/apps/admin/traefik2/dev/01-traefik2.yaml
+++ b/apps/admin/traefik2/dev/01-traefik2.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: traefik2

--- a/apps/admin/traefik2/ithc/00-traefik2.yaml
+++ b/apps/admin/traefik2/ithc/00-traefik2.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: traefik2

--- a/apps/admin/traefik2/ithc/01-traefik2.yaml
+++ b/apps/admin/traefik2/ithc/01-traefik2.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: traefik2

--- a/apps/admin/traefik2/prod/00-traefik2.yaml
+++ b/apps/admin/traefik2/prod/00-traefik2.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: traefik2

--- a/apps/admin/traefik2/prod/01-traefik2.yaml
+++ b/apps/admin/traefik2/prod/01-traefik2.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: traefik2

--- a/apps/admin/traefik2/ptl/00-traefik.yaml
+++ b/apps/admin/traefik2/ptl/00-traefik.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: traefik2

--- a/apps/admin/traefik2/ptlsbox/00-traefik.yaml
+++ b/apps/admin/traefik2/ptlsbox/00-traefik.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: traefik2

--- a/apps/admin/traefik2/sbox/00-traefik2.yaml
+++ b/apps/admin/traefik2/sbox/00-traefik2.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: traefik2

--- a/apps/admin/traefik2/sbox/01-traefik2.yaml
+++ b/apps/admin/traefik2/sbox/01-traefik2.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: traefik2

--- a/apps/admin/traefik2/stg/00-traefik2.yaml
+++ b/apps/admin/traefik2/stg/00-traefik2.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: traefik2

--- a/apps/admin/traefik2/stg/01-traefik2.yaml
+++ b/apps/admin/traefik2/stg/01-traefik2.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: traefik2

--- a/apps/admin/traefik2/test/00-traefik2.yaml
+++ b/apps/admin/traefik2/test/00-traefik2.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: traefik2

--- a/apps/admin/traefik2/test/01-traefik2.yaml
+++ b/apps/admin/traefik2/test/01-traefik2.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: traefik2

--- a/apps/admin/traefik2/traefik2.yaml
+++ b/apps/admin/traefik2/traefik2.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: traefik2

--- a/apps/aspnet/dotnet48/dotnet48.yaml
+++ b/apps/aspnet/dotnet48/dotnet48.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: aspnet-dotnet48

--- a/apps/azure-devops/azure-devops-agent-keda/azure-devops-agent.yaml
+++ b/apps/azure-devops/azure-devops-agent-keda/azure-devops-agent.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: azure-devops-agent

--- a/apps/azure-devops/azure-devops-agent-keda/dev.yaml
+++ b/apps/azure-devops/azure-devops-agent-keda/dev.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: azure-devops-agent

--- a/apps/azure-devops/azure-devops-agent-keda/ithc.yaml
+++ b/apps/azure-devops/azure-devops-agent-keda/ithc.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: azure-devops-agent

--- a/apps/azure-devops/azure-devops-agent-keda/prod.yaml
+++ b/apps/azure-devops/azure-devops-agent-keda/prod.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: azure-devops-agent

--- a/apps/azure-devops/azure-devops-agent-keda/ptl.yaml
+++ b/apps/azure-devops/azure-devops-agent-keda/ptl.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: azure-devops-agent

--- a/apps/azure-devops/azure-devops-agent-keda/ptlsbox.yaml
+++ b/apps/azure-devops/azure-devops-agent-keda/ptlsbox.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: azure-devops-agent

--- a/apps/azure-devops/azure-devops-agent-keda/sbox.yaml
+++ b/apps/azure-devops/azure-devops-agent-keda/sbox.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: azure-devops-agent

--- a/apps/azure-devops/azure-devops-agent-keda/stg.yaml
+++ b/apps/azure-devops/azure-devops-agent-keda/stg.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: azure-devops-agent

--- a/apps/azure-devops/azure-devops-agent-keda/test.yaml
+++ b/apps/azure-devops/azure-devops-agent-keda/test.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: azure-devops-agent

--- a/apps/base/kustomize.yaml
+++ b/apps/base/kustomize.yaml
@@ -14,7 +14,7 @@ spec:
     namespace: flux-system
   patches:
     - patch: |-
-        apiVersion: helm.toolkit.fluxcd.io/v2beta1
+        apiVersion: helm.toolkit.fluxcd.io/v2beta2
         kind: HelmRelease
         metadata:
           name: test-helmrelease

--- a/apps/cronjob/cronjobtest/cronjobtest.yaml
+++ b/apps/cronjob/cronjobtest/cronjobtest.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: crontabtest

--- a/apps/darts-modernisation/darts-api/darts-api.yaml
+++ b/apps/darts-modernisation/darts-api/darts-api.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: darts-api

--- a/apps/darts-modernisation/darts-api/demo.yaml
+++ b/apps/darts-modernisation/darts-api/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: darts-api

--- a/apps/darts-modernisation/darts-api/prod.yaml
+++ b/apps/darts-modernisation/darts-api/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: darts-api

--- a/apps/darts-modernisation/darts-api/sbox.yaml
+++ b/apps/darts-modernisation/darts-api/sbox.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: darts-api

--- a/apps/darts-modernisation/darts-api/stg.yaml
+++ b/apps/darts-modernisation/darts-api/stg.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: darts-api

--- a/apps/darts-modernisation/darts-api/test.yaml
+++ b/apps/darts-modernisation/darts-api/test.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: darts-api

--- a/apps/darts-modernisation/darts-automated-tasks/darts-automated-tasks.yaml
+++ b/apps/darts-modernisation/darts-automated-tasks/darts-automated-tasks.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: darts-automated-tasks

--- a/apps/darts-modernisation/darts-automated-tasks/stg.yaml
+++ b/apps/darts-modernisation/darts-automated-tasks/stg.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: darts-automated-tasks

--- a/apps/darts-modernisation/darts-gateway/darts-gateway.yaml
+++ b/apps/darts-modernisation/darts-gateway/darts-gateway.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: darts-gateway

--- a/apps/darts-modernisation/darts-gateway/demo.yaml
+++ b/apps/darts-modernisation/darts-gateway/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: darts-gateway

--- a/apps/darts-modernisation/darts-gateway/prod.yaml
+++ b/apps/darts-modernisation/darts-gateway/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: darts-gateway

--- a/apps/darts-modernisation/darts-gateway/sbox.yaml
+++ b/apps/darts-modernisation/darts-gateway/sbox.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: darts-gateway

--- a/apps/darts-modernisation/darts-gateway/stg.yaml
+++ b/apps/darts-modernisation/darts-gateway/stg.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: darts-gateway

--- a/apps/darts-modernisation/darts-gateway/test.yaml
+++ b/apps/darts-modernisation/darts-gateway/test.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: darts-gateway

--- a/apps/darts-modernisation/darts-portal/darts-portal.yaml
+++ b/apps/darts-modernisation/darts-portal/darts-portal.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: darts-portal

--- a/apps/darts-modernisation/darts-portal/demo.yaml
+++ b/apps/darts-modernisation/darts-portal/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: darts-portal

--- a/apps/darts-modernisation/darts-portal/prod.yaml
+++ b/apps/darts-modernisation/darts-portal/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: darts-portal

--- a/apps/darts-modernisation/darts-portal/sbox.yaml
+++ b/apps/darts-modernisation/darts-portal/sbox.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: darts-portal

--- a/apps/darts-modernisation/darts-portal/stg.yaml
+++ b/apps/darts-modernisation/darts-portal/stg.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: darts-portal

--- a/apps/darts-modernisation/darts-portal/test.yaml
+++ b/apps/darts-modernisation/darts-portal/test.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: darts-portal

--- a/apps/darts-modernisation/darts-stub-services/darts-stub-services.yaml
+++ b/apps/darts-modernisation/darts-stub-services/darts-stub-services.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: darts-stub-services

--- a/apps/darts-modernisation/darts-stub-services/demo.yaml
+++ b/apps/darts-modernisation/darts-stub-services/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: darts-stub-services

--- a/apps/darts-modernisation/darts-stub-services/sbox.yaml
+++ b/apps/darts-modernisation/darts-stub-services/sbox.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: darts-stub-services

--- a/apps/darts-modernisation/darts-stub-services/stg.yaml
+++ b/apps/darts-modernisation/darts-stub-services/stg.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: darts-stub-services

--- a/apps/darts-modernisation/darts-stub-services/test.yaml
+++ b/apps/darts-modernisation/darts-stub-services/test.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: darts-gateway

--- a/apps/dc/dc-purview-shir/dc-purview-shir.yaml
+++ b/apps/dc/dc-purview-shir/dc-purview-shir.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: dc-purview-shir-deployment

--- a/apps/dc/dc-purview-shir/dev.yaml
+++ b/apps/dc/dc-purview-shir/dev.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: dc-purview-shir-deployment

--- a/apps/dts-legacy/lgy-iac-web/lgy-iac-web.yaml
+++ b/apps/dts-legacy/lgy-iac-web/lgy-iac-web.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: lgy-iac-web

--- a/apps/dts-legacy/lgy-iac-web/stg.yaml
+++ b/apps/dts-legacy/lgy-iac-web/stg.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: lgy-iac-web

--- a/apps/dynatrace/dynatrace-operator.yaml
+++ b/apps/dynatrace/dynatrace-operator.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: dynatrace-operator

--- a/apps/hmi/hmi-rota-dtu/demo.yaml
+++ b/apps/hmi/hmi-rota-dtu/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: hmi-rota-dtu

--- a/apps/hmi/hmi-rota-dtu/hmi-rota-dtu.yaml
+++ b/apps/hmi/hmi-rota-dtu/hmi-rota-dtu.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: hmi-rota-dtu

--- a/apps/hmi/hmi-rota-dtu/ithc.yaml
+++ b/apps/hmi/hmi-rota-dtu/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: hmi-rota-dtu

--- a/apps/hmi/hmi-rota-dtu/prod.yaml
+++ b/apps/hmi/hmi-rota-dtu/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: hmi-rota-dtu

--- a/apps/hmi/hmi-rota-dtu/sbox.yaml
+++ b/apps/hmi/hmi-rota-dtu/sbox.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: hmi-rota-dtu

--- a/apps/hmi/hmi-rota-dtu/stg.yaml
+++ b/apps/hmi/hmi-rota-dtu/stg.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: hmi-rota-dtu

--- a/apps/hmi/hmi-rota-dtu/test.yaml
+++ b/apps/hmi/hmi-rota-dtu/test.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: hmi-rota-dtu

--- a/apps/jenkins/jenkins-webhook-relay/jenkins-webhook-relay.yaml
+++ b/apps/jenkins/jenkins-webhook-relay/jenkins-webhook-relay.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: jenkins-webhook-relay

--- a/apps/jenkins/jenkins-webhook-relay/ptl/jenkins-webhook-relay.yaml
+++ b/apps/jenkins/jenkins-webhook-relay/ptl/jenkins-webhook-relay.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: jenkins-webhook-relay

--- a/apps/jenkins/jenkins-webhook-relay/ptlsbox/jenkins-webhook-relay.yaml
+++ b/apps/jenkins/jenkins-webhook-relay/ptlsbox/jenkins-webhook-relay.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: jenkins-webhook-relay

--- a/apps/jenkins/jenkins/jenkins-controller-version.yaml
+++ b/apps/jenkins/jenkins/jenkins-controller-version.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: jenkins

--- a/apps/jenkins/jenkins/jenkins.yaml
+++ b/apps/jenkins/jenkins/jenkins.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: jenkins

--- a/apps/jenkins/jenkins/ptl/jenkins-azure-vm-agent.yaml
+++ b/apps/jenkins/jenkins/ptl/jenkins-azure-vm-agent.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: jenkins

--- a/apps/jenkins/jenkins/ptl/jenkins.yaml
+++ b/apps/jenkins/jenkins/ptl/jenkins.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: jenkins

--- a/apps/jenkins/jenkins/ptlsbox/jenkins-azure-vm-agent.yaml
+++ b/apps/jenkins/jenkins/ptlsbox/jenkins-azure-vm-agent.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: jenkins

--- a/apps/jenkins/jenkins/ptlsbox/jenkins-controller-version.yaml
+++ b/apps/jenkins/jenkins/ptlsbox/jenkins-controller-version.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: jenkins

--- a/apps/jenkins/jenkins/ptlsbox/jenkins.yaml
+++ b/apps/jenkins/jenkins/ptlsbox/jenkins.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: jenkins

--- a/apps/juror-digital/jd-bureau/jd-bureau.yaml
+++ b/apps/juror-digital/jd-bureau/jd-bureau.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: jd-bureau

--- a/apps/juror-digital/jd-bureau/prod.yaml
+++ b/apps/juror-digital/jd-bureau/prod.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: jd-bureau

--- a/apps/juror-digital/jd-public/jd-public.yaml
+++ b/apps/juror-digital/jd-public/jd-public.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: jd-public

--- a/apps/juror-digital/jd-public/prod.yaml
+++ b/apps/juror-digital/jd-public/prod.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: jd-public

--- a/apps/juror-digital/moj-reverse-proxy/moj-reverse-proxy.yaml
+++ b/apps/juror-digital/moj-reverse-proxy/moj-reverse-proxy.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: moj-reverse-proxy

--- a/apps/juror-digital/moj-reverse-proxy/prod.yaml
+++ b/apps/juror-digital/moj-reverse-proxy/prod.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: moj-reverse-proxy

--- a/apps/juror/juror-pnc/demo.yaml
+++ b/apps/juror/juror-pnc/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: juror-pnc

--- a/apps/juror/juror-pnc/ithc.yaml
+++ b/apps/juror/juror-pnc/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: juror-pnc

--- a/apps/juror/juror-pnc/juror-pnc.yaml
+++ b/apps/juror/juror-pnc/juror-pnc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: juror-pnc

--- a/apps/juror/juror-pnc/prod.yaml
+++ b/apps/juror/juror-pnc/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: juror-pnc

--- a/apps/juror/juror-pnc/sbox.yaml
+++ b/apps/juror/juror-pnc/sbox.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: juror-pnc

--- a/apps/juror/juror-pnc/stg.yaml
+++ b/apps/juror/juror-pnc/stg.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: juror-pnc

--- a/apps/juror/juror-pnc/test.yaml
+++ b/apps/juror/juror-pnc/test.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: juror-pnc

--- a/apps/juror/juror-public/demo.yaml
+++ b/apps/juror/juror-public/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: juror-public

--- a/apps/juror/juror-public/ithc.yaml
+++ b/apps/juror/juror-public/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: juror-public

--- a/apps/juror/juror-public/juror-public.yaml
+++ b/apps/juror/juror-public/juror-public.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: juror-public

--- a/apps/juror/juror-public/prod.yaml
+++ b/apps/juror/juror-public/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: juror-public

--- a/apps/juror/juror-public/sbox.yaml
+++ b/apps/juror/juror-public/sbox.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: juror-public

--- a/apps/juror/juror-public/stg.yaml
+++ b/apps/juror/juror-public/stg.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: juror-public

--- a/apps/juror/juror-public/test.yaml
+++ b/apps/juror/juror-public/test.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: juror-public

--- a/apps/juror/juror-scheduler-api/demo.yaml
+++ b/apps/juror/juror-scheduler-api/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: juror-scheduler-api

--- a/apps/juror/juror-scheduler-api/ithc.yaml
+++ b/apps/juror/juror-scheduler-api/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: juror-scheduler-api

--- a/apps/juror/juror-scheduler-api/juror-scheduler-api.yaml
+++ b/apps/juror/juror-scheduler-api/juror-scheduler-api.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: juror-scheduler-api

--- a/apps/juror/juror-scheduler-api/prod.yaml
+++ b/apps/juror/juror-scheduler-api/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: juror-scheduler-api

--- a/apps/juror/juror-scheduler-api/sbox.yaml
+++ b/apps/juror/juror-scheduler-api/sbox.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: juror-scheduler-api

--- a/apps/juror/juror-scheduler-api/stg.yaml
+++ b/apps/juror/juror-scheduler-api/stg.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: juror-scheduler-api

--- a/apps/juror/juror-scheduler-api/test.yaml
+++ b/apps/juror/juror-scheduler-api/test.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: juror-scheduler-api

--- a/apps/juror/juror-scheduler-execution/demo.yaml
+++ b/apps/juror/juror-scheduler-execution/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: juror-scheduler-execution

--- a/apps/juror/juror-scheduler-execution/ithc.yaml
+++ b/apps/juror/juror-scheduler-execution/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: juror-scheduler-execution

--- a/apps/juror/juror-scheduler-execution/juror-scheduler-execution.yaml
+++ b/apps/juror/juror-scheduler-execution/juror-scheduler-execution.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: juror-scheduler-execution

--- a/apps/juror/juror-scheduler-execution/prod.yaml
+++ b/apps/juror/juror-scheduler-execution/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: juror-scheduler-execution

--- a/apps/juror/juror-scheduler-execution/sbox.yaml
+++ b/apps/juror/juror-scheduler-execution/sbox.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: juror-scheduler-execution

--- a/apps/juror/juror-scheduler-execution/stg.yaml
+++ b/apps/juror/juror-scheduler-execution/stg.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: juror-scheduler-execution

--- a/apps/juror/juror-scheduler-execution/test.yaml
+++ b/apps/juror/juror-scheduler-execution/test.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: juror-scheduler-execution

--- a/apps/keda/keda/keda.yaml
+++ b/apps/keda/keda/keda.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: keda

--- a/apps/mailrelay/mailrelay/dev/00.yaml
+++ b/apps/mailrelay/mailrelay/dev/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: mailrelay

--- a/apps/mailrelay/mailrelay/dev/01.yaml
+++ b/apps/mailrelay/mailrelay/dev/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: mailrelay

--- a/apps/mailrelay/mailrelay/dev/dev.yaml
+++ b/apps/mailrelay/mailrelay/dev/dev.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: mailrelay

--- a/apps/mailrelay/mailrelay/mailrelay.yaml
+++ b/apps/mailrelay/mailrelay/mailrelay.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: mailrelay

--- a/apps/mailrelay/mailrelay/prod/00.yaml
+++ b/apps/mailrelay/mailrelay/prod/00.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: mailrelay

--- a/apps/mailrelay/mailrelay/prod/01.yaml
+++ b/apps/mailrelay/mailrelay/prod/01.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: mailrelay

--- a/apps/mailrelay/mailrelay/prod/prod.yaml
+++ b/apps/mailrelay/mailrelay/prod/prod.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: mailrelay

--- a/apps/mailrelay2/mailrelay2/dev/00.yaml
+++ b/apps/mailrelay2/mailrelay2/dev/00.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: mailrelay2

--- a/apps/mailrelay2/mailrelay2/dev/01.yaml
+++ b/apps/mailrelay2/mailrelay2/dev/01.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: mailrelay2

--- a/apps/mailrelay2/mailrelay2/dev/dev.yaml
+++ b/apps/mailrelay2/mailrelay2/dev/dev.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: mailrelay2

--- a/apps/mailrelay2/mailrelay2/mailrelay2.yaml
+++ b/apps/mailrelay2/mailrelay2/mailrelay2.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: mailrelay2

--- a/apps/mailrelay2/mailrelay2/prod/00.yaml
+++ b/apps/mailrelay2/mailrelay2/prod/00.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: mailrelay2

--- a/apps/mailrelay2/mailrelay2/prod/01.yaml
+++ b/apps/mailrelay2/mailrelay2/prod/01.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: mailrelay2

--- a/apps/mailrelay2/mailrelay2/prod/prod.yaml
+++ b/apps/mailrelay2/mailrelay2/prod/prod.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: mailrelay2

--- a/apps/met/themis-fe/prod.yaml
+++ b/apps/met/themis-fe/prod.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: themis-fe

--- a/apps/met/themis-fe/test.yaml
+++ b/apps/met/themis-fe/test.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: themis-fe

--- a/apps/met/themis-fe/themis-fe.yaml
+++ b/apps/met/themis-fe/themis-fe.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: themis-fe

--- a/apps/mi/mi-adf-shir-2/dev.yaml
+++ b/apps/mi/mi-adf-shir-2/dev.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: mi-adf-shir-deployment-2

--- a/apps/mi/mi-adf-shir-2/ithc.yaml
+++ b/apps/mi/mi-adf-shir-2/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: mi-adf-shir-deployment-2

--- a/apps/mi/mi-adf-shir-2/mi-adf-shir.yaml
+++ b/apps/mi/mi-adf-shir-2/mi-adf-shir.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: mi-adf-shir-deployment-2

--- a/apps/mi/mi-adf-shir-2/prod.yaml
+++ b/apps/mi/mi-adf-shir-2/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: mi-adf-shir-deployment-2

--- a/apps/mi/mi-adf-shir-2/sbox.yaml
+++ b/apps/mi/mi-adf-shir-2/sbox.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: mi-adf-shir-deployment-2

--- a/apps/mi/mi-adf-shir-2/stg.yaml
+++ b/apps/mi/mi-adf-shir-2/stg.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: mi-adf-shir-deployment-2

--- a/apps/mi/mi-adf-shir-2/test.yaml
+++ b/apps/mi/mi-adf-shir-2/test.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: mi-adf-shir-deployment-2

--- a/apps/mi/mi-adf-shir/dev.yaml
+++ b/apps/mi/mi-adf-shir/dev.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: mi-adf-shir-deployment

--- a/apps/mi/mi-adf-shir/ithc.yaml
+++ b/apps/mi/mi-adf-shir/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: mi-adf-shir-deployment

--- a/apps/mi/mi-adf-shir/mi-adf-shir.yaml
+++ b/apps/mi/mi-adf-shir/mi-adf-shir.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: mi-adf-shir-deployment

--- a/apps/mi/mi-adf-shir/prod.yaml
+++ b/apps/mi/mi-adf-shir/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: mi-adf-shir-deployment

--- a/apps/mi/mi-adf-shir/sbox.yaml
+++ b/apps/mi/mi-adf-shir/sbox.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: mi-adf-shir-deployment

--- a/apps/mi/mi-adf-shir/stg.yaml
+++ b/apps/mi/mi-adf-shir/stg.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: mi-adf-shir-deployment

--- a/apps/mi/mi-adf-shir/test.yaml
+++ b/apps/mi/mi-adf-shir/test.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: mi-adf-shir-deployment

--- a/apps/mi/mi-azure-functions/dev.yaml
+++ b/apps/mi/mi-azure-functions/dev.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: mi-azure-functions-deployment

--- a/apps/mi/mi-azure-functions/ithc.yaml
+++ b/apps/mi/mi-azure-functions/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: mi-azure-functions-deployment

--- a/apps/mi/mi-azure-functions/mi-azure-functions.yaml
+++ b/apps/mi/mi-azure-functions/mi-azure-functions.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: mi-azure-functions-deployment

--- a/apps/mi/mi-azure-functions/prod.yaml
+++ b/apps/mi/mi-azure-functions/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: mi-azure-functions-deployment

--- a/apps/mi/mi-azure-functions/sbox.yaml
+++ b/apps/mi/mi-azure-functions/sbox.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: mi-azure-functions-deployment

--- a/apps/mi/mi-azure-functions/stg.yaml
+++ b/apps/mi/mi-azure-functions/stg.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: mi-azure-functions-deployment

--- a/apps/mi/mi-azure-functions/test.yaml
+++ b/apps/mi/mi-azure-functions/test.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: mi-azure-functions-deployment

--- a/apps/mi/mi-house-keeping-service/dev.yaml
+++ b/apps/mi/mi-house-keeping-service/dev.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: mi-house-keeping-service

--- a/apps/mi/mi-house-keeping-service/ithc.yaml
+++ b/apps/mi/mi-house-keeping-service/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: mi-house-keeping-service

--- a/apps/mi/mi-house-keeping-service/mi-house-keeping-service.yaml
+++ b/apps/mi/mi-house-keeping-service/mi-house-keeping-service.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: mi-house-keeping-service

--- a/apps/mi/mi-house-keeping-service/prod.yaml
+++ b/apps/mi/mi-house-keeping-service/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: mi-house-keeping-service

--- a/apps/mi/mi-house-keeping-service/sbox.yaml
+++ b/apps/mi/mi-house-keeping-service/sbox.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: mi-house-keeping-service

--- a/apps/mi/mi-house-keeping-service/stg.yaml
+++ b/apps/mi/mi-house-keeping-service/stg.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: mi-house-keeping-service

--- a/apps/mi/mi-house-keeping-service/test.yaml
+++ b/apps/mi/mi-house-keeping-service/test.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: mi-house-keeping-service

--- a/apps/mi/prod/01/remove-house-keeping-patch.yaml
+++ b/apps/mi/prod/01/remove-house-keeping-patch.yaml
@@ -1,5 +1,5 @@
 $patch: delete
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: mi-house-keeping-service

--- a/apps/monitoring/kube-prometheus-stack/dev/00.yaml
+++ b/apps/monitoring/kube-prometheus-stack/dev/00.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: kube-prometheus-stack

--- a/apps/monitoring/kube-prometheus-stack/dev/01.yaml
+++ b/apps/monitoring/kube-prometheus-stack/dev/01.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: kube-prometheus-stack

--- a/apps/monitoring/kube-prometheus-stack/ithc/00.yaml
+++ b/apps/monitoring/kube-prometheus-stack/ithc/00.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: kube-prometheus-stack

--- a/apps/monitoring/kube-prometheus-stack/ithc/01.yaml
+++ b/apps/monitoring/kube-prometheus-stack/ithc/01.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: kube-prometheus-stack

--- a/apps/monitoring/kube-prometheus-stack/kube-prometheus-stack.yaml
+++ b/apps/monitoring/kube-prometheus-stack/kube-prometheus-stack.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: kube-prometheus-stack

--- a/apps/monitoring/kube-prometheus-stack/prod/00.yaml
+++ b/apps/monitoring/kube-prometheus-stack/prod/00.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: kube-prometheus-stack

--- a/apps/monitoring/kube-prometheus-stack/prod/01.yaml
+++ b/apps/monitoring/kube-prometheus-stack/prod/01.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: kube-prometheus-stack

--- a/apps/monitoring/kube-prometheus-stack/ptl/00.yaml
+++ b/apps/monitoring/kube-prometheus-stack/ptl/00.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: kube-prometheus-stack

--- a/apps/monitoring/kube-prometheus-stack/ptlsbox/00.yaml
+++ b/apps/monitoring/kube-prometheus-stack/ptlsbox/00.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: kube-prometheus-stack

--- a/apps/monitoring/kube-prometheus-stack/sbox/00.yaml
+++ b/apps/monitoring/kube-prometheus-stack/sbox/00.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: kube-prometheus-stack

--- a/apps/monitoring/kube-prometheus-stack/sbox/01.yaml
+++ b/apps/monitoring/kube-prometheus-stack/sbox/01.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: kube-prometheus-stack

--- a/apps/monitoring/kube-prometheus-stack/stg/00.yaml
+++ b/apps/monitoring/kube-prometheus-stack/stg/00.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: kube-prometheus-stack

--- a/apps/monitoring/kube-prometheus-stack/stg/01.yaml
+++ b/apps/monitoring/kube-prometheus-stack/stg/01.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: kube-prometheus-stack

--- a/apps/monitoring/kube-prometheus-stack/test/00.yaml
+++ b/apps/monitoring/kube-prometheus-stack/test/00.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: kube-prometheus-stack

--- a/apps/monitoring/kube-prometheus-stack/test/01.yaml
+++ b/apps/monitoring/kube-prometheus-stack/test/01.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: kube-prometheus-stack

--- a/apps/monitoring/loki/dev/01.yaml
+++ b/apps/monitoring/loki/dev/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: loki

--- a/apps/monitoring/loki/release.yaml
+++ b/apps/monitoring/loki/release.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: loki

--- a/apps/monitoring/promtail/dev/01.yaml
+++ b/apps/monitoring/promtail/dev/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: promtail

--- a/apps/monitoring/promtail/release.yaml
+++ b/apps/monitoring/promtail/release.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: promtail

--- a/apps/monitoring/version-reporter/docsoutdated/docs-outdated.yaml
+++ b/apps/monitoring/version-reporter/docsoutdated/docs-outdated.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: version-reporter-service-docsoutdated

--- a/apps/monitoring/version-reporter/helmcharts/helm-charts.yaml
+++ b/apps/monitoring/version-reporter/helmcharts/helm-charts.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: version-reporter-service-helmcharts

--- a/apps/monitoring/version-reporter/paloalto/palo-alto.yaml
+++ b/apps/monitoring/version-reporter/paloalto/palo-alto.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: version-reporter-service-palo-alto

--- a/apps/monitoring/version-reporter/ptl/ptl.yaml
+++ b/apps/monitoring/version-reporter/ptl/ptl.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: version-reporter-service-palo-alto

--- a/apps/monitoring/version-reporter/ptlsbox/ptlsbox.yaml
+++ b/apps/monitoring/version-reporter/ptlsbox/ptlsbox.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: version-reporter-service-palo-alto

--- a/apps/monitoring/version-reporter/renovate/renovate.yaml
+++ b/apps/monitoring/version-reporter/renovate/renovate.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: version-reporter-service-renovate

--- a/apps/monitoring/vm-hourlyusage/hourlyusage.yaml
+++ b/apps/monitoring/vm-hourlyusage/hourlyusage.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: vm-hourlyusage

--- a/apps/my-time/my-time-api/demo.yaml
+++ b/apps/my-time/my-time-api/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: my-time-api

--- a/apps/my-time/my-time-api/ithc.yaml
+++ b/apps/my-time/my-time-api/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: my-time-api

--- a/apps/my-time/my-time-api/my-time-api.yaml
+++ b/apps/my-time/my-time-api/my-time-api.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: my-time-api

--- a/apps/my-time/my-time-api/stg.yaml
+++ b/apps/my-time/my-time-api/stg.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: my-time-api

--- a/apps/my-time/my-time-frontend/demo.yaml
+++ b/apps/my-time/my-time-frontend/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: my-time-frontend

--- a/apps/my-time/my-time-frontend/ithc.yaml
+++ b/apps/my-time/my-time-frontend/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: my-time-frontend

--- a/apps/my-time/my-time-frontend/my-time-frontend.yaml
+++ b/apps/my-time/my-time-frontend/my-time-frontend.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: my-time-frontend

--- a/apps/my-time/my-time-frontend/stg.yaml
+++ b/apps/my-time/my-time-frontend/stg.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: my-time-frontend

--- a/apps/netbox/netbox/netbox.yaml
+++ b/apps/netbox/netbox/netbox.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: netbox

--- a/apps/netbox/netbox/ptl/netbox.yaml
+++ b/apps/netbox/netbox/ptl/netbox.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: netbox

--- a/apps/netbox/netbox/ptlsbox/netbox.yaml
+++ b/apps/netbox/netbox/ptlsbox/netbox.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: netbox

--- a/apps/neuvector/fluentbit-log/fluentbit-log.yaml
+++ b/apps/neuvector/fluentbit-log/fluentbit-log.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: fluentbit-log

--- a/apps/neuvector/neuvector/ithc/00.yaml
+++ b/apps/neuvector/neuvector/ithc/00.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: neuvector

--- a/apps/neuvector/neuvector/ithc/01.yaml
+++ b/apps/neuvector/neuvector/ithc/01.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: neuvector

--- a/apps/neuvector/neuvector/ithc/ithc.yaml
+++ b/apps/neuvector/neuvector/ithc/ithc.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: neuvector

--- a/apps/neuvector/neuvector/neuvector.yaml
+++ b/apps/neuvector/neuvector/neuvector.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: neuvector

--- a/apps/neuvector/neuvector/prod/00.yaml
+++ b/apps/neuvector/neuvector/prod/00.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: neuvector

--- a/apps/neuvector/neuvector/prod/01.yaml
+++ b/apps/neuvector/neuvector/prod/01.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: neuvector

--- a/apps/neuvector/neuvector/prod/prod.yaml
+++ b/apps/neuvector/neuvector/prod/prod.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: neuvector

--- a/apps/neuvector/neuvector/stg/00.yaml
+++ b/apps/neuvector/neuvector/stg/00.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: neuvector

--- a/apps/neuvector/neuvector/stg/01.yaml
+++ b/apps/neuvector/neuvector/stg/01.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: neuvector

--- a/apps/neuvector/neuvector/stg/stg.yaml
+++ b/apps/neuvector/neuvector/stg/stg.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: neuvector

--- a/apps/neuvector/neuvector/test/00.yaml
+++ b/apps/neuvector/neuvector/test/00.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: neuvector

--- a/apps/neuvector/neuvector/test/01.yaml
+++ b/apps/neuvector/neuvector/test/01.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: neuvector

--- a/apps/neuvector/neuvector/test/test.yaml
+++ b/apps/neuvector/neuvector/test/test.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: neuvector

--- a/apps/opal/opal-fines-service/opal-fines-service.yaml
+++ b/apps/opal/opal-fines-service/opal-fines-service.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: opal-fines-service

--- a/apps/opal/opal-fines-service/stg.yaml
+++ b/apps/opal/opal-fines-service/stg.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: opal-fines-service

--- a/apps/opal/opal-frontend/opal-frontend.yaml
+++ b/apps/opal/opal-frontend/opal-frontend.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: opal-frontend

--- a/apps/opal/opal-frontend/stg.yaml
+++ b/apps/opal/opal-frontend/stg.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: opal-frontend

--- a/apps/pip/account-management-clear-audit-cron/demo/00.yaml
+++ b/apps/pip/account-management-clear-audit-cron/demo/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-account-management-clear-audit-cron

--- a/apps/pip/account-management-clear-audit-cron/demo/01.yaml
+++ b/apps/pip/account-management-clear-audit-cron/demo/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-account-management-clear-audit-cron

--- a/apps/pip/account-management-clear-audit-cron/pip-account-management-clear-audit-cron.yaml
+++ b/apps/pip/account-management-clear-audit-cron/pip-account-management-clear-audit-cron.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-account-management-clear-audit-cron

--- a/apps/pip/account-management-clear-audit-cron/prod/00.yaml
+++ b/apps/pip/account-management-clear-audit-cron/prod/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-account-management-clear-audit-cron

--- a/apps/pip/account-management-clear-audit-cron/prod/01.yaml
+++ b/apps/pip/account-management-clear-audit-cron/prod/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-account-management-clear-audit-cron

--- a/apps/pip/account-management-clear-audit-cron/stg/00.yaml
+++ b/apps/pip/account-management-clear-audit-cron/stg/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-account-management-clear-audit-cron

--- a/apps/pip/account-management-clear-audit-cron/stg/01.yaml
+++ b/apps/pip/account-management-clear-audit-cron/stg/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-account-management-clear-audit-cron

--- a/apps/pip/account-management-clear-audit-cron/test/00.yaml
+++ b/apps/pip/account-management-clear-audit-cron/test/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-account-management-clear-audit-cron

--- a/apps/pip/account-management-clear-audit-cron/test/01.yaml
+++ b/apps/pip/account-management-clear-audit-cron/test/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-account-management-clear-audit-cron

--- a/apps/pip/account-management-inactive-verification-cron/demo/00.yaml
+++ b/apps/pip/account-management-inactive-verification-cron/demo/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-account-management-inactive-verify-cron

--- a/apps/pip/account-management-inactive-verification-cron/demo/01.yaml
+++ b/apps/pip/account-management-inactive-verification-cron/demo/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-account-management-inactive-verify-cron

--- a/apps/pip/account-management-inactive-verification-cron/pip-account-management-inactive-verification-cron.yaml
+++ b/apps/pip/account-management-inactive-verification-cron/pip-account-management-inactive-verification-cron.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-account-management-inactive-verify-cron

--- a/apps/pip/account-management-inactive-verification-cron/prod/00.yaml
+++ b/apps/pip/account-management-inactive-verification-cron/prod/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-account-management-inactive-verify-cron

--- a/apps/pip/account-management-inactive-verification-cron/prod/01.yaml
+++ b/apps/pip/account-management-inactive-verification-cron/prod/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-account-management-inactive-verify-cron

--- a/apps/pip/account-management-inactive-verification-cron/stg/00.yaml
+++ b/apps/pip/account-management-inactive-verification-cron/stg/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-account-management-inactive-verify-cron

--- a/apps/pip/account-management-inactive-verification-cron/stg/01.yaml
+++ b/apps/pip/account-management-inactive-verification-cron/stg/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-account-management-inactive-verify-cron

--- a/apps/pip/account-management-inactive-verification-cron/test/00.yaml
+++ b/apps/pip/account-management-inactive-verification-cron/test/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-account-management-inactive-verify-cron

--- a/apps/pip/account-management-inactive-verification-cron/test/01.yaml
+++ b/apps/pip/account-management-inactive-verification-cron/test/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-account-management-inactive-verify-cron

--- a/apps/pip/account-management-media-reporting-cron/demo/00.yaml
+++ b/apps/pip/account-management-media-reporting-cron/demo/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-account-management-media-reporting-cron

--- a/apps/pip/account-management-media-reporting-cron/demo/01.yaml
+++ b/apps/pip/account-management-media-reporting-cron/demo/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-account-management-media-reporting-cron

--- a/apps/pip/account-management-media-reporting-cron/pip-account-management-media-reporting-cron.yaml
+++ b/apps/pip/account-management-media-reporting-cron/pip-account-management-media-reporting-cron.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-account-management-media-reporting-cron

--- a/apps/pip/account-management-media-reporting-cron/prod/00.yaml
+++ b/apps/pip/account-management-media-reporting-cron/prod/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-account-management-media-reporting-cron

--- a/apps/pip/account-management-media-reporting-cron/prod/01.yaml
+++ b/apps/pip/account-management-media-reporting-cron/prod/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-account-management-media-reporting-cron

--- a/apps/pip/account-management-media-reporting-cron/stg/00.yaml
+++ b/apps/pip/account-management-media-reporting-cron/stg/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-account-management-media-reporting-cron

--- a/apps/pip/account-management-media-reporting-cron/stg/01.yaml
+++ b/apps/pip/account-management-media-reporting-cron/stg/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-account-management-media-reporting-cron

--- a/apps/pip/account-management-media-reporting-cron/test/00.yaml
+++ b/apps/pip/account-management-media-reporting-cron/test/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-account-management-media-reporting-cron

--- a/apps/pip/account-management-media-reporting-cron/test/01.yaml
+++ b/apps/pip/account-management-media-reporting-cron/test/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-account-management-media-reporting-cron

--- a/apps/pip/account-management/demo.yaml
+++ b/apps/pip/account-management/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-account-management

--- a/apps/pip/account-management/ithc.yaml
+++ b/apps/pip/account-management/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-account-management

--- a/apps/pip/account-management/pip-account-management.yaml
+++ b/apps/pip/account-management/pip-account-management.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-account-management

--- a/apps/pip/account-management/prod.yaml
+++ b/apps/pip/account-management/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-account-management

--- a/apps/pip/account-management/stg.yaml
+++ b/apps/pip/account-management/stg.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-account-management

--- a/apps/pip/account-management/test.yaml
+++ b/apps/pip/account-management/test.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-account-management

--- a/apps/pip/channel-management/demo.yaml
+++ b/apps/pip/channel-management/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-channel-management

--- a/apps/pip/channel-management/ithc.yaml
+++ b/apps/pip/channel-management/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-channel-management

--- a/apps/pip/channel-management/pip-channel-management.yaml
+++ b/apps/pip/channel-management/pip-channel-management.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-channel-management

--- a/apps/pip/channel-management/prod.yaml
+++ b/apps/pip/channel-management/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-channel-management

--- a/apps/pip/channel-management/stg.yaml
+++ b/apps/pip/channel-management/stg.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-channel-management

--- a/apps/pip/channel-management/test.yaml
+++ b/apps/pip/channel-management/test.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-channel-management

--- a/apps/pip/data-management-expired-artefacts-cron/demo/00.yaml
+++ b/apps/pip/data-management-expired-artefacts-cron/demo/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-data-management-expired-artefacts-cron

--- a/apps/pip/data-management-expired-artefacts-cron/demo/01.yaml
+++ b/apps/pip/data-management-expired-artefacts-cron/demo/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-data-management-expired-artefacts-cron

--- a/apps/pip/data-management-expired-artefacts-cron/pip-data-management-expired-artefacts-cron.yaml
+++ b/apps/pip/data-management-expired-artefacts-cron/pip-data-management-expired-artefacts-cron.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-data-management-expired-artefacts-cron

--- a/apps/pip/data-management-expired-artefacts-cron/prod/00.yaml
+++ b/apps/pip/data-management-expired-artefacts-cron/prod/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-data-management-expired-artefacts-cron

--- a/apps/pip/data-management-expired-artefacts-cron/prod/01.yaml
+++ b/apps/pip/data-management-expired-artefacts-cron/prod/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-data-management-expired-artefacts-cron

--- a/apps/pip/data-management-expired-artefacts-cron/stg/00.yaml
+++ b/apps/pip/data-management-expired-artefacts-cron/stg/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-data-management-expired-artefacts-cron

--- a/apps/pip/data-management-expired-artefacts-cron/stg/01.yaml
+++ b/apps/pip/data-management-expired-artefacts-cron/stg/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-data-management-expired-artefacts-cron

--- a/apps/pip/data-management-expired-artefacts-cron/test/00.yaml
+++ b/apps/pip/data-management-expired-artefacts-cron/test/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-data-management-expired-artefacts-cron

--- a/apps/pip/data-management-expired-artefacts-cron/test/01.yaml
+++ b/apps/pip/data-management-expired-artefacts-cron/test/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-data-management-expired-artefacts-cron

--- a/apps/pip/data-management-no-match-artefacts-cron/demo/00.yaml
+++ b/apps/pip/data-management-no-match-artefacts-cron/demo/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-data-management-no-match-artefacts-cron

--- a/apps/pip/data-management-no-match-artefacts-cron/demo/01.yaml
+++ b/apps/pip/data-management-no-match-artefacts-cron/demo/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-data-management-no-match-artefacts-cron

--- a/apps/pip/data-management-no-match-artefacts-cron/pip-data-management-no-match-artefacts-cron.yaml
+++ b/apps/pip/data-management-no-match-artefacts-cron/pip-data-management-no-match-artefacts-cron.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-data-management-no-match-artefacts-cron

--- a/apps/pip/data-management-no-match-artefacts-cron/prod/00.yaml
+++ b/apps/pip/data-management-no-match-artefacts-cron/prod/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-data-management-no-match-artefacts-cron

--- a/apps/pip/data-management-no-match-artefacts-cron/prod/01.yaml
+++ b/apps/pip/data-management-no-match-artefacts-cron/prod/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-data-management-no-match-artefacts-cron

--- a/apps/pip/data-management-no-match-artefacts-cron/stg/00.yaml
+++ b/apps/pip/data-management-no-match-artefacts-cron/stg/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-data-management-no-match-artefacts-cron

--- a/apps/pip/data-management-no-match-artefacts-cron/stg/01.yaml
+++ b/apps/pip/data-management-no-match-artefacts-cron/stg/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-data-management-no-match-artefacts-cron

--- a/apps/pip/data-management-no-match-artefacts-cron/test/00.yaml
+++ b/apps/pip/data-management-no-match-artefacts-cron/test/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-data-management-no-match-artefacts-cron

--- a/apps/pip/data-management-no-match-artefacts-cron/test/01.yaml
+++ b/apps/pip/data-management-no-match-artefacts-cron/test/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-data-management-no-match-artefacts-cron

--- a/apps/pip/data-management-subscriptions-cron/demo/00.yaml
+++ b/apps/pip/data-management-subscriptions-cron/demo/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-data-management-subscriptions-cron

--- a/apps/pip/data-management-subscriptions-cron/demo/01.yaml
+++ b/apps/pip/data-management-subscriptions-cron/demo/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-data-management-subscriptions-cron

--- a/apps/pip/data-management-subscriptions-cron/pip-data-management-subscriptions-cron.yaml
+++ b/apps/pip/data-management-subscriptions-cron/pip-data-management-subscriptions-cron.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-data-management-subscriptions-cron

--- a/apps/pip/data-management-subscriptions-cron/prod/00.yaml
+++ b/apps/pip/data-management-subscriptions-cron/prod/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-data-management-subscriptions-cron

--- a/apps/pip/data-management-subscriptions-cron/prod/01.yaml
+++ b/apps/pip/data-management-subscriptions-cron/prod/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-data-management-subscriptions-cron

--- a/apps/pip/data-management-subscriptions-cron/stg/00.yaml
+++ b/apps/pip/data-management-subscriptions-cron/stg/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-data-management-subscriptions-cron

--- a/apps/pip/data-management-subscriptions-cron/stg/01.yaml
+++ b/apps/pip/data-management-subscriptions-cron/stg/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-data-management-subscriptions-cron

--- a/apps/pip/data-management-subscriptions-cron/test/00.yaml
+++ b/apps/pip/data-management-subscriptions-cron/test/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-data-management-subscriptions-cron

--- a/apps/pip/data-management-subscriptions-cron/test/01.yaml
+++ b/apps/pip/data-management-subscriptions-cron/test/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-data-management-subscriptions-cron

--- a/apps/pip/data-management/demo.yaml
+++ b/apps/pip/data-management/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-data-management

--- a/apps/pip/data-management/ithc.yaml
+++ b/apps/pip/data-management/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-data-management

--- a/apps/pip/data-management/pip-data-management.yaml
+++ b/apps/pip/data-management/pip-data-management.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-data-management

--- a/apps/pip/data-management/prod.yaml
+++ b/apps/pip/data-management/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-data-management

--- a/apps/pip/data-management/sbox.yaml
+++ b/apps/pip/data-management/sbox.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-data-management

--- a/apps/pip/data-management/stg.yaml
+++ b/apps/pip/data-management/stg.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-data-management

--- a/apps/pip/data-management/test.yaml
+++ b/apps/pip/data-management/test.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-data-management

--- a/apps/pip/frontend/demo.yaml
+++ b/apps/pip/frontend/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-frontend

--- a/apps/pip/frontend/ithc.yaml
+++ b/apps/pip/frontend/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-frontend

--- a/apps/pip/frontend/pip-frontend.yaml
+++ b/apps/pip/frontend/pip-frontend.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-frontend

--- a/apps/pip/frontend/prod.yaml
+++ b/apps/pip/frontend/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-frontend

--- a/apps/pip/frontend/stg.yaml
+++ b/apps/pip/frontend/stg.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-frontend

--- a/apps/pip/frontend/test.yaml
+++ b/apps/pip/frontend/test.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-frontend

--- a/apps/pip/publication-services-mi-reporting-cron/demo/00.yaml
+++ b/apps/pip/publication-services-mi-reporting-cron/demo/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-publication-services-mi-reporting-cron

--- a/apps/pip/publication-services-mi-reporting-cron/demo/01.yaml
+++ b/apps/pip/publication-services-mi-reporting-cron/demo/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-publication-services-mi-reporting-cron

--- a/apps/pip/publication-services-mi-reporting-cron/pip-publication-services-mi-reporting-cron.yaml
+++ b/apps/pip/publication-services-mi-reporting-cron/pip-publication-services-mi-reporting-cron.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-publication-services-mi-reporting-cron

--- a/apps/pip/publication-services-mi-reporting-cron/prod/00.yaml
+++ b/apps/pip/publication-services-mi-reporting-cron/prod/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-publication-services-mi-reporting-cron

--- a/apps/pip/publication-services-mi-reporting-cron/prod/01.yaml
+++ b/apps/pip/publication-services-mi-reporting-cron/prod/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-publication-services-mi-reporting-cron

--- a/apps/pip/publication-services-mi-reporting-cron/stg/00.yaml
+++ b/apps/pip/publication-services-mi-reporting-cron/stg/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-publication-services-mi-reporting-cron

--- a/apps/pip/publication-services-mi-reporting-cron/stg/01.yaml
+++ b/apps/pip/publication-services-mi-reporting-cron/stg/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-publication-services-mi-reporting-cron

--- a/apps/pip/publication-services-mi-reporting-cron/test/00.yaml
+++ b/apps/pip/publication-services-mi-reporting-cron/test/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-publication-services-mi-reporting-cron

--- a/apps/pip/publication-services-mi-reporting-cron/test/01.yaml
+++ b/apps/pip/publication-services-mi-reporting-cron/test/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-publication-services-mi-reporting-cron

--- a/apps/pip/publication-services/demo.yaml
+++ b/apps/pip/publication-services/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-publication-services

--- a/apps/pip/publication-services/ithc.yaml
+++ b/apps/pip/publication-services/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-publication-services

--- a/apps/pip/publication-services/pip-publication-services.yaml
+++ b/apps/pip/publication-services/pip-publication-services.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-publication-services

--- a/apps/pip/publication-services/prod.yaml
+++ b/apps/pip/publication-services/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-publication-services

--- a/apps/pip/publication-services/stg.yaml
+++ b/apps/pip/publication-services/stg.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-publication-services

--- a/apps/pip/publication-services/test.yaml
+++ b/apps/pip/publication-services/test.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-publication-services

--- a/apps/pip/refresh-views-cron/demo/00.yaml
+++ b/apps/pip/refresh-views-cron/demo/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-refresh-views-cron

--- a/apps/pip/refresh-views-cron/demo/01.yaml
+++ b/apps/pip/refresh-views-cron/demo/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-refresh-views-cron

--- a/apps/pip/refresh-views-cron/pip-refresh-views-cron.yaml
+++ b/apps/pip/refresh-views-cron/pip-refresh-views-cron.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-refresh-views-cron

--- a/apps/pip/refresh-views-cron/prod/00.yaml
+++ b/apps/pip/refresh-views-cron/prod/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-refresh-views-cron

--- a/apps/pip/refresh-views-cron/prod/01.yaml
+++ b/apps/pip/refresh-views-cron/prod/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-refresh-views-cron

--- a/apps/pip/refresh-views-cron/stg/00.yaml
+++ b/apps/pip/refresh-views-cron/stg/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-refresh-views-cron

--- a/apps/pip/refresh-views-cron/stg/01.yaml
+++ b/apps/pip/refresh-views-cron/stg/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-refresh-views-cron

--- a/apps/pip/refresh-views-cron/test/00.yaml
+++ b/apps/pip/refresh-views-cron/test/00.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-refresh-views-cron

--- a/apps/pip/refresh-views-cron/test/01.yaml
+++ b/apps/pip/refresh-views-cron/test/01.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-refresh-views-cron

--- a/apps/pip/subscription-management/demo.yaml
+++ b/apps/pip/subscription-management/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-subscription-management

--- a/apps/pip/subscription-management/ithc.yaml
+++ b/apps/pip/subscription-management/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-subscription-management

--- a/apps/pip/subscription-management/pip-subscription-management.yaml
+++ b/apps/pip/subscription-management/pip-subscription-management.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-subscription-management

--- a/apps/pip/subscription-management/prod.yaml
+++ b/apps/pip/subscription-management/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-subscription-management

--- a/apps/pip/subscription-management/stg.yaml
+++ b/apps/pip/subscription-management/stg.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-subscription-management

--- a/apps/pip/subscription-management/test.yaml
+++ b/apps/pip/subscription-management/test.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pip-subscription-management

--- a/apps/pre/pre-api/demo.yaml
+++ b/apps/pre/pre-api/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pre-api

--- a/apps/pre/pre-api/dev.yaml
+++ b/apps/pre/pre-api/dev.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pre-api

--- a/apps/pre/pre-api/pre-api.yaml
+++ b/apps/pre/pre-api/pre-api.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pre-api

--- a/apps/pre/pre-api/prod.yaml
+++ b/apps/pre/pre-api/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pre-api

--- a/apps/pre/pre-api/sbox.yaml
+++ b/apps/pre/pre-api/sbox.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pre-api

--- a/apps/pre/pre-api/stg.yaml
+++ b/apps/pre/pre-api/stg.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pre-api

--- a/apps/pre/pre-api/test.yaml
+++ b/apps/pre/pre-api/test.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pre-api

--- a/apps/pre/pre-portal/demo.yaml
+++ b/apps/pre/pre-portal/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pre-portal

--- a/apps/pre/pre-portal/dev.yaml
+++ b/apps/pre/pre-portal/dev.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pre-portal

--- a/apps/pre/pre-portal/pre-portal.yaml
+++ b/apps/pre/pre-portal/pre-portal.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pre-portal

--- a/apps/pre/pre-portal/prod.yaml
+++ b/apps/pre/pre-portal/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pre-portal

--- a/apps/pre/pre-portal/sbox.yaml
+++ b/apps/pre/pre-portal/sbox.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pre-portal

--- a/apps/pre/pre-portal/stg.yaml
+++ b/apps/pre/pre-portal/stg.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pre-portal

--- a/apps/pre/pre-portal/test.yaml
+++ b/apps/pre/pre-portal/test.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: pre-portal

--- a/apps/testkube/testkube/testkube.yaml
+++ b/apps/testkube/testkube/testkube.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: testkube

--- a/apps/toffee/frontend/demo.yaml
+++ b/apps/toffee/frontend/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: toffee-frontend

--- a/apps/toffee/frontend/ithc.yaml
+++ b/apps/toffee/frontend/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: toffee-frontend

--- a/apps/toffee/frontend/prod.yaml
+++ b/apps/toffee/frontend/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: toffee-frontend

--- a/apps/toffee/frontend/sbox.yaml
+++ b/apps/toffee/frontend/sbox.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: toffee-frontend

--- a/apps/toffee/frontend/stg.yaml
+++ b/apps/toffee/frontend/stg.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: toffee-frontend

--- a/apps/toffee/frontend/test.yaml
+++ b/apps/toffee/frontend/test.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: toffee-frontend

--- a/apps/toffee/frontend/toffee-frontend.yaml
+++ b/apps/toffee/frontend/toffee-frontend.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: toffee-frontend

--- a/apps/toffee/recipe-backend/demo.yaml
+++ b/apps/toffee/recipe-backend/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: toffee-recipe-backend

--- a/apps/toffee/recipe-backend/ithc.yaml
+++ b/apps/toffee/recipe-backend/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: toffee-recipe-backend

--- a/apps/toffee/recipe-backend/prod.yaml
+++ b/apps/toffee/recipe-backend/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: toffee-recipe-backend

--- a/apps/toffee/recipe-backend/sbox.yaml
+++ b/apps/toffee/recipe-backend/sbox.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: toffee-recipe-backend

--- a/apps/toffee/recipe-backend/stg.yaml
+++ b/apps/toffee/recipe-backend/stg.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: toffee-recipe-backend

--- a/apps/toffee/recipe-backend/test.yaml
+++ b/apps/toffee/recipe-backend/test.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: toffee-recipe-backend

--- a/apps/toffee/recipe-backend/toffee-recipe-backend.yaml
+++ b/apps/toffee/recipe-backend/toffee-recipe-backend.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: toffee-recipe-backend

--- a/apps/toffee/recipe-receiver/demo.yaml
+++ b/apps/toffee/recipe-receiver/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: toffee-recipe-receiver

--- a/apps/toffee/recipe-receiver/ithc.yaml
+++ b/apps/toffee/recipe-receiver/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: toffee-recipe-receiver

--- a/apps/toffee/recipe-receiver/prod.yaml
+++ b/apps/toffee/recipe-receiver/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: toffee-recipe-receiver

--- a/apps/toffee/recipe-receiver/sbox.yaml
+++ b/apps/toffee/recipe-receiver/sbox.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: toffee-recipe-receiver

--- a/apps/toffee/recipe-receiver/stg.yaml
+++ b/apps/toffee/recipe-receiver/stg.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: toffee-recipe-receiver

--- a/apps/toffee/recipe-receiver/test.yaml
+++ b/apps/toffee/recipe-receiver/test.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: toffee-recipe-receiver

--- a/apps/toffee/recipe-receiver/toffee-recipe-receiver.yaml
+++ b/apps/toffee/recipe-receiver/toffee-recipe-receiver.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: toffee-recipe-receiver

--- a/apps/vh/admin-web/admin-web.yaml
+++ b/apps/vh/admin-web/admin-web.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: vh-admin-web

--- a/apps/vh/admin-web/demo.yaml
+++ b/apps/vh/admin-web/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: vh-admin-web

--- a/apps/vh/admin-web/dev.yaml
+++ b/apps/vh/admin-web/dev.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: vh-admin-web

--- a/apps/vh/admin-web/ithc.yaml
+++ b/apps/vh/admin-web/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: vh-admin-web

--- a/apps/vh/admin-web/prod.yaml
+++ b/apps/vh/admin-web/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: vh-admin-web

--- a/apps/vh/admin-web/stg.yaml
+++ b/apps/vh/admin-web/stg.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: vh-admin-web

--- a/apps/vh/admin-web/test.yaml
+++ b/apps/vh/admin-web/test.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: vh-admin-web

--- a/apps/vh/booking-queue-subscriber/booking-queue-subscriber.yaml
+++ b/apps/vh/booking-queue-subscriber/booking-queue-subscriber.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: vh-booking-queue-subscriber

--- a/apps/vh/booking-queue-subscriber/demo.yaml
+++ b/apps/vh/booking-queue-subscriber/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: vh-booking-queue-subscriber

--- a/apps/vh/booking-queue-subscriber/dev.yaml
+++ b/apps/vh/booking-queue-subscriber/dev.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: vh-booking-queue-subscriber

--- a/apps/vh/booking-queue-subscriber/ithc.yaml
+++ b/apps/vh/booking-queue-subscriber/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: vh-booking-queue-subscriber

--- a/apps/vh/booking-queue-subscriber/prod.yaml
+++ b/apps/vh/booking-queue-subscriber/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: vh-booking-queue-subscriber

--- a/apps/vh/booking-queue-subscriber/stg.yaml
+++ b/apps/vh/booking-queue-subscriber/stg.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: vh-booking-queue-subscriber

--- a/apps/vh/booking-queue-subscriber/test.yaml
+++ b/apps/vh/booking-queue-subscriber/test.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: vh-booking-queue-subscriber

--- a/apps/vh/bookings-api/bookings-api.yaml
+++ b/apps/vh/bookings-api/bookings-api.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: vh-bookings-api

--- a/apps/vh/bookings-api/demo.yaml
+++ b/apps/vh/bookings-api/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: vh-bookings-api

--- a/apps/vh/bookings-api/dev.yaml
+++ b/apps/vh/bookings-api/dev.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: vh-bookings-api

--- a/apps/vh/bookings-api/ithc.yaml
+++ b/apps/vh/bookings-api/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: vh-bookings-api

--- a/apps/vh/bookings-api/prod.yaml
+++ b/apps/vh/bookings-api/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: vh-bookings-api

--- a/apps/vh/bookings-api/stg.yaml
+++ b/apps/vh/bookings-api/stg.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: vh-bookings-api

--- a/apps/vh/bookings-api/test.yaml
+++ b/apps/vh/bookings-api/test.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: vh-bookings-api

--- a/apps/vh/notification-api/demo.yaml
+++ b/apps/vh/notification-api/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: vh-notification-api

--- a/apps/vh/notification-api/dev.yaml
+++ b/apps/vh/notification-api/dev.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: vh-notification-api

--- a/apps/vh/notification-api/ithc.yaml
+++ b/apps/vh/notification-api/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: vh-notification-api

--- a/apps/vh/notification-api/notification-api.yaml
+++ b/apps/vh/notification-api/notification-api.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: vh-notification-api

--- a/apps/vh/notification-api/prod.yaml
+++ b/apps/vh/notification-api/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: vh-notification-api

--- a/apps/vh/notification-api/stg.yaml
+++ b/apps/vh/notification-api/stg.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: vh-notification-api

--- a/apps/vh/notification-api/test.yaml
+++ b/apps/vh/notification-api/test.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: vh-notification-api

--- a/apps/vh/scheduler-jobs/demo.yaml
+++ b/apps/vh/scheduler-jobs/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: vh-scheduler-jobs

--- a/apps/vh/scheduler-jobs/dev.yaml
+++ b/apps/vh/scheduler-jobs/dev.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: vh-scheduler-jobs

--- a/apps/vh/scheduler-jobs/ithc.yaml
+++ b/apps/vh/scheduler-jobs/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: vh-scheduler-jobs

--- a/apps/vh/scheduler-jobs/prod.yaml
+++ b/apps/vh/scheduler-jobs/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: vh-scheduler-jobs

--- a/apps/vh/scheduler-jobs/scheduler-jobs.yaml
+++ b/apps/vh/scheduler-jobs/scheduler-jobs.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: vh-scheduler-jobs

--- a/apps/vh/scheduler-jobs/stg.yaml
+++ b/apps/vh/scheduler-jobs/stg.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: vh-scheduler-jobs

--- a/apps/vh/scheduler-jobs/test.yaml
+++ b/apps/vh/scheduler-jobs/test.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: vh-scheduler-jobs

--- a/apps/vh/test-api/dev.yaml
+++ b/apps/vh/test-api/dev.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: vh-test-api

--- a/apps/vh/test-api/stg.yaml
+++ b/apps/vh/test-api/stg.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: vh-test-api

--- a/apps/vh/test-api/test-api.yaml
+++ b/apps/vh/test-api/test-api.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: vh-test-api

--- a/apps/vh/test-api/test.yaml
+++ b/apps/vh/test-api/test.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: vh-test-api

--- a/apps/vh/test-web/dev.yaml
+++ b/apps/vh/test-web/dev.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: vh-test-web

--- a/apps/vh/test-web/stg.yaml
+++ b/apps/vh/test-web/stg.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: vh-test-web

--- a/apps/vh/test-web/test-web.yaml
+++ b/apps/vh/test-web/test-web.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: vh-test-web

--- a/apps/vh/test-web/test.yaml
+++ b/apps/vh/test-web/test.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: vh-test-web

--- a/apps/vh/user-api/demo.yaml
+++ b/apps/vh/user-api/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: vh-user-api

--- a/apps/vh/user-api/dev.yaml
+++ b/apps/vh/user-api/dev.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: vh-user-api

--- a/apps/vh/user-api/ithc.yaml
+++ b/apps/vh/user-api/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: vh-user-api

--- a/apps/vh/user-api/prod.yaml
+++ b/apps/vh/user-api/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: vh-user-api

--- a/apps/vh/user-api/stg.yaml
+++ b/apps/vh/user-api/stg.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: vh-user-api

--- a/apps/vh/user-api/test.yaml
+++ b/apps/vh/user-api/test.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: vh-user-api

--- a/apps/vh/user-api/user-api.yaml
+++ b/apps/vh/user-api/user-api.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: vh-user-api

--- a/apps/vh/video-api/demo.yaml
+++ b/apps/vh/video-api/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: vh-video-api

--- a/apps/vh/video-api/dev.yaml
+++ b/apps/vh/video-api/dev.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: vh-video-api

--- a/apps/vh/video-api/ithc.yaml
+++ b/apps/vh/video-api/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: vh-video-api

--- a/apps/vh/video-api/prod.yaml
+++ b/apps/vh/video-api/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: vh-video-api

--- a/apps/vh/video-api/stg.yaml
+++ b/apps/vh/video-api/stg.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: vh-video-api

--- a/apps/vh/video-api/test.yaml
+++ b/apps/vh/video-api/test.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: vh-video-api

--- a/apps/vh/video-api/video-api.yaml
+++ b/apps/vh/video-api/video-api.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: vh-video-api

--- a/apps/vh/video-web/demo.yaml
+++ b/apps/vh/video-web/demo.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: vh-video-web

--- a/apps/vh/video-web/dev.yaml
+++ b/apps/vh/video-web/dev.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: vh-video-web

--- a/apps/vh/video-web/ithc.yaml
+++ b/apps/vh/video-web/ithc.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: vh-video-web

--- a/apps/vh/video-web/prod.yaml
+++ b/apps/vh/video-web/prod.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: vh-video-web

--- a/apps/vh/video-web/stg.yaml
+++ b/apps/vh/video-web/stg.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: vh-video-web

--- a/apps/vh/video-web/test.yaml
+++ b/apps/vh/video-web/test.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: vh-video-web

--- a/apps/vh/video-web/video-web.yaml
+++ b/apps/vh/video-web/video-web.yaml
@@ -1,4 +1,4 @@
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: vh-video-web

--- a/bin/v2/add-helm-release.sh
+++ b/bin/v2/add-helm-release.sh
@@ -37,7 +37,7 @@ fi
 (
 cat <<EOF
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2beta2
 kind: HelmRelease
 metadata:
   name: ${PRODUCT}-${COMPONENT}


### PR DESCRIPTION
### Change description ###

* Flux upgrade to v2.2.0 has seen apiversion for _helmRelease_ increase from _helm.toolkit.fluxcd.io/v2beta1_ to _helm.toolkit.fluxcd.io/v2beta2_
* New apiversion has been tested through environments using our test application Plum and working as expected.
* v2beta2 API is backwards compatible with v2beta1 - for info on deprecation and new fields see the [release notes](https://github.com/fluxcd/flux2/releases/tag/v2.2.0). All current config will be valid

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
