### PR TITLE
Update kustomization.yaml

### DIFF
--- a/apps/dynatrace/dynatrace-crds/kustomization.yaml
+++ b/apps/dynatrace/dynatrace-crds/kustomization.yaml
@@ -2,3 +2,9 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - https://github.com/Dynatrace/dynatrace-operator/releases/download/v1.0.0/dynatrace-operator-crd.yaml
+
+commonLabels:
+  app.kubernetes.io/managed-by: Helm
+commonAnnotations:
+  meta.helm.sh/release-name: dynatrace-operator
+  meta.helm.sh/release-namespace: dynatrace


### PR DESCRIPTION
Jira link (if applicable)
To be upgraded as part of patching: [tools.hmcts.net/jira/browse/DTSPO-17585](https://tools.hmcts.net/jira/browse/DTSPO-17585)

Change description
adding label and annotations as upgrade is complaining about them.

Helm upgrade failed for release dynatrace/dynatrace-operator with chart dynatrace-operator@1.0.0: Unable to continue with update: CustomResourceDefinition "dynakubes.dynatrace.com" in namespace "" exists and cannot be imported into the current release: invalid ownership metadata; label validation error: missing key "app.kubernetes.io/managed-by": must be set to "Helm"; annotation validation error: missing key "meta.helm.sh/release-name": must be set to "dynatrace-operator"; annotation validation error: missing key "meta.helm.sh/release-namespace": must be set to "dynatrace"


## 🤖AEP PR SUMMARY🤖

Request to AEP failed to process