### PR TITLE
DTSPO-16591 - turn off Juror and darts because of failed pods

### DIFF
--- a/clusters/ithc/base/kustomization.yaml
+++ b/clusters/ithc/base/kustomization.yaml
@@ -15,8 +15,8 @@ resources:
   - ../../../apps/monitoring/base/kustomize.yaml
   - ../../../apps/azureserviceoperator-system/base/kustomize.yaml
   - ../../../apps/keda/base/kustomize.yaml
-  - ../../../apps/juror/base/kustomize.yaml
-  - ../../../apps/darts-modernisation/base/kustomize.yaml
+  # - ../../../apps/juror/base/kustomize.yaml
+  # - ../../../apps/darts-modernisation/base/kustomize.yaml
 patches:
   - path: ../../../apps/base/kustomize.yaml
     target:


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DTSPO-16591

### Change description ###

Turning off ITHC juror and darts because of  failed pods and HRs to continue with upgrade

![image](https://github.com/hmcts/sds-flux-config/assets/111435448/aaf71402-7a59-4cf2-85d7-92e59e264709)
