### PR TITLE
feat: test traefik internal ingress in sbox

### DIFF
--- a/apps/admin/traefik2/sbox/00-traefik2.yaml
+++ b/apps/admin/traefik2/sbox/00-traefik2.yaml
@@ -17,6 +17,16 @@ spec:
     service:
       spec:
         loadBalancerIP: "10.140.15.250"
+      additionalServices:
+        internal:
+          type: ClusterIP
+          labels:
+            traefik-service-label: internal
+          ports:
+            traefik:
+              expose:
+                default: false
+                internal: true
     deployment:
       podLabels:
         useWorkloadIdentity: "true"

--- a/apps/admin/traefik2/sbox/01-traefik2.yaml
+++ b/apps/admin/traefik2/sbox/01-traefik2.yaml
@@ -17,6 +17,16 @@ spec:
     service:
       spec:
         loadBalancerIP: "10.140.31.250"
+      additionalServices:
+        internal:
+          type: ClusterIP
+          labels:
+            traefik-service-label: internal
+          ports:
+            traefik:
+              expose:
+                default: false
+                internal: true
     deployment:
       podLabels:
         useWorkloadIdentity: "true"

--- a/apps/admin/traefik2/sbox/kustomization.yaml
+++ b/apps/admin/traefik2/sbox/kustomization.yaml
@@ -2,5 +2,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../../base
+- ./traefik-ping-ingress.yaml
 patches:
 - path: secret-provider.yaml

--- a/apps/admin/traefik2/sbox/traefik-ping-ingress.yaml
+++ b/apps/admin/traefik2/sbox/traefik-ping-ingress.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: traefik-ping-ingress
+  namespace: admin
+spec:
+  rules:
+    - http:
+        paths:
+          - backend:
+              service:
+                name: traefik-internal
+                port:
+                  number: 9000
+            path: /ping
+            pathType: ImplementationSpecific
+status:
+  loadBalancer: {}


### PR DESCRIPTION
### Jira link (if applicable)
N/A


### Change description ###
Testing an additional service for traefik and an ingress to expose the /ping endpoint for a LB health check.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


- Added the `additionalServices` block with an `internal` service of type `ClusterIP` and labels to  `apps/admin/traefik2/sbox/00-traefik2.yaml` and `apps/admin/traefik2/sbox/01-traefik2.yaml`
- Updated `apps/admin/traefik2/sbox/kustomization.yaml` to include `traefik-ping-ingress.yaml` and removed `traefik-ping-ingress.yaml` from the base resources.
- Added a new file `apps/admin/traefik2/sbox/traefik-ping-ingress.yaml` with Ingress configuration for traefik ping.