### PR TITLE
Update version reporter values to use new custom service account settings

### DIFF
--- a/apps/monitoring/version-reporter/docsoutdated/docs-outdated.yaml
+++ b/apps/monitoring/version-reporter/docsoutdated/docs-outdated.yaml
@@ -26,7 +26,8 @@ spec:
     successfulJobsHistoryLimit: 5
     backoffLimit: 3
     restartPolicy: Never
-    serviceAccountName: version-reporter-service-sa
+    saEnabled: false
+    customServiceAccountName: version-reporter-service-sa
     kind: CronJob
     image: sdshmctspublic.azurecr.io/version-reporter-service/docsoutdated:prod-eb74249-20231128092345 #{"$imagepolicy": "flux-system:version-reporter-docsoutdated"}
     imagePullPolicy: Always

--- a/apps/monitoring/version-reporter/helmcharts/helm-charts.yaml
+++ b/apps/monitoring/version-reporter/helmcharts/helm-charts.yaml
@@ -26,7 +26,8 @@ spec:
     successfulJobsHistoryLimit: 5
     backoffLimit: 3
     restartPolicy: Never
-    serviceAccountName: version-reporter-service-sa
+    saEnabled: false
+    customServiceAccountName: version-reporter-service-sa
     kind: CronJob
     image: sdshmctspublic.azurecr.io/version-reporter-service/helmcharts:prod-aec76df-20240607114406 #{"$imagepolicy": "flux-system:version-reporter-helmcharts"}
     imagePullPolicy: Always

--- a/apps/monitoring/version-reporter/paloalto/palo-alto.yaml
+++ b/apps/monitoring/version-reporter/paloalto/palo-alto.yaml
@@ -26,7 +26,8 @@ spec:
     successfulJobsHistoryLimit: 5
     backoffLimit: 3
     restartPolicy: Never
-    serviceAccountName: version-reporter-service-sa
+    saEnabled: false
+    customServiceAccountName: version-reporter-service-sa
     kind: CronJob
     image: sdshmctspublic.azurecr.io/version-reporter-service/paloalto:prod-7fc9c22-20231129113549 #{"$imagepolicy": "flux-system:version-reporter-paloalto"}
     imagePullPolicy: Always

--- a/apps/monitoring/version-reporter/renovate/renovate.yaml
+++ b/apps/monitoring/version-reporter/renovate/renovate.yaml
@@ -26,7 +26,8 @@ spec:
     successfulJobsHistoryLimit: 5
     backoffLimit: 3
     restartPolicy: Never
-    serviceAccountName: version-reporter-service-sa
+    saEnabled: false
+    customServiceAccountName: version-reporter-service-sa
     kind: CronJob
     image: sdshmctspublic.azurecr.io/version-reporter-service/renovate:prod-eb74249-20231128092327 #{"$imagepolicy": "flux-system:version-reporter-renovate"}
     imagePullPolicy: Always


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-17826


### Change description ###
Update version reporter values to use new custom service account settings

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


### apps/monitoring/version-reporter/docsoutdated/docs-outdated.yaml
- The `saEnabled` field has been set to `false`.
- The `serviceAccountName` field has been replaced with `customServiceAccountName`.

### apps/monitoring/version-reporter/helmcharts/helm-charts.yaml
- The `saEnabled` field has been set to `false`.
- The `serviceAccountName` field has been replaced with `customServiceAccountName`.

### apps/monitoring/version-reporter/paloalto/palo-alto.yaml
- The `saEnabled` field has been set to `false`.
- The `serviceAccountName` field has been replaced with `customServiceAccountName`.

### apps/monitoring/version-reporter/renovate/renovate.yaml
- The `saEnabled` field has been set to `false`.
- The `serviceAccountName` field has been replaced with `customServiceAccountName`.