### PR TITLE
bump version back to 1.1.0, dynatrace merged possible fix

### DIFF
--- a/apps/dynatrace/dynatrace-crds-upgrade/kustomization.yaml
+++ b/apps/dynatrace/dynatrace-crds-upgrade/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/Dynatrace/dynatrace-operator/releases/download/v1.0.1/dynatrace-operator-crd.yaml
+  - https://github.com/Dynatrace/dynatrace-operator/releases/download/v1.1.0/dynatrace-operator-crd.yaml

--- a/apps/dynatrace/dynatrace-operator-upgrade.yaml
+++ b/apps/dynatrace/dynatrace-operator-upgrade.yaml
@@ -3,8 +3,6 @@ kind: HelmRelease
 metadata:
   name: dynatrace-operator
   namespace: dynatrace
-  labels:
-    app.kubernetes.io/managed-by: Helm
 spec:
   releaseName: dynatrace-operator
   interval: 5m
@@ -12,4 +10,4 @@ spec:
     spec:
       chart: dynatrace-operator
       # update the CRDs in dynatrace-crds when changing this value
-      version: 1.0.1
+      version: 1.1.0


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DTSPO-17585

### Change description ###

bump version back to 1.1.0, dynatrace merged possible fix - https://github.com/Dynatrace/dynatrace-operator/pull/3219/files

## 🤖AEP PR SUMMARY🤖


- In `apps/dynatrace/dynatrace-crds-upgrade/kustomization.yaml`, the file path `dynatrace-operator-crd.yaml` was updated from version 1.0.1 to 1.1.0.
- In `apps/dynatrace/dynatrace-operator-upgrade.yaml`, the version of the chart `dynatrace-operator` was updated from 1.0.1 to 1.1.0. The `labels` section was removed.