### PR TITLE
DTSPO-15812: Add prod&ptl, move chart upgrade to base

### DIFF
--- a/apps/azure-devops/azure-devops-agent-keda/azure-devops-agent.yaml
+++ b/apps/azure-devops/azure-devops-agent-keda/azure-devops-agent.yaml
@@ -40,7 +40,7 @@ spec:
   chart:
     spec:
       chart: function
-      version: 2.3.4
+      version: 2.5.1
       sourceRef:
         kind: HelmRepository
         name: hmctspublic

--- a/apps/azure-devops/azure-devops-agent-keda/dev.yaml
+++ b/apps/azure-devops/azure-devops-agent-keda/dev.yaml
@@ -13,11 +13,3 @@ spec:
         poolID: "36"
         organizationURLFromEnv: "AZP_URL"
         personalAccessTokenFromEnv: "AZP_TOKEN"
-  chart:
-    spec:
-      chart: function
-      version: 2.5.1
-      sourceRef:
-        kind: HelmRepository
-        name: hmctspublic
-        namespace: flux-system

--- a/apps/azure-devops/azure-devops-agent-keda/ptlsbox.yaml
+++ b/apps/azure-devops/azure-devops-agent-keda/ptlsbox.yaml
@@ -13,11 +13,3 @@ spec:
         poolID: "46"
         organizationURLFromEnv: "AZP_URL"
         personalAccessTokenFromEnv: "AZP_TOKEN"
-  chart:
-    spec:
-      chart: function
-      version: 2.5.1
-      sourceRef:
-        kind: HelmRepository
-        name: hmctspublic
-        namespace: flux-system

--- a/apps/azure-devops/azure-devops-agent-keda/sbox.yaml
+++ b/apps/azure-devops/azure-devops-agent-keda/sbox.yaml
@@ -13,11 +13,3 @@ spec:
         poolID: "40"
         organizationURLFromEnv: "AZP_URL"
         personalAccessTokenFromEnv: "AZP_TOKEN"
-  chart:
-    spec:
-      chart: function
-      version: 2.5.1
-      sourceRef:
-        kind: HelmRepository
-        name: hmctspublic
-        namespace: flux-system

--- a/apps/azure-devops/azure-devops-agent-keda/stg.yaml
+++ b/apps/azure-devops/azure-devops-agent-keda/stg.yaml
@@ -13,11 +13,3 @@ spec:
         poolID: "38"
         organizationURLFromEnv: "AZP_URL"
         personalAccessTokenFromEnv: "AZP_TOKEN"
-  chart:
-    spec:
-      chart: function
-      version: 2.5.1
-      sourceRef:
-        kind: HelmRepository
-        name: hmctspublic
-        namespace: flux-system

--- a/apps/azure-devops/azure-devops-agent-keda/test.yaml
+++ b/apps/azure-devops/azure-devops-agent-keda/test.yaml
@@ -14,11 +14,3 @@ spec:
         poolID: "37"
         organizationURLFromEnv: "AZP_URL"
         personalAccessTokenFromEnv: "AZP_TOKEN"
-  chart:
-    spec:
-      chart: function
-      version: 2.5.1
-      sourceRef:
-        kind: HelmRepository
-        name: hmctspublic
-        namespace: flux-system

--- a/apps/azure-devops/prod/base/kustomization.yaml
+++ b/apps/azure-devops/prod/base/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
 patches:
   - path: ../../azure-devops-agent-keda/prod.yaml
   - path: ../../azure-devops-agent-keda/prod/identity.yaml
+  - path: ../../serviceaccount/prod.yaml

--- a/apps/azure-devops/ptl/base/kustomization.yaml
+++ b/apps/azure-devops/ptl/base/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
 patches:
 - path: ../../azure-devops-agent-keda/ptl.yaml
 - path: ../../azure-devops-agent-keda/ptl/identity.yaml
+- path: ../../serviceaccount/ptl.yaml

--- a/apps/azure-devops/serviceaccount/prod.yaml
+++ b/apps/azure-devops/serviceaccount/prod.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ${NAMESPACE}
+  namespace: ${NAMESPACE}
+  annotations:
+    azure.workload.identity/client-id: "411fbae7-e4a4-4f1d-bf53-813596f44391"

--- a/apps/azure-devops/serviceaccount/ptl.yaml
+++ b/apps/azure-devops/serviceaccount/ptl.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ${NAMESPACE}
+  namespace: ${NAMESPACE}
+  annotations:
+    azure.workload.identity/client-id: "5729c2ba-1706-41d7-9b99-f67d167d5c8e"


### PR DESCRIPTION
Adds ado agents workload identity change to prod and ptl

To go in with https://github.com/hmcts/postgresql-cron-jobs/pull/70 -- as previously this job broke
Tested that this command works on an ADO pod using workload identity