### PR TITLE
Adds managed by label

### DIFF
--- a/apps/dynatrace/dynatrace-operator-upgrade-1.1.0.yaml
+++ b/apps/dynatrace/dynatrace-operator-upgrade-1.1.0.yaml
@@ -3,6 +3,8 @@ kind: HelmRelease
 metadata:
   name: dynatrace-operator
   namespace: dynatrace
+  labels:
+    app.kubernetes.io/managed-by: Helm
 spec:
   releaseName: dynatrace-operator
   interval: 5m


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DTSPO-17585

### Change description ###

Adds label for this error to test 
`dynatrace-operator   33m   False   Helm install failed for release dynatrace/dynatrace-operator with chart dynatrace-operator@1.1.0: Unable to continue with install: CustomResourceDefinition "dynakubes.dynatrace.com" in namespace "" exists and cannot be imported into the current release: invalid ownership metadata; label validation error: missing key "app.kubernetes.io/managed-by": must be set to "Helm"; annotation validation error: missing key "meta.helm.sh/release-name": must be set to "dynatrace-operator"; annotation validation error: missing key "meta.helm.sh/release-namespace": must be set to "dynatrace"`