### PR TITLE
Temp breaking of DARTS_GATEWAY URL for DARTS API

### DIFF
--- a/apps/darts-modernisation/darts-api/stg.yaml
+++ b/apps/darts-modernisation/darts-api/stg.yaml
@@ -9,7 +9,7 @@ spec:
     java:
       ingressHost: darts-api.staging.platform.hmcts.net
       environment:
-        DARTS_GATEWAY_URL: http://darts-gateway.staging.platform.hmcts.net
+        DARTS_GATEWAY_URL: http://darts-gateway-removeme.staging.platform.hmcts.net
         DARTS_PORTAL_URL: https://darts.staging.apps.hmcts.net
         DARTS_LOG_LEVEL: DEBUG
         RESTART_ME: '007'

--- a/apps/darts-modernisation/darts-api/stg.yaml
+++ b/apps/darts-modernisation/darts-api/stg.yaml
@@ -9,7 +9,7 @@ spec:
     java:
       ingressHost: darts-api.staging.platform.hmcts.net
       environment:
-        DARTS_GATEWAY_URL: http://darts-gateway-removeme.staging.platform.hmcts.net
+        DARTS_GATEWAY_URL: http://darts-gateway.staging.platform.hmcts.net/removeme
         DARTS_PORTAL_URL: https://darts.staging.apps.hmcts.net
         DARTS_LOG_LEVEL: DEBUG
         RESTART_ME: '007'


### PR DESCRIPTION
### Jira link (if applicable)



### Change description ###


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change








## 🤖AEP PR SUMMARY🤖


- stg.yaml
  - Updated DARTS_GATEWAY_URL to http://darts-gateway.staging.platform.hmcts.net/removeme