### PR TITLE
Adding aks version reporter service release to SDS monitoring namespace as a cronjob

### DIFF
--- a/apps/monitoring/automation/kustomization.yaml
+++ b/apps/monitoring/automation/kustomization.yaml
@@ -1,6 +1,8 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ../version-reporter/aksversions/image-repo.yaml
+  - ../version-reporter/aksversions/image-policy.yaml
   - ../version-reporter/paloalto/image-repo.yaml
   - ../version-reporter/paloalto/image-policy.yaml
   - ../version-reporter/helmcharts/image-repo.yaml

--- a/apps/monitoring/version-reporter/aksversions/aks-versions.yaml
+++ b/apps/monitoring/version-reporter/aksversions/aks-versions.yaml
@@ -30,7 +30,7 @@ spec:
     customServiceAccountName: version-reporter-service-sa
     runAsRoot: true
     kind: CronJob
-    image: sdshmctspublic.azurecr.io/version-reporter-service/aksversions:prod-aec76df-20240607114406 #{"$imagepolicy": "flux-system:version-reporter-aksversions"}
+    image: sdshmctspublic.azurecr.io/version-reporter-service/aksversions:prod-2835015-20240620083514 #{"$imagepolicy": "flux-system:version-reporter-aksversions"}
     imagePullPolicy: Always
     environment:
       COSMOS_DB_URI: https://sds-platform-version-reporter.documents.azure.com:443/

--- a/apps/monitoring/version-reporter/aksversions/aks-versions.yaml
+++ b/apps/monitoring/version-reporter/aksversions/aks-versions.yaml
@@ -1,0 +1,58 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: version-reporter-service-aksversions
+  namespace: monitoring
+  labels:
+    app: version-reporter-service-aksversions
+spec:
+  releaseName: version-reporter-service-aksversions
+  chart:
+    spec:
+      chart: job
+      sourceRef:
+        kind: GitRepository
+        name: chart-job
+        namespace: flux-system
+      interval: 1m
+  interval: 5m
+  values:
+    global:
+      tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
+    schedule: "30 8 * * 1-5" # interval 8:30am weekdays
+    concurrencyPolicy: "Forbid"
+    failedJobsHistoryLimit: 5
+    startingDeadlineSeconds: 300
+    successfulJobsHistoryLimit: 5
+    backoffLimit: 3
+    restartPolicy: Never
+    saEnabled: false
+    customServiceAccountName: version-reporter-service-sa
+    runAsRoot: true
+    kind: CronJob
+    image: sdshmctspublic.azurecr.io/version-reporter-service/aksversions:prod-aec76df-20240607114406 #{"$imagepolicy": "flux-system:version-reporter-aksversions"}
+    imagePullPolicy: Always
+    environment:
+      COSMOS_DB_URI: https://sds-platform-version-reporter.documents.azure.com:443/
+      COSMOS_DB_NAME: reports
+      COSMOS_DB_CONTAINER: aksversions
+    secrets:
+      COSMOS_KEY:
+        secretRef: version-reporter
+        key: cosmos_key
+      AZURE_TENANT_ID:
+        secretRef: version-reporter
+        key: tenant_id
+      AZURE_CLIENT_ID:
+        secretRef: version-reporter
+        key: client_id
+      AZURE_CLIENT_SECRET:
+        secretRef: version-reporter
+        key: client_secret
+    nodeSelector:
+      agentpool: cronjob
+    tolerations:
+      - key: dedicated
+        effect: NoSchedule
+        operator: Equal
+        value: jobs

--- a/apps/monitoring/version-reporter/aksversions/image-policy.yaml
+++ b/apps/monitoring/version-reporter/aksversions/image-policy.yaml
@@ -1,0 +1,7 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta1
+kind: ImagePolicy
+metadata:
+  name: version-reporter-aksversions
+spec:
+  imageRepositoryRef:
+    name: version-reporter-aksversions

--- a/apps/monitoring/version-reporter/aksversions/image-repo.yaml
+++ b/apps/monitoring/version-reporter/aksversions/image-repo.yaml
@@ -1,0 +1,6 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImageRepository
+metadata:
+  name: version-reporter-aksversions
+spec:
+  image: sdshmctspublic.azurecr.io/version-reporter-service/aksversions

--- a/apps/monitoring/version-reporter/kustomization.yaml
+++ b/apps/monitoring/version-reporter/kustomization.yaml
@@ -1,6 +1,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - aksversions/aks-versions.yaml
   - helmcharts/helm-charts.yaml
   - paloalto/palo-alto.yaml
   - renovate/renovate.yaml

--- a/apps/monitoring/version-reporter/kustomization.yaml
+++ b/apps/monitoring/version-reporter/kustomization.yaml
@@ -1,9 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - aksversions/aks-versions.yaml
   - helmcharts/helm-charts.yaml
   - paloalto/palo-alto.yaml
   - renovate/renovate.yaml
   - docsoutdated/docs-outdated.yaml
   - rbac.yaml
+  - aksversions/aks-versions.yaml


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-17828


### Change description ###
Adding aks version reporter service release to SDS monitoring namespace as a cronjob

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change








## 🤖AEP PR SUMMARY🤖


- Added new file `aks-versions.yaml` in `apps/monitoring/version-reporter` for defining a CronJob to report AKS versions with specific configurations.
- Updated `kustomization.yaml` in `apps/monitoring/automation` to include references to the newly added `aks-versions.yaml` and related image repositories and policies.