### PR TITLE
Upgrade ss-stg agents cpu&memory limits

### DIFF
--- a/apps/azure-devops/azure-devops-agent-keda/stg.yaml
+++ b/apps/azure-devops/azure-devops-agent-keda/stg.yaml
@@ -13,3 +13,5 @@ spec:
         poolID: "38"
         organizationURLFromEnv: "AZP_URL"
         personalAccessTokenFromEnv: "AZP_TOKEN"
+    memoryLimits: 3Gi
+    cpuLimits: 2Gi

--- a/apps/azure-devops/azure-devops-agent-keda/stg.yaml
+++ b/apps/azure-devops/azure-devops-agent-keda/stg.yaml
@@ -14,4 +14,4 @@ spec:
         organizationURLFromEnv: "AZP_URL"
         personalAccessTokenFromEnv: "AZP_TOKEN"
     memoryLimits: 3Gi
-    cpuLimits: 2Gi
+    cpuLimits: 2


### PR DESCRIPTION
Example of failure https://dev.azure.com/hmcts/MI%20Reporting/_build/results?buildId=513334&view=logs&s=6e00c4af-236e-555a-ee60-91129ae06a5d

[DTSPO-16540](https://tools.hmcts.net/jira/browse/DTSPO-16540)

Seems the agent is being kicked for some reason, re-establishing the session and then the build is breaking because between then it lost contact. 
I watched the mem/cpu usage during a failing stage, and they were sat consistently at 997Mi&1900mi for cpu/mem respectively and then the job failed and pod was restarted. 
Want to increase this ceiling for troubleshooting purposes to see if it's causing the failure.


<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
