### PR TITLE
Update dev shir image for MI

### DIFF
--- a/apps/mi/mi-adf-shir-2/dev.yaml
+++ b/apps/mi/mi-adf-shir-2/dev.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   releaseName: mi-adf-shir-2
   values:
-    image: sdshmctspublic.azurecr.io/mi/adf-integration-runtime:dev-2022-3f48a9b-20230619095136 #{"$imagepolicy": "flux-system:mi-adf-shir-dev"}
+    image: sdshmctspublic.azurecr.io/mi/adf-integration-runtime:dev-138fe9e-20240603124222 #{"$imagepolicy": "flux-system:mi-adf-shir-dev"}
     replicaCount: 4
     memoryLimits: '4096Mi'
     environment: "dev"

--- a/apps/mi/mi-adf-shir/dev.yaml
+++ b/apps/mi/mi-adf-shir/dev.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   releaseName: mi-adf-shir
   values:
-    image: sdshmctspublic.azurecr.io/mi/adf-integration-runtime:dev-2022-3f48a9b-20230619095136 #{"$imagepolicy": "flux-system:mi-adf-shir-dev"}
+    image: sdshmctspublic.azurecr.io/mi/adf-integration-runtime:dev-138fe9e-20240603124222 #{"$imagepolicy": "flux-system:mi-adf-shir-dev"}
     replicaCount: 4
     memoryLimits: '4096Mi'
     environment: "dev"


### PR DESCRIPTION
### Jira link (if applicable)



### Change description ###


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


- Updated file: `dev.yaml`
  - Updated the image tag for `mi-adf-shir-2` and `mi-adf-shir` to `dev-138fe9e-20240603124222`
  - Updated replica count to 4 and memory limits to '4096Mi' for both configurations