### PR TITLE
upgrade ImageRepository apiVersion to v2beta2 introudced in flux 2.2.0

### DIFF
--- a/apps/azure-devops/azure-devops-agent-keda/image-repo.yaml
+++ b/apps/azure-devops/azure-devops-agent-keda/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: azure-devops-agent

--- a/apps/darts-modernisation/darts-api/image-repo.yaml
+++ b/apps/darts-modernisation/darts-api/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: darts-api

--- a/apps/darts-modernisation/darts-automated-tasks/image-repo.yaml
+++ b/apps/darts-modernisation/darts-automated-tasks/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: darts-automated-tasks

--- a/apps/darts-modernisation/darts-gateway/image-repo.yaml
+++ b/apps/darts-modernisation/darts-gateway/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: darts-gateway

--- a/apps/darts-modernisation/darts-portal/image-repo.yaml
+++ b/apps/darts-modernisation/darts-portal/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: darts-portal

--- a/apps/darts-modernisation/darts-stub-services/image-repo.yaml
+++ b/apps/darts-modernisation/darts-stub-services/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: darts-stub-services

--- a/apps/dc/dc-purview-shir/image-repo.yaml
+++ b/apps/dc/dc-purview-shir/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: dc-purview-shir

--- a/apps/dts-legacy/lgy-iac-web/image-repo.yaml
+++ b/apps/dts-legacy/lgy-iac-web/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: lgy-iac-web

--- a/apps/flux-system/automation/hmctsprivate-image-repo.yaml
+++ b/apps/flux-system/automation/hmctsprivate-image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: default

--- a/apps/flux-system/automation/hmctspublic-image-repo.yaml
+++ b/apps/flux-system/automation/hmctspublic-image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: default

--- a/apps/flux-system/automation/sdshmctsprivate-image-repo.yaml
+++ b/apps/flux-system/automation/sdshmctsprivate-image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: default

--- a/apps/flux-system/automation/sdshmctspublic-image-repo.yaml
+++ b/apps/flux-system/automation/sdshmctspublic-image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: default

--- a/apps/hmi/hmi-rota-dtu/image-repo.yaml
+++ b/apps/hmi/hmi-rota-dtu/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: hmi-rota-dtu

--- a/apps/jenkins/jenkins-webhook-relay/image-repo.yaml
+++ b/apps/jenkins/jenkins-webhook-relay/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: jenkins-webhook-relay

--- a/apps/juror/juror-pnc/image-repo.yaml
+++ b/apps/juror/juror-pnc/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: juror-pnc

--- a/apps/juror/juror-public/image-repo.yaml
+++ b/apps/juror/juror-public/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: juror-public

--- a/apps/juror/juror-scheduler-execution/image-repo.yaml
+++ b/apps/juror/juror-scheduler-execution/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: juror-scheduler-execution

--- a/apps/mailrelay/mailrelay/image-repo.yaml
+++ b/apps/mailrelay/mailrelay/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: mailrelay

--- a/apps/mailrelay2/mailrelay2/image-repo.yaml
+++ b/apps/mailrelay2/mailrelay2/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: mailrelay

--- a/apps/mi/mi-adf-shir/image-repo.yaml
+++ b/apps/mi/mi-adf-shir/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: mi-adf-shir

--- a/apps/mi/mi-azure-functions/image-repo.yaml
+++ b/apps/mi/mi-azure-functions/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: mi-azure-functions

--- a/apps/mi/mi-house-keeping-service/image-repo.yaml
+++ b/apps/mi/mi-house-keeping-service/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: mi-house-keeping-service

--- a/apps/monitoring/version-reporter/docsoutdated/image-repo.yaml
+++ b/apps/monitoring/version-reporter/docsoutdated/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: version-reporter-docsoutdated

--- a/apps/monitoring/version-reporter/helmcharts/image-repo.yaml
+++ b/apps/monitoring/version-reporter/helmcharts/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: version-reporter-helmcharts

--- a/apps/monitoring/version-reporter/paloalto/image-repo.yaml
+++ b/apps/monitoring/version-reporter/paloalto/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: version-reporter-paloalto

--- a/apps/monitoring/version-reporter/renovate/image-repo.yaml
+++ b/apps/monitoring/version-reporter/renovate/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: version-reporter-renovate

--- a/apps/monitoring/vm-hourlyusage/image-repo.yaml
+++ b/apps/monitoring/vm-hourlyusage/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: vm-hourlyusage

--- a/apps/my-time/my-time-api/image-repo.yaml
+++ b/apps/my-time/my-time-api/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: my-time-api

--- a/apps/my-time/my-time-frontend/image-repo.yaml
+++ b/apps/my-time/my-time-frontend/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: my-time-frontend

--- a/apps/opal/opal-fines-service/image-repo.yaml
+++ b/apps/opal/opal-fines-service/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: opal-fines-service

--- a/apps/opal/opal-frontend/image-repo.yaml
+++ b/apps/opal/opal-frontend/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: opal-frontend

--- a/apps/pip/account-management-clear-audit-cron/image-repo.yaml
+++ b/apps/pip/account-management-clear-audit-cron/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: pip-account-management-clear-audit-cron

--- a/apps/pip/account-management-inactive-verification-cron/image-repo.yaml
+++ b/apps/pip/account-management-inactive-verification-cron/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: pip-account-management-inactive-verification-cron

--- a/apps/pip/account-management-media-reporting-cron/image-repo.yaml
+++ b/apps/pip/account-management-media-reporting-cron/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: pip-account-management-media-reporting-cron

--- a/apps/pip/account-management/image-repo.yaml
+++ b/apps/pip/account-management/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: pip-account-management

--- a/apps/pip/channel-management/image-repo.yaml
+++ b/apps/pip/channel-management/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: pip-channel-management

--- a/apps/pip/data-management-expired-artefacts-cron/image-repo.yaml
+++ b/apps/pip/data-management-expired-artefacts-cron/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: pip-data-management-expired-artefacts-cron

--- a/apps/pip/data-management-no-match-artefacts-cron/image-repo.yaml
+++ b/apps/pip/data-management-no-match-artefacts-cron/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: pip-data-management-no-match-artefacts-cron

--- a/apps/pip/data-management-subscriptions-cron/image-repo.yaml
+++ b/apps/pip/data-management-subscriptions-cron/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: pip-data-management-subscriptions-cron

--- a/apps/pip/data-management/image-repo.yaml
+++ b/apps/pip/data-management/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: pip-data-management

--- a/apps/pip/frontend/image-repo.yaml
+++ b/apps/pip/frontend/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: pip-frontend

--- a/apps/pip/publication-services-mi-reporting-cron/image-repo.yaml
+++ b/apps/pip/publication-services-mi-reporting-cron/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: pip-publication-services-mi-reporting-cron

--- a/apps/pip/publication-services/image-repo.yaml
+++ b/apps/pip/publication-services/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: pip-publication-services

--- a/apps/pip/refresh-views-cron/image-repo.yaml
+++ b/apps/pip/refresh-views-cron/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: pip-refresh-views-cron

--- a/apps/pip/subscription-management/image-repo.yaml
+++ b/apps/pip/subscription-management/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: pip-subscription-management

--- a/apps/pre/pre-api/image-repo.yaml
+++ b/apps/pre/pre-api/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: pre-api

--- a/apps/pre/pre-portal/image-repo.yaml
+++ b/apps/pre/pre-portal/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: pre-portal

--- a/apps/toffee/frontend/image-repo.yaml
+++ b/apps/toffee/frontend/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: toffee-frontend

--- a/apps/toffee/recipe-backend/image-repo.yaml
+++ b/apps/toffee/recipe-backend/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: toffee-recipe-backend

--- a/apps/toffee/recipe-receiver/image-repo.yaml
+++ b/apps/toffee/recipe-receiver/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: toffee-recipe-receiver

--- a/apps/vh/admin-web/image-repo.yaml
+++ b/apps/vh/admin-web/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: vh-admin-web

--- a/apps/vh/booking-queue-subscriber/image-repo.yaml
+++ b/apps/vh/booking-queue-subscriber/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: vh-booking-queue-subscriber

--- a/apps/vh/bookings-api/image-repo.yaml
+++ b/apps/vh/bookings-api/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: vh-bookings-api

--- a/apps/vh/notification-api/image-repo.yaml
+++ b/apps/vh/notification-api/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: vh-notification-api

--- a/apps/vh/scheduler-jobs/image-repo.yaml
+++ b/apps/vh/scheduler-jobs/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: vh-scheduler-jobs

--- a/apps/vh/test-api/image-repo.yaml
+++ b/apps/vh/test-api/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: vh-test-api

--- a/apps/vh/test-web/image-repo.yaml
+++ b/apps/vh/test-web/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: vh-test-web

--- a/apps/vh/user-api/image-repo.yaml
+++ b/apps/vh/user-api/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: vh-user-api

--- a/apps/vh/video-api/image-repo.yaml
+++ b/apps/vh/video-api/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: vh-video-api

--- a/apps/vh/video-web/image-repo.yaml
+++ b/apps/vh/video-web/image-repo.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: vh-video-web

--- a/bin/v2/add-image-policies.sh
+++ b/bin/v2/add-image-policies.sh
@@ -43,7 +43,7 @@ if [[ ${ACR} == "hmctspublic" ]]
 then
 (
 cat <<EOF
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: ${PRODUCT}-${COMPONENT}
@@ -55,7 +55,7 @@ elif [[ ${ACR} == "sdshmctspublicsbox" ]]
 then
 (
 cat <<EOF
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: ${PRODUCT}-${COMPONENT}
@@ -69,7 +69,7 @@ elif [[ ${ACR} == "hmctsprivate" ]]
 then
 (
 cat <<EOF
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
   name: ${PRODUCT}-${COMPONENT}


### PR DESCRIPTION
### Change description ###

* Flux upgrade to v2.2.0 has seen apiversion for _imageRepository_ increase from _image.toolkit.fluxcd.io/v2beta1_ to _image.toolkit.fluxcd.io/v2beta2_
* New apiversion has been tested through environments using our test application Plum and working as expected.
* v2beta2 API is backwards compatible with v2beta1. All current config will be valid

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
