### PR TITLE
Revert "Update test.yaml to 1.25.1"

### DIFF
--- a/apps/met/themis-fe/test.yaml
+++ b/apps/met/themis-fe/test.yaml
@@ -8,7 +8,7 @@ spec:
   values:
     nodejs:
       ingressHost: 'cloudgobgateway.test.platform.hmcts.net'
-      image: 'sdshmctspublic.azurecr.io/themis/themis_sb_azure:1.25.1'
+      image: 'sdshmctspublic.azurecr.io/themis/themis_sb_azure:1.22.0'
       replicas: 1
       autoscaling:
         enabled: false


### PR DESCRIPTION
Reverts hmcts/sds-flux-config#4798

## 🤖AEP PR SUMMARY🤖


- In `test.yaml`, the image version has been changed from `sdshmctspublic.azurecr.io/themis/themis_sb_azure:1.25.1` to `sdshmctspublic.azurecr.io/themis/themis_sb_azure:1.22.0` 🔧