### PR TITLE
DTSPO-16658 Updating ptl traefik v26.0.0

### DIFF
--- a/apps/admin/traefik2/ptl/00-traefik.yaml
+++ b/apps/admin/traefik2/ptl/00-traefik.yaml
@@ -4,6 +4,15 @@ metadata:
   name: traefik2
   namespace: admin
 spec:
+  chart:
+    spec:
+      chart: traefik
+      # update the crd version in traefik-crds when updating this
+      version: 26.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: admin
   values:
     service:
       spec:

--- a/clusters/ptl/base/kustomization.yaml
+++ b/clusters/ptl/base/kustomization.yaml
@@ -17,3 +17,4 @@ patches:
       kind: Kustomization
       annotationSelector: hmcts.github.com/kustomize-defaults != disabled
   - path: ../../../apps/admin/ptl/base/kustomize.yaml
+  - path: ../../../apps/admin/traefik-crds-upgrade-v26/kustomize.yaml


### PR DESCRIPTION
### Jira link (if applicable)

[DTSPO-16658](https://tools.hmcts.net/jira/browse/DTSPO-16658)

### Change description ###

Upgraded traefik to v26, followed what has been done on the non-prod environment https://github.com/hmcts/sds-flux-config/pull/4156