### PR TITLE
Updating external-dns version

### DIFF
--- a/apps/admin/external-dns/dev/01-external-dns.yaml
+++ b/apps/admin/external-dns/dev/01-external-dns.yaml
@@ -9,3 +9,11 @@ spec:
     txtOwnerId: sds-dev-aks-active
     domainFilters:
       - dev.platform.hmcts.net
+  chart:
+    spec:
+      chart: external-dns
+      version: 7.5.1
+      sourceRef:
+        kind: HelmRepository
+        name: external-dns
+        namespace: admin


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DTSPO-17589

### Change description ###
Updating external-dns version to 7.5.1

### Checklist







## 🤖AEP PR SUMMARY🤖


- The file `01-external-dns.yaml` in the `apps/admin/external-dns/dev` directory has been updated to include a new chart specification for external-dns with version 7.5.1 and relevant source references.