### PR TITLE
Fix Mi SHIR 2 stg image

### DIFF
--- a/apps/mi/mi-adf-shir-2/stg.yaml
+++ b/apps/mi/mi-adf-shir-2/stg.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   releaseName: mi-adf-shir-2
   values:
-    image: sdshmctspublic.azurecr.io/mi/adf-integration-runtime:prod-91ba39e-20240607154028 #{"$imagepolicy": "flux-system:mi-adf-shir"}
+    image: sdshmctspublic.azurecr.io/mi/adf-integration-runtime:prod-91ba39e-20240312133745
     memoryLimits: '4096Mi'
     environment: "stg"
     resourceGroup: "mi-stg-rg"


### PR DESCRIPTION


## 🤖AEP PR SUMMARY🤖


### apps/mi/mi-adf-shir-2/stg.yaml
- Updated the image version to `prod-91ba39e-20240312133745` from `prod-91ba39e-20240607154028` 🔄
- Changed memoryLimits to `'4096Mi'`
- Updated environment to \"stg\"
- Updated resourceGroup to \"mi-stg-rg\"