### PR TITLE
DTSPO-16538 - added missing document db

### DIFF
--- a/apps/azureserviceoperator-system/aso/kustomization.yaml
+++ b/apps/azureserviceoperator-system/aso/kustomization.yaml
@@ -6,7 +6,7 @@ patches:
   - patch: |-
       - op: add
         path: /spec/template/spec/containers/0/args/-
-        value: --crd-pattern=managedidentity.azure.com/*;servicebus.azure.com/*;resources.azure.com/*;managedidentity.azure.com/*;storage.azure.com/*;dbforpostgresql.azure.com/*
+        value: --crd-pattern=managedidentity.azure.com/*;servicebus.azure.com/*;resources.azure.com/*;managedidentity.azure.com/*;storage.azure.com/*;dbforpostgresql.azure.com/*;documentdb.azure.com/*
     target:
       kind: Deployment
   - patch: |-


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DTSPO-16538
### Change description ###
to fix this error
DatabaseAccount/ipam/ipam-ptl-cosmos dry-run failed: failed to get API group resources: unable to retrieve the complete 
