### PR TITLE
Update envs for housekeeping job chart

### DIFF
--- a/apps/mi/mi-house-keeping-service/dev.yaml
+++ b/apps/mi/mi-house-keeping-service/dev.yaml
@@ -7,12 +7,8 @@ spec:
   releaseName: mi-house-keeping-service-job
   values:
     kind: CronJob
-    aadIdentityName: mi-house-keeping-service
     schedule: "45 * * * *"
-    userAssignedIdentityID: "5793ad47-8629-4723-82dc-78b1b49ed280"
     image: sdshmctspublic.azurecr.io/mi-house-keeping-service:prod-4875ce0-20230315120048 #{"$imagepolicy": "flux-system:mi-house-keeping-service"}
-    environment:
-      MI_CLIENT_ID: 5793ad47-8629-4723-82dc-78b1b49ed280
     global:
       subscriptionId: "867a878b-cb68-4de5-9741-361ac9e178b6"
       environment: "dev"

--- a/apps/mi/mi-house-keeping-service/ithc.yaml
+++ b/apps/mi/mi-house-keeping-service/ithc.yaml
@@ -7,12 +7,8 @@ spec:
   releaseName: mi-house-keeping-service-job
   values:
     kind: CronJob
-    aadIdentityName: mi-house-keeping-service
     schedule: "45 * * * *"
-    userAssignedIdentityID: "baf8db11-a87e-4212-8c85-d72622dc26c9"
     image: sdshmctspublic.azurecr.io/mi-house-keeping-service:prod-4875ce0-20230315120048 #{"$imagepolicy": "flux-system:mi-house-keeping-service"}
-    environment:
-      MI_CLIENT_ID: baf8db11-a87e-4212-8c85-d72622dc26c9
     global:
       subscriptionId: "ba71a911-e0d6-4776-a1a6-079af1df7139"
       environment: "ithc"

--- a/apps/mi/mi-house-keeping-service/mi-house-keeping-service.yaml
+++ b/apps/mi/mi-house-keeping-service/mi-house-keeping-service.yaml
@@ -11,6 +11,11 @@ spec:
     suspend: false
     kind: CronJob
     schedule: '45 * * * *'
+    environment:
+      STORAGE_LANDING_NAME: milanding{{ .Values.global.environment }}
+      STORAGE_EXPORT_NAME: miexport{{ .Values.global.environment }}
+      STORAGE_PERSISTENT_NAME: mipersistent{{ .Values.global.environment }}
+      STORAGE_AUDIT_NAME: miaudit{{ .Values.global.environment }}
     global:
       jobKind: CronJob
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"

--- a/apps/mi/mi-house-keeping-service/prod.yaml
+++ b/apps/mi/mi-house-keeping-service/prod.yaml
@@ -9,9 +9,6 @@ spec:
     suspend: false
     schedule: '45 2 * * *'
     activeDeadlineSeconds: 82800
-    aadIdentityName: mi-house-keeping-service
-    environment:
-      MI_CLIENT_ID: "12d8c94d-2d49-48d8-9e1b-0bc9937c6670"
     global:
       subscriptionId: "5ca62022-6aa2-4cee-aaa7-e7536c8d566c"
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"

--- a/apps/mi/mi-house-keeping-service/sbox.yaml
+++ b/apps/mi/mi-house-keeping-service/sbox.yaml
@@ -8,10 +8,6 @@ spec:
   values:
     kind: CronJob
     image: sdshmctspublic.azurecr.io/mi-house-keeping-service:prod-4875ce0-20230315120048 #{"$imagepolicy": "flux-system:mi-house-keeping-service"}
-    userAssignedIdentityID: "f74e3f17-9785-480b-8bd4-fcac2b53c682"
-    aadIdentityName: mi-house-keeping-service
-    environment:
-      MI_CLIENT_ID: f74e3f17-9785-480b-8bd4-fcac2b53c682
     schedule: "45 * * * *"
     global:
       subscriptionId: "a8140a9e-f1b0-481f-a4de-09e2ee23f7ab"

--- a/apps/mi/mi-house-keeping-service/stg.yaml
+++ b/apps/mi/mi-house-keeping-service/stg.yaml
@@ -7,12 +7,8 @@ spec:
   releaseName: mi-house-keeping-service-job
   values:
     kind: CronJob
-    aadIdentityName: mi-house-keeping-service
     schedule: "45 * * * *"
-    userAssignedIdentityID: "6ad9dea6-326e-4b34-9ccf-f7785b1ddb58"
     image: sdshmctspublic.azurecr.io/mi-house-keeping-service:prod-4875ce0-20230315120048 #{"$imagepolicy": "flux-system:mi-house-keeping-service"}
-    environment:
-      MI_CLIENT_ID: 6ad9dea6-326e-4b34-9ccf-f7785b1ddb58
     global:
       subscriptionId: "a8140a9e-f1b0-481f-a4de-09e2ee23f7ab"
       environment: "stg"

--- a/apps/mi/mi-house-keeping-service/test.yaml
+++ b/apps/mi/mi-house-keeping-service/test.yaml
@@ -10,11 +10,6 @@ spec:
     suspend: false
     kind: CronJob
     schedule: '45 1 * * *'
-    userAssignedIdentityID: "b97f7ade-7db0-41b0-bac2-22effc9d79b5"
-    aadIdentityName: mi-house-keeping-service
-    environment:
-      MI_CLIENT_ID: b97f7ade-7db0-41b0-bac2-22effc9d79b5
-      STORAGE_DATA_EXTRACTOR_RETENTION: "14"
     global:
       subscriptionId: "3eec5bde-7feb-4566-bfb6-805df6e10b90"
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"


### PR DESCRIPTION
Removed unused aadIdentity and mi client ID (now using workload identity via serviceaccount)
Added required envs for storage account names now moved from mi-job to chart-job



## 🤖AEP PR SUMMARY🤖


ℹ️ `dev.yaml`
- Removed `aadIdentityName` and `userAssignedIdentityID`
- Changed `schedule` to \"45 * * * *\"
- Removed `environment` and `MI_CLIENT_ID`

ℹ️ `ithc.yaml`
- Removed `aadIdentityName` and `userAssignedIdentityID`
- Changed `schedule` to \"45 * * * *\"
- Removed `environment` and `MI_CLIENT_ID`

ℹ️ `mi-house-keeping-service.yaml`
- Added environment variables for storage landing, export, persistent, and audit
- Changed `schedule` to '45 * * * *'

ℹ️ `prod.yaml`
- Removed `aadIdentityName` and `MI_CLIENT_ID`
- Changed `schedule` from \"45 2 * * *\" to \"45 2 * * *\"

ℹ️ `sbox.yaml`
- Removed `userAssignedIdentityID`, `aadIdentityName`, and `MI_CLIENT_ID`
- Changed `schedule` to \"45 * * * *\"

ℹ️ `stg.yaml`
- Removed `aadIdentityName` and `userAssignedIdentityID`
- Changed `schedule` to \"45 * * * *\"
- Removed `environment` and `MI_CLIENT_ID`

ℹ️ `test.yaml`
- Removed `userAssignedIdentityID`, `aadIdentityName`, and `MI_CLIENT_ID`
- Changed `schedule` from '45 1 * * *' to \"45 1 * * *\"
- Removed `STORAGE_DATA_EXTRACTOR_RETENTION` and its value