### PR TITLE
DTSPO-13833-testing-managed-identity-ptlsbox

### DIFF
--- a/apps/azure-devops/azure-devops-agent-keda/azure-devops-agent.yaml
+++ b/apps/azure-devops/azure-devops-agent-keda/azure-devops-agent.yaml
@@ -25,10 +25,6 @@ spec:
       AZP_POOL: hmcts-sds-ptlsbox
     job:
       activeDeadlineSeconds: 10800
-    secrets:
-      AZP_TOKEN:
-        secretRef: azure-devops-token
-        key: token
     memoryRequests: 512Mi
     cpuRequests: 25m
     memoryLimits: 3Gi

--- a/apps/azure-devops/azure-devops-agent-keda/dev.yaml
+++ b/apps/azure-devops/azure-devops-agent-keda/dev.yaml
@@ -8,6 +8,10 @@ spec:
   values:
     environment:
       AZP_POOL: hmcts-ss-dev
+    secrets:
+      AZP_TOKEN:
+        secretRef: azure-devops-token
+        key: token
     triggers:
       - type: azure-pipelines
         poolID: "36"

--- a/apps/azure-devops/azure-devops-agent-keda/ithc.yaml
+++ b/apps/azure-devops/azure-devops-agent-keda/ithc.yaml
@@ -8,6 +8,10 @@ spec:
   values:
     environment:
       AZP_POOL: hmcts-ss-ithc
+    secrets:
+      AZP_TOKEN:
+        secretRef: azure-devops-token
+        key: token
     triggers:
       - type: azure-pipelines
         poolID: "39"

--- a/apps/azure-devops/azure-devops-agent-keda/prod.yaml
+++ b/apps/azure-devops/azure-devops-agent-keda/prod.yaml
@@ -8,6 +8,10 @@ spec:
   values:
     environment:
       AZP_POOL: hmcts-ss-prod
+    secrets:
+      AZP_TOKEN:
+        secretRef: azure-devops-token
+        key: token
     memoryRequests: 1024Mi
     triggers:
       - type: azure-pipelines

--- a/apps/azure-devops/azure-devops-agent-keda/ptl.yaml
+++ b/apps/azure-devops/azure-devops-agent-keda/ptl.yaml
@@ -9,6 +9,10 @@ spec:
     maxReplicaCount: 6
     environment:
       AZP_POOL: hmcts-sds-ptl
+    secrets:
+      AZP_TOKEN:
+        secretRef: azure-devops-token
+        key: token
     triggers:
       - type: azure-pipelines
         poolID: "45"

--- a/apps/azure-devops/azure-devops-agent-keda/ptlsbox.yaml
+++ b/apps/azure-devops/azure-devops-agent-keda/ptlsbox.yaml
@@ -6,10 +6,23 @@ metadata:
   namespace: azure-devops
 spec:
   values:
+    image: hmctspublic.azurecr.io/azure-devops-agent:pr-34-6afbd78f-1717672466
     environment:
       AZP_POOL: hmcts-sds-ptlsbox
+    triggerAuth:
+      enabled: true
+      create: true
+      triggerPodIdentityProvider: "azure-workload"
+      triggerPodIdentityIdentityId: "4cc379a4-06b4-435e-8e61-a410aa241d6b" # keda-ptlsbox-mi
     triggers:
       - type: azure-pipelines
         poolID: "46"
         organizationURLFromEnv: "AZP_URL"
         personalAccessTokenFromEnv: "AZP_TOKEN"
+  chart:
+    spec:
+      chart: function
+      sourceRef:
+        kind: GitRepository
+        name: chart-function-test
+        namespace: flux-system

--- a/apps/azure-devops/azure-devops-agent-keda/ptlsbox.yaml
+++ b/apps/azure-devops/azure-devops-agent-keda/ptlsbox.yaml
@@ -9,10 +9,6 @@ spec:
     image: hmctspublic.azurecr.io/azure-devops-agent:pr-34-7212de02-1717688337
     environment:
       AZP_POOL: hmcts-sds-ptlsbox
-    # secrets:
-    #   AZP_TOKEN:
-    #     secretRef: azure-devops-token
-    #     key: token
     triggerAuth:
       enabled: true
       create: true

--- a/apps/azure-devops/azure-devops-agent-keda/ptlsbox.yaml
+++ b/apps/azure-devops/azure-devops-agent-keda/ptlsbox.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: azure-devops
 spec:
   values:
-    image: hmctspublic.azurecr.io/azure-devops-agent:pr-34-6afbd78f-1717672466
+    image: hmctspublic.azurecr.io/azure-devops-agent:pr-34-7212de02-1717688337
     environment:
       AZP_POOL: hmcts-sds-ptlsbox
     triggerAuth:

--- a/apps/azure-devops/azure-devops-agent-keda/ptlsbox.yaml
+++ b/apps/azure-devops/azure-devops-agent-keda/ptlsbox.yaml
@@ -9,6 +9,10 @@ spec:
     image: hmctspublic.azurecr.io/azure-devops-agent:pr-34-7212de02-1717688337
     environment:
       AZP_POOL: hmcts-sds-ptlsbox
+    # secrets:
+    #   AZP_TOKEN:
+    #     secretRef: azure-devops-token
+    #     key: token
     triggerAuth:
       enabled: true
       create: true

--- a/apps/azure-devops/azure-devops-agent-keda/sbox.yaml
+++ b/apps/azure-devops/azure-devops-agent-keda/sbox.yaml
@@ -8,6 +8,10 @@ spec:
   values:
     environment:
       AZP_POOL: hmcts-ss-sbox
+    secrets:
+      AZP_TOKEN:
+        secretRef: azure-devops-token
+        key: token
     triggers:
       - type: azure-pipelines
         poolID: "40"

--- a/apps/azure-devops/azure-devops-agent-keda/stg.yaml
+++ b/apps/azure-devops/azure-devops-agent-keda/stg.yaml
@@ -8,6 +8,10 @@ spec:
   values:
     environment:
       AZP_POOL: hmcts-ss-stg
+    secrets:
+      AZP_TOKEN:
+        secretRef: azure-devops-token
+        key: token
     triggers:
       - type: azure-pipelines
         poolID: "38"

--- a/apps/azure-devops/azure-devops-agent-keda/test.yaml
+++ b/apps/azure-devops/azure-devops-agent-keda/test.yaml
@@ -8,6 +8,10 @@ spec:
   values:
     environment:
       AZP_POOL: hmcts-ss-test
+    secrets:
+      AZP_TOKEN:
+        secretRef: azure-devops-token
+        key: token
     maxReplicaCount: 5
     triggers:
       - type: azure-pipelines


### PR DESCRIPTION
### Jira link (if applicable)
[DTSPO-13833](https://tools.hmcts.net/jira/browse/DTSPO-13833)


### Change description ###
Did some local testing replacing the pat token with using a managed identity.  Want to test this through flux using my chart-function branch.




















## 🤖AEP PR SUMMARY🤖


- `azure-devops-agent.yaml`:
   - Removed 'secrets' section and 'AZP_TOKEN' configuration.
- `dev.yaml`, `ithc.yaml`, `prod.yaml`, `ptl.yaml`, `sbox.yaml`, `stg.yaml`, `test.yaml`:
   - Added 'secrets' section and 'AZP_TOKEN' configuration.
- `ptlsbox.yaml`:
   - Added new configurations for image, triggerAuth, and chart.