### PR TITLE
DTSPO-17035 - change ipam dns zone to plaform.hmcts.net

### DIFF
--- a/apps/ipam/README.md
+++ b/apps/ipam/README.md
@@ -1,7 +1,7 @@
 # IPAM
 We have deployed ipam following some of the documetation here - https://azure.github.io/ipam/#/  , please note that there is no official documentation on ipam on AKS so we manage to deploy it by doing some research and then some help from the ipam support team.
 
-ipam is available here, you would NOT need VPN as we have configured it behind app proxy - https://ipam.hmcts.net/
+ipam is available here, you would NOT need VPN as we have configured it behind app proxy - https://ipam.platform.hmcts.net/
 
 ## IPAM resources
 This are the resources deployed part of the ipam deployment on AKS.

--- a/apps/ipam/ipam-engine.yaml
+++ b/apps/ipam/ipam-engine.yaml
@@ -47,8 +47,7 @@ spec:
               name: ipam-sop-secrets
               key: TENANT-ID
         - name: IPAM_UI_URL
-          # value: "https://ipam.hmcts.net"
-          value: "https://ipam2.hmcts.net"
+          value: "https://ipam.platform.hmcts.net"
         - name: AZURE_ENV
           value: "AZURE_PUBLIC"
         - name: KEYVAULT_URL

--- a/apps/ipam/ipam-ingress.yaml
+++ b/apps/ipam/ipam-ingress.yaml
@@ -11,24 +11,7 @@ metadata:
   namespace: ipam
 spec:
   rules:
-  - host: ipam.hmcts.net
-    http:
-      paths:
-      - backend:
-          service:
-            name: ipam-ui-service
-            port:
-              number: 80
-        path: /
-        pathType: Prefix
-      - backend:
-          service:
-            name: ipam-engine-service
-            port:
-              number: 80
-        path: /api
-        pathType: Prefix
-  - host: ipam2.hmcts.net
+  - host: ipam.platform.hmcts.net
     http:
       paths:
       - backend:

--- a/apps/ipam/ipam-ui.yaml
+++ b/apps/ipam/ipam-ui.yaml
@@ -39,8 +39,7 @@ spec:
               name: ipam-sop-secrets
               key: TENANT-ID
         - name: REACT_APP_IPAM_ENGINE_URL
-          # value: "https://ipam.hmcts.net/api"
-          value: "https://ipam2.hmcts.net/api"
+          value: "https://ipam.platform.hmcts.net/api"
         resources: {}
 status: {}
 ---


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DTSPO-17035

### Change description ###

Change ipam dns zone from hmcts.net to platform.hmcts.net because of the private dns zone issue.
