### PR TITLE
DTSPO-16590 - Turned off failing pods

### DIFF
--- a/clusters/sbox/base/kustomization.yaml
+++ b/clusters/sbox/base/kustomization.yaml
@@ -4,14 +4,14 @@ resources:
   - ../../../apps/flux-system/sbox/base
   - ../../../apps/toffee/base/kustomize.yaml
   - ../../../apps/azure-devops/base/kustomize.yaml
-  - ../../../apps/mi/base/kustomize.yaml
+  # - ../../../apps/mi/base/kustomize.yaml
   - ../../../apps/hmi/base/kustomize.yaml
   - ../../../apps/monitoring/base/kustomize.yaml
   - ../../../apps/admin/base/kustomize.yaml
   - ../../../apps/kube-system/base/kustomize.yaml
   - ../../../apps/cronjob/base/kustomize.yaml
   # - ../../../apps/darts-modernisation/base/kustomize.yaml
-  - ../../../apps/pip/base/kustomize.yaml
+  # - ../../../apps/pip/base/kustomize.yaml
   - ../../../apps/aspnet/base/kustomize.yaml
   - ../../../apps/azureserviceoperator-system/base/kustomize.yaml
   - ../../../apps/keda/base/kustomize.yaml


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DTSPO-16590

### Change description ###
Turning off failed pods to continue with AKS upgrade
