### PR TITLE
DTSPO-16592 - disble Darts pdb

### DIFF
--- a/apps/darts-modernisation/darts-api/prod.yaml
+++ b/apps/darts-modernisation/darts-api/prod.yaml
@@ -16,5 +16,7 @@ spec:
         ARM_PROPERTY_FILE_ENVIRONMENT: live
         ACTIVE_DIRECTORY_B2C_BASE_URI: https://hmctsextid.b2clogin.com
         ACTIVE_DIRECTORY_B2C_AUTH_URI: https://hmctsextid.b2clogin.com/hmctsextid.onmicrosoft.com
+      pdb:
+        enabled: false
     function:
       image: sdshmctspublic.azurecr.io/darts/api:prod-5164ef1-20240419160501 # {"$imagepolicy": "flux-system:darts-api"}

--- a/apps/darts-modernisation/darts-automated-tasks/prod.yaml
+++ b/apps/darts-modernisation/darts-automated-tasks/prod.yaml
@@ -13,3 +13,5 @@ spec:
         DARTS_LOG_LEVEL: DEBUG
         AUTOMATED_TASK_MODE: true
         API_MODE: false
+      pdb:
+        enabled: false

--- a/apps/darts-modernisation/darts-gateway/prod.yaml
+++ b/apps/darts-modernisation/darts-gateway/prod.yaml
@@ -15,3 +15,5 @@ spec:
         ACTIVE_DIRECTORY_B2C_BASE_URI: https://hmctsextid.b2clogin.com
         ACTIVE_DIRECTORY_B2C_AUTH_URI: https://hmctsextid.b2clogin.com/hmctsextid.onmicrosoft.com
         ACTIVE_DIRECTORY_B2C_ON_MICROSOFT_URI: https://hmctsextid.onmicrosoft.com
+      pdb:
+        enabled: false


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DTSPO-16592

### Change description ###

Disable Darts PDB to upgrade production clusters

