### PR TITLE
Updating external-dns version

### DIFF
--- a/apps/admin/external-dns/dev/01-external-dns.yaml
+++ b/apps/admin/external-dns/dev/01-external-dns.yaml
@@ -9,11 +9,3 @@ spec:
     txtOwnerId: sds-dev-aks-active
     domainFilters:
       - dev.platform.hmcts.net
-  chart:
-    spec:
-      chart: external-dns
-      version: 7.5.1
-      sourceRef:
-        kind: HelmRepository
-        name: external-dns
-        namespace: admin

--- a/apps/admin/external-dns/external-dns.yaml
+++ b/apps/admin/external-dns/external-dns.yaml
@@ -8,7 +8,7 @@ spec:
   chart:
     spec:
       chart: external-dns
-      version: 6.34.2
+      version: 7.5.1
       sourceRef:
         kind: HelmRepository
         name: external-dns


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-17589

### Change description ###
Updating external-dns version to 7.5.1



## 🤖AEP PR SUMMARY🤖


- `apps/admin/external-dns/dev/01-external-dns.yaml` 📝
  - Removed the chart, version, and sourceRef related to the external-dns.
  - Updated the domainFilters to include dev.platform.hmcts.net.

- `apps/admin/external-dns/external-dns.yaml` 📝
  - Updated the version from 6.34.2 to 7.5.1 for the external-dns chart.