### PR TITLE
fix: correct traefik config sbox

### DIFF
--- a/apps/admin/traefik2/sbox/00-traefik2.yaml
+++ b/apps/admin/traefik2/sbox/00-traefik2.yaml
@@ -14,6 +14,11 @@ spec:
         name: traefik
         namespace: admin
   values:
+    ports:
+      traefik:
+        expose:
+          default: false
+          internal: true
     service:
       spec:
         loadBalancerIP: "10.140.15.250"
@@ -22,11 +27,6 @@ spec:
           type: ClusterIP
           labels:
             traefik-service-label: internal
-          ports:
-            traefik:
-              expose:
-                default: false
-                internal: true
     deployment:
       podLabels:
         useWorkloadIdentity: "true"

--- a/apps/admin/traefik2/sbox/01-traefik2.yaml
+++ b/apps/admin/traefik2/sbox/01-traefik2.yaml
@@ -14,6 +14,11 @@ spec:
         name: traefik
         namespace: admin
   values:
+    ports:
+      traefik:
+        expose:
+          default: false
+          internal: true
     service:
       spec:
         loadBalancerIP: "10.140.31.250"
@@ -22,11 +27,6 @@ spec:
           type: ClusterIP
           labels:
             traefik-service-label: internal
-          ports:
-            traefik:
-              expose:
-                default: false
-                internal: true
     deployment:
       podLabels:
         useWorkloadIdentity: "true"


### PR DESCRIPTION
### Jira link (if applicable)
N/A


### Change description ###
Correct traefik config based on docs.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


- `apps/admin/traefik2/sbox/00-traefik2.yaml` 🔄
  - Added configuration to set the `traefik` port to be internally exposed with `default: false` and `internal: true`.
  - Updated the `loadBalancerIP` to \"10.140.15.250\".

- `apps/admin/traefik2/sbox/01-traefik2.yaml` 🔄
  - Added configuration to set the `traefik` port to be internally exposed with `default: false` and `internal: true`.
  - Updated the `loadBalancerIP` to \"10.140.31.250\".