### PR TITLE
upgrade Alert/Provider from v1beta2 to v1beta3 introudced in flux 2.2.0

### DIFF
--- a/apps/base/alert.yaml
+++ b/apps/base/alert.yaml
@@ -1,4 +1,4 @@
-apiVersion: notification.toolkit.fluxcd.io/v1beta1
+apiVersion: notification.toolkit.fluxcd.io/v1beta3
 kind: Alert
 metadata:
   generation: 2

--- a/apps/base/provider.yaml
+++ b/apps/base/provider.yaml
@@ -1,4 +1,4 @@
-apiVersion: notification.toolkit.fluxcd.io/v1beta1
+apiVersion: notification.toolkit.fluxcd.io/v1beta3
 kind: Provider
 metadata:
   name: slack


### PR DESCRIPTION
### Change description ###

* Flux upgrade to v2.2.0 has seen apiversion for _Alert_ & _Provider_ increase from _notification.toolkit.fluxcd.io/v1beta2_ to _notification.toolkit.fluxcd.io/v1beta3_
* v1beta3 API is backwards compatible with v1beta2. All current config will be valid

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
