### PR TITLE
fix: include ping ingress in correct Kustomization

### DIFF
--- a/apps/admin/sbox/base/kustomization.yaml
+++ b/apps/admin/sbox/base/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
 - ../../kured/sbox/kured-values.enc.yaml
 - ../../../rbac/reader-clusterrole.yaml
 - ../../traefik2
+- ../../traefik2/sbox/traefik-ping-ingress.yaml
 - ../../delete-hung-pods
 patches:
 - path: ../../aad-pod-identity/sbox/azure-identity-patch.yaml

--- a/apps/admin/traefik2/sbox/kustomization.yaml
+++ b/apps/admin/traefik2/sbox/kustomization.yaml
@@ -2,6 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
 - ../../base
-- ./traefik-ping-ingress.yaml
 patches:
 - path: secret-provider.yaml


### PR DESCRIPTION
### Jira link (if applicable)
N/A


### Change description ###
Include the new Traefik ping ingress in the correct kustomization so it actually gets applied 🤦 

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


- `apps/admin/sbox/base/kustomization.yaml`:
  - Added a reference to `././traefik2/sbox/traefik-ping-ingress.yaml` under the `resources` section.
  - Removed the reference to `./traefik-ping-ingress.yaml` under the `patches` section.

- `apps/admin/traefik2/sbox/kustomization.yaml`:
  - Removed the reference to `./traefik-ping-ingress.yaml` under the `resources` section.