### PR TITLE
Adds upgrade patch to stg 01

### DIFF
--- a/apps/dynatrace/stg/00/kustomization.yaml
+++ b/apps/dynatrace/stg/00/kustomization.yaml
@@ -2,4 +2,3 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../base
-

--- a/apps/dynatrace/stg/00/kustomization.yaml
+++ b/apps/dynatrace/stg/00/kustomization.yaml
@@ -3,5 +3,3 @@ kind: Kustomization
 resources:
   - ../base
 
-patches:
-  - path: ../../dynatrace-operator-upgrade.yaml

--- a/apps/dynatrace/stg/base/kustomization.yaml
+++ b/apps/dynatrace/stg/base/kustomization.yaml
@@ -1,8 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ../../base
-- dynakube-secret.enc.yaml
+  - ../../base
+  - dynakube-secret.enc.yaml
 namespace: dynatrace
 patches:
-- path: dynakube.yaml
+  - path: dynakube.yaml
+  - path: ../../dynatrace-operator-upgrade.yaml

--- a/clusters/stg/00/kustomization.yaml
+++ b/clusters/stg/00/kustomization.yaml
@@ -1,9 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ../base
+  - ../base
 #- ../../../apps/toffee/base/kustomize.yaml
 
 patches:
-- path: ../../../apps/flux-system/stg/00/kustomize.yaml
-- path: ../../../apps/dynatrace/base/kustomize-upgrade.yaml
+  - path: ../../../apps/flux-system/stg/00/kustomize.yaml

--- a/clusters/stg/base/kustomization.yaml
+++ b/clusters/stg/base/kustomization.yaml
@@ -29,3 +29,4 @@ patches:
       annotationSelector: hmcts.github.com/kustomize-defaults != disabled
   - path: ../../../apps/toffee/stg/base/kustomize.yaml
   - path: ../../../apps/admin/stg/base/kustomize.yaml
+  - path: ../../../apps/dynatrace/base/kustomize-upgrade.yaml


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DTSPO-17585

### Change description ###

Adds upgrade patch to stg 01




## 🤖AEP PR SUMMARY🤖


- `apps/dynatrace/stg/00/kustomization.yaml`
  - Removed patches for dynatrace-operator-upgrade.yaml.

- `apps/dynatrace/stg/base/kustomization.yaml`
  - Added dynakube-secret.enc.yaml to resources.
  - Removed dynakube.yaml from patches.
  - Added dynakube.yaml and dynatrace-operator-upgrade.yaml to patches.

- `clusters/stg/00/kustomization.yaml`
  - Added base to resources.
  - Removed paths for apps/flux-system/stg/00/kustomize.yaml.

- `clusters/stg/base/kustomization.yaml`
  - Added paths for apps/admin/stg/base/kustomize.yaml and apps/dynatrace/base/kustomize-upgrade.yaml.