### PR TITLE
Revert "Increasing darts-api KEDA function maxReplicaCount to 5"

### DIFF
--- a/apps/darts-modernisation/darts-api/darts-api.yaml
+++ b/apps/darts-modernisation/darts-api/darts-api.yaml
@@ -24,4 +24,3 @@ spec:
       image: sdshmctspublic.azurecr.io/darts/api:prod-8c7fe5c-20240605083203 # {"$imagepolicy": "flux-system:darts-api"}
       memoryRequests: '2G'
       memoryLimits: '3G'
-      maxReplicaCount: 5


### PR DESCRIPTION
Reverts hmcts/sds-flux-config#4864

## 🤖AEP PR SUMMARY🤖


- darts-api.yaml 🔄
  - Removed the `maxReplicaCount` field with a value of 5.