### PR TITLE
Revert "juror: temp unlock api"

### DIFF
--- a/apps/juror/juror-api/test.yaml
+++ b/apps/juror/juror-api/test.yaml
@@ -8,5 +8,5 @@ spec:
   values:
     java:
       # Uncomment and edit the line below to fix the environment at a specific image
-      # image: sdshmctspublic.azurecr.io/juror/api:prod-80aa422-20240515120635
+      image: sdshmctspublic.azurecr.io/juror/api:prod-80aa422-20240515120635
       ingressHost: juror-api.test.platform.hmcts.net


### PR DESCRIPTION
Reverts hmcts/sds-flux-config#4699

## 🤖AEP PR SUMMARY🤖


### apps/juror/juror-api/test.yaml
- Added the image `sdshmctspublic.azurecr.io/juror/api:prod-80aa422-20240515120635` to the `java` values.