### PR TITLE
DTSPO-16537  removed uid

### DIFF
--- a/apps/ipam/ipam-ingress.yaml
+++ b/apps/ipam/ipam-ingress.yaml
@@ -13,7 +13,6 @@ metadata:
   name: ipam-ingress
   namespace: ipam
   resourceVersion: "648192689"
-  uid: cc8c5e4e-f8c7-4308-b8f8-e83718affbfb
 spec:
   rules:
   - host: ipam.platform.hmcts.net


### PR DESCRIPTION
### Jira link (if applicable)


DTSPO-16537 
### Change description ###

Fix
ipam             6h48m   False   Ingress/ipam/ipam-ingress dry-run failed (Conflict): Operation cannot be fulfilled on ingresses.networking.k8s.io "ipam-ingress": uid mismatch: the provided object specified uid cc8c5e4e-f8c7-4308-b8f8-e83718affbfb, and no existing object was found...
