### PR TITLE
DMP-2765 Setting graceful shutdown timeout for DARTS automated tasks

### DIFF
--- a/apps/darts-modernisation/darts-automated-tasks/darts-automated-tasks.yaml
+++ b/apps/darts-modernisation/darts-automated-tasks/darts-automated-tasks.yaml
@@ -20,6 +20,7 @@ spec:
       disableTraefikTls: true
       memoryRequests: '3G'
       memoryLimits: '4G'
+      terminationGracePeriodSeconds: 120
     function:
       image: sdshmctspublic.azurecr.io/darts/api:prod-131a40e-20240529110123 # {"$imagepolicy": "flux-system:darts-api"}
       minReplicaCount: 0

--- a/apps/darts-modernisation/darts-automated-tasks/demo.yaml
+++ b/apps/darts-modernisation/darts-automated-tasks/demo.yaml
@@ -14,3 +14,4 @@ spec:
         AUTOMATED_TASK_MODE: true
         API_MODE: false
         ARM_URL: https://www.test.court-tribunal-records-archive.service.justice.gov.uk
+        GRACEFUL_SHUTDOWN_TIMEOUT: 2m

--- a/apps/darts-modernisation/darts-automated-tasks/ithc.yaml
+++ b/apps/darts-modernisation/darts-automated-tasks/ithc.yaml
@@ -14,3 +14,4 @@ spec:
         AUTOMATED_TASK_MODE: true
         API_MODE: false
         ARM_URL: http://darts-stub-services.ithc.platform.hmcts.net
+        GRACEFUL_SHUTDOWN_TIMEOUT: 2m

--- a/apps/darts-modernisation/darts-automated-tasks/prod.yaml
+++ b/apps/darts-modernisation/darts-automated-tasks/prod.yaml
@@ -14,5 +14,6 @@ spec:
         AUTOMATED_TASK_MODE: true
         API_MODE: false
         ARM_URL: https://www.court-tribunal-records-archive.service.justice.gov.uk
+        GRACEFUL_SHUTDOWN_TIMEOUT: 2m
       pdb:
         enabled: false

--- a/apps/darts-modernisation/darts-automated-tasks/sbox.yaml
+++ b/apps/darts-modernisation/darts-automated-tasks/sbox.yaml
@@ -13,3 +13,4 @@ spec:
         DARTS_LOG_LEVEL: DEBUG
         AUTOMATED_TASK_MODE: true
         API_MODE: false
+        GRACEFUL_SHUTDOWN_TIMEOUT: 2m

--- a/apps/darts-modernisation/darts-automated-tasks/stg.yaml
+++ b/apps/darts-modernisation/darts-automated-tasks/stg.yaml
@@ -14,3 +14,4 @@ spec:
         AUTOMATED_TASK_MODE: true
         API_MODE: false
         ARM_URL: http://darts-stub-services.staging.platform.hmcts.net
+        GRACEFUL_SHUTDOWN_TIMEOUT: 2m

--- a/apps/darts-modernisation/darts-automated-tasks/test.yaml
+++ b/apps/darts-modernisation/darts-automated-tasks/test.yaml
@@ -15,3 +15,4 @@ spec:
         API_MODE: false
         RESTART: 001
         ARM_URL: http://darts-stub-services.test.platform.hmcts.net
+        GRACEFUL_SHUTDOWN_TIMEOUT: 2m


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DMP-2765

### Change description ###

- k8s to 120s
- spring to 2m

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change






## 🤖AEP PR SUMMARY🤖


- Made changes to `darts-automated-tasks.yaml`:
  - Added `terminationGracePeriodSeconds: 120`.

- Updated `demo.yaml`:
  - Added `GRACEFUL_SHUTDOWN_TIMEOUT: 2m`.

- Updated `ithc.yaml`:
  - Added `GRACEFUL_SHUTDOWN_TIMEOUT: 2m`.

- Updated `prod.yaml`:
  - Added `GRACEFUL_SHUTDOWN_TIMEOUT: 2m`.

- Updated `sbox.yaml`:
  - Added `GRACEFUL_SHUTDOWN_TIMEOUT: 2m`.

- Updated `stg.yaml`:
  - Added `GRACEFUL_SHUTDOWN_TIMEOUT: 2m`.

- Updated `test.yaml`:
  - Added `GRACEFUL_SHUTDOWN_TIMEOUT: 2m`.