### PR TITLE
Update dev ado token

### DIFF
--- a/apps/azure-devops/dev/base/azure-devops-token.yaml
+++ b/apps/azure-devops/dev/base/azure-devops-token.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-  token: ENC[AES256_GCM,data:Kz2MI5hqCcI1D1cyY4mt9sE4MtOKMnTrfD1TlxmmdFEGB6+pefZbDu+WCir97cSAEq8N0/cfUXov8SJNaAOgSzmBbmT8JVbB,iv:STCWG00ElyLkj376gCcQmoWWV670CocsgMmbEq9Imjc=,tag:/jGgwWRWOBJ7Zmg5vzk5gQ==,type:str]
+  token: ENC[AES256_GCM,data:tvbPpOC5R33ivCSdRUi6RStshhALlhW/UM5HoWljvFQfNBF7loG05DJtynJM5ZCzhfg5KkFqwfWBjRaeP/tvRuRkHIOFYRiQ,iv:pN4cTncqNA2sECEUNOu0m8BtiJHKSBAabrdcNmSjm8M=,tag:iSOu68xyzWOAxQRt5bhyrw==,type:str]
 kind: Secret
 metadata:
   creationTimestamp: null
@@ -14,12 +14,12 @@ sops:
     - vault_url: https://dtssharedservicesdevkv.vault.azure.net
       name: sops-key
       version: 2beba064ddfe454482ad0133af2cf0fd
-      created_at: "2023-09-29T12:46:56Z"
-      enc: k8qrCY2dfO90lmSS4N5lEu0heAVTDic_j-SBvBN6iMVpT8vtLPPr3JeiZZqXlscgqGopXdNX_FOwArTplGGCps7laYBPgcXsRM88dd_IHBUEk0UcPwMhwOapiQhQqxXuVFDUkKP4Jbj4phdGADc59ix0Nm9N4Q1joqGukQbDK732p_R-r8ZfMRvWxY48thQsZZuPA-JUleTeG6AvxR5Q7u_KYYzHZbYABMb4g5C5Zcv6ks2338yFywoWxVQ9zBDrh9rNey76a001YCHKq3GMlEqyV0ZG3VHaH7hdbp9vwEchkuFxVFv87jfHfTY-iUNvRSNPMqNbrCIOrIhKIPog7g
-  hc_vault: []
-  age: []
-  lastmodified: "2023-09-29T12:46:58Z"
-  mac: ENC[AES256_GCM,data:aI7i3HGHrWfbi+GgS11BXrfYG4vEC8YUaztCmxGBbnXUzw45+fiK9RtSBayWfRVCOfTakzIkWSvdD8ZSIWXGxXLxbup8JZzJOccMPHJMOYBS7L8B1XaK75/5yejqg2JfMqZUzvIvm4EuNLKq/c5lIvvBuOjXQOJCKOPqzu3kU3E=,iv:Gu/BO5ka07/mWmKwpsI2WGP4SojoaAIve6diYc79iII=,tag:LMtDRD14XPzfeaayXIV8kg==,type:str]
-  pgp: []
-  encrypted_regex: ^(data|stringData)$
-  version: 3.7.3
+      created_at: "2024-03-06T13:31:20Z"
+      enc: GPZt1BcmETYOZs6S_jG3GWcblp0CFcXz50VjieMhlw06mk4K8wIk6KLswt0LEXZs1EKgXlxk0gxveyWd9dsnUGMGBN53Bu412XBRol1xwicz3hiDBFo1nYlUDz8X0W6fOWdfOeTErwL9J-v4yHADyPKUg74FQK4CVVQSMpirLfs7I7Xp_Fc8wWBlZW5gqEDSSYcMD2KjtDlf4lv4sQK4e4K-Khd3hSqLpAt3NvmiMaHmjNUv8UbyDhwXyHXk6D4uCYG4hWXWgIUAVqpP18lDPEaMSs2Hcnz8kmeoSZiyRCIBDkVfPx97oW6bwmE3gLCiy02ao7cZLR9WI54ONF93QA
+hc_vault: []
+age: []
+lastmodified: "2024-03-06T13:31:26Z"
+mac: ENC[AES256_GCM,data:ltX8ZltNmCYYa6vc+Sstb/ZnTrihw9jtxim8nbM+Cn4sKNNswC4nuRiUUWQBVHKUWDQgoJ5395y/Io/JnEbarHYWvMf3BqxJkN7nUTqL/fQPcIZg06aw/mDF0CnX0/8OIVaf+HlGC3qHORndw06v/9BShit+T6TMOglk6XVBnCQ=,iv:FiAAvUPTtWLuT6doLBTxEfWahX5b8jg1yvMDG84JG1k=,tag:wUE2jsduHw3pUKPd87APFA==,type:str]
+pgp: []
+encrypted_regex: ^(data|stringData)$
+version: 3.7.3

--- a/apps/azure-devops/dev/base/azure-devops-token.yaml
+++ b/apps/azure-devops/dev/base/azure-devops-token.yaml
@@ -16,10 +16,10 @@ sops:
       version: 2beba064ddfe454482ad0133af2cf0fd
       created_at: "2024-03-06T13:31:20Z"
       enc: GPZt1BcmETYOZs6S_jG3GWcblp0CFcXz50VjieMhlw06mk4K8wIk6KLswt0LEXZs1EKgXlxk0gxveyWd9dsnUGMGBN53Bu412XBRol1xwicz3hiDBFo1nYlUDz8X0W6fOWdfOeTErwL9J-v4yHADyPKUg74FQK4CVVQSMpirLfs7I7Xp_Fc8wWBlZW5gqEDSSYcMD2KjtDlf4lv4sQK4e4K-Khd3hSqLpAt3NvmiMaHmjNUv8UbyDhwXyHXk6D4uCYG4hWXWgIUAVqpP18lDPEaMSs2Hcnz8kmeoSZiyRCIBDkVfPx97oW6bwmE3gLCiy02ao7cZLR9WI54ONF93QA
-hc_vault: []
-age: []
-lastmodified: "2024-03-06T13:31:26Z"
-mac: ENC[AES256_GCM,data:ltX8ZltNmCYYa6vc+Sstb/ZnTrihw9jtxim8nbM+Cn4sKNNswC4nuRiUUWQBVHKUWDQgoJ5395y/Io/JnEbarHYWvMf3BqxJkN7nUTqL/fQPcIZg06aw/mDF0CnX0/8OIVaf+HlGC3qHORndw06v/9BShit+T6TMOglk6XVBnCQ=,iv:FiAAvUPTtWLuT6doLBTxEfWahX5b8jg1yvMDG84JG1k=,tag:wUE2jsduHw3pUKPd87APFA==,type:str]
-pgp: []
-encrypted_regex: ^(data|stringData)$
-version: 3.7.3
+  hc_vault: []
+  age: []
+  lastmodified: "2024-03-06T13:31:26Z"
+  mac: ENC[AES256_GCM,data:ltX8ZltNmCYYa6vc+Sstb/ZnTrihw9jtxim8nbM+Cn4sKNNswC4nuRiUUWQBVHKUWDQgoJ5395y/Io/JnEbarHYWvMf3BqxJkN7nUTqL/fQPcIZg06aw/mDF0CnX0/8OIVaf+HlGC3qHORndw06v/9BShit+T6TMOglk6XVBnCQ=,iv:FiAAvUPTtWLuT6doLBTxEfWahX5b8jg1yvMDG84JG1k=,tag:wUE2jsduHw3pUKPd87APFA==,type:str]
+  pgp: []
+  encrypted_regex: ^(data|stringData)$
+  version: 3.7.3


### PR DESCRIPTION
Getting a 401 agent pool not found by ID in dev and some other envs, I can fetch the agent pool by ID correctly with my own PAT, so perhaps the one in aks is expired?


<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
