### PR TITLE
DTSPO-15812: Remove nonprod old identities

### DIFF
--- a/apps/azure-devops/azure-devops-agent-keda/dev/identity.yaml
+++ b/apps/azure-devops/azure-devops-agent-keda/dev/identity.yaml
@@ -1,9 +1,0 @@
-apiVersion: "aadpodidentity.k8s.io/v1"
-kind: AzureIdentity
-metadata:
-  name: azure-devops-agent
-  namespace: azure-devops
-spec:
-  type: 0
-  resourceID: "/subscriptions/867a878b-cb68-4de5-9741-361ac9e178b6/resourcegroups/genesis-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aks-dev-mi"
-  clientID: "b86d64c4-ec90-451a-ab22-77cea15aeb68"

--- a/apps/azure-devops/azure-devops-agent-keda/ithc/identity.yaml
+++ b/apps/azure-devops/azure-devops-agent-keda/ithc/identity.yaml
@@ -1,9 +1,0 @@
-apiVersion: "aadpodidentity.k8s.io/v1"
-kind: AzureIdentity
-metadata:
-  name: azure-devops-agent
-  namespace: azure-devops
-spec:
-  type: 0
-  resourceID: "/subscriptions/ba71a911-e0d6-4776-a1a6-079af1df7139/resourcegroups/genesis-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aks-ithc-mi"
-  clientID: "9bcd6a33-c10b-4a8b-a77d-7341592874de"

--- a/apps/azure-devops/azure-devops-agent-keda/ptlsbox/identity.yaml
+++ b/apps/azure-devops/azure-devops-agent-keda/ptlsbox/identity.yaml
@@ -1,9 +1,0 @@
-apiVersion: "aadpodidentity.k8s.io/v1"
-kind: AzureIdentity
-metadata:
-  name: azure-devops-agent
-  namespace: azure-devops
-spec:
-  type: 0
-  resourceID: "/subscriptions/64b1c6d6-1481-44ad-b620-d8fe26a2c768/resourcegroups/genesis-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aks-ptlsbox-mi"
-  clientID: "d864b3ca-238c-474a-a426-6e526207cf4a"

--- a/apps/azure-devops/azure-devops-agent-keda/sbox/identity.yaml
+++ b/apps/azure-devops/azure-devops-agent-keda/sbox/identity.yaml
@@ -1,9 +1,0 @@
-apiVersion: "aadpodidentity.k8s.io/v1"
-kind: AzureIdentity
-metadata:
-  name: azure-devops-agent
-  namespace: azure-devops
-spec:
-  type: 0
-  resourceID: "/subscriptions/a8140a9e-f1b0-481f-a4de-09e2ee23f7ab/resourcegroups/genesis-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aks-sbox-mi"
-  clientID: "09d99cb4-e1e7-49c2-a8e6-b5b1740e9c3b"

--- a/apps/azure-devops/azure-devops-agent-keda/stg/identity.yaml
+++ b/apps/azure-devops/azure-devops-agent-keda/stg/identity.yaml
@@ -1,9 +1,0 @@
-apiVersion: "aadpodidentity.k8s.io/v1"
-kind: AzureIdentity
-metadata:
-  name: azure-devops-agent
-  namespace: azure-devops
-spec:
-  type: 0
-  resourceID: "/subscriptions/74dacd4f-a248-45bb-a2f0-af700dc4cf68/resourcegroups/genesis-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aks-stg-mi"
-  clientID: "fa0102b9-d3d3-4134-ad45-85a529ce9a9e"

--- a/apps/azure-devops/azure-devops-agent-keda/test/identity.yaml
+++ b/apps/azure-devops/azure-devops-agent-keda/test/identity.yaml
@@ -1,9 +1,0 @@
-apiVersion: "aadpodidentity.k8s.io/v1"
-kind: AzureIdentity
-metadata:
-  name: azure-devops-agent
-  namespace: azure-devops
-spec:
-  type: 0
-  resourceID: "/subscriptions/3eec5bde-7feb-4566-bfb6-805df6e10b90/resourcegroups/genesis-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/aks-test-mi"
-  clientID: "d477322e-1f41-4bec-9fbb-fceecd4edcc2"

--- a/apps/azure-devops/dev/base/kustomization.yaml
+++ b/apps/azure-devops/dev/base/kustomization.yaml
@@ -5,5 +5,4 @@ resources:
 - azure-devops-token.yaml
 patches:
 - path: ../../azure-devops-agent-keda/dev.yaml
-- path: ../../azure-devops-agent-keda/dev/identity.yaml
 - path: ../../serviceaccount/dev.yaml

--- a/apps/azure-devops/ithc/base/kustomization.yaml
+++ b/apps/azure-devops/ithc/base/kustomization.yaml
@@ -5,5 +5,4 @@ resources:
 - azure-devops-token.yaml
 patches:
 - path: ../../azure-devops-agent-keda/ithc.yaml
-- path: ../../azure-devops-agent-keda/ithc/identity.yaml
 - path: ../../serviceaccount/ithc.yaml

--- a/apps/azure-devops/ptlsbox/base/kustomization.yaml
+++ b/apps/azure-devops/ptlsbox/base/kustomization.yaml
@@ -6,5 +6,4 @@ resources:
 - azure-devops-token.yaml
 patches:
 - path: ../../azure-devops-agent-keda/ptlsbox.yaml
-- path: ../../azure-devops-agent-keda/ptlsbox/identity.yaml
 - path: ../../serviceaccount/ptlsbox.yaml

--- a/apps/azure-devops/sbox/base/kustomization.yaml
+++ b/apps/azure-devops/sbox/base/kustomization.yaml
@@ -6,5 +6,4 @@ resources:
   - azure-devops-token.yaml
 patches:
   - path: ../../azure-devops-agent-keda/sbox.yaml
-  - path: ../../azure-devops-agent-keda/sbox/identity.yaml
   - path: ../../serviceaccount/sbox.yaml

--- a/apps/azure-devops/stg/base/kustomization.yaml
+++ b/apps/azure-devops/stg/base/kustomization.yaml
@@ -5,5 +5,4 @@ resources:
 - azure-devops-token.yaml
 patches:
 - path: ../../azure-devops-agent-keda/stg.yaml
-- path: ../../azure-devops-agent-keda/stg/identity.yaml
 - path: ../../serviceaccount/stg.yaml

--- a/apps/azure-devops/test/base/kustomization.yaml
+++ b/apps/azure-devops/test/base/kustomization.yaml
@@ -5,5 +5,4 @@ resources:
 - azure-devops-token.yaml
 patches:
 - path: ../../azure-devops-agent-keda/test.yaml
-- path: ../../azure-devops-agent-keda/test/identity.yaml
 - path: ../../serviceaccount/test.yaml


### PR DESCRIPTION
All envs in ADO now using workload identity in SDS and confirmed working ok - removing old pod identities as cleanup work in nonprod, and will do prod afterwards

https://tools.hmcts.net/jira/browse/DTSPO-15812

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
