### PR TITLE
Darts ingress fixes

### DIFF
--- a/apps/darts-modernisation/darts-automated-tasks/darts-automated-tasks.yaml
+++ b/apps/darts-modernisation/darts-automated-tasks/darts-automated-tasks.yaml
@@ -15,6 +15,7 @@ spec:
       interval: 1m
   values:
     java:
+      ingressHost: darts-automated-tasks.{{ .Values.global.environment }}.platform.hmcts.net
       image: sdshmctspublic.azurecr.io/darts/api:prod-aac6c07-20240307144021 # {"$imagepolicy": "flux-system:darts-api"}
       disableTraefikTls: true
       memoryRequests: '2G'

--- a/apps/darts-modernisation/darts-migration/darts-api-migration.yaml
+++ b/apps/darts-modernisation/darts-migration/darts-api-migration.yaml
@@ -15,6 +15,7 @@ spec:
       interval: 1m
   values:
     java:
+      ingressHost: darts-api-migration.{{ .Values.global.environment }}.platform.hmcts.net
       replicas: 0
       # pin the version of the container image from the commit build here - update string removed
       image: sdshmctspublic.azurecr.io/darts/api:prod-32bdc24-20240229110157


### PR DESCRIPTION
### Jira link (if applicable)

N/A

### Change description ###

Setting ingress for darts-automated-tasks and darts-migration so that they don't use the default for the darts-api chart.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
