### PR TITLE
Updated demo.yml to refer to non-prod chart 0.17

### DIFF
--- a/apps/vh/video-api/demo.yaml
+++ b/apps/vh/video-api/demo.yaml
@@ -12,4 +12,4 @@ spec:
       #image: sdshmctspublic.azurecr.io/vh/video-api:pr-633-202403251634-1 #{"$imagepolicy": "flux-system:vh-video-api-demo"}
   chart:
     spec:
-      chart: ./stable/vh-video-api/prod
+      chart: ./stable/vh-video-api/non-prod


### PR DESCRIPTION
### Jira link (if applicable)



### Change description ###


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


### apps/vh/video-api/demo.yaml
- Changed the chart reference from ./stable/vh-video-api/prod``` to ```./stable/vh-video-api/non-prod```. 🔄