### PR TITLE
Revert "Temp breaking of DARTS_GATEWAY URL for DARTS API"

### DIFF
--- a/apps/darts-modernisation/darts-api/stg.yaml
+++ b/apps/darts-modernisation/darts-api/stg.yaml
@@ -9,7 +9,7 @@ spec:
     java:
       ingressHost: darts-api.staging.platform.hmcts.net
       environment:
-        DARTS_GATEWAY_URL: http://darts-gateway.staging.platform.hmcts.net/removeme
+        DARTS_GATEWAY_URL: http://darts-gateway.staging.platform.hmcts.net
         DARTS_PORTAL_URL: https://darts.staging.apps.hmcts.net
         DARTS_LOG_LEVEL: DEBUG
         RESTART_ME: '007'


### PR DESCRIPTION
Reverts hmcts/sds-flux-config#4944





## 🤖AEP PR SUMMARY🤖


- Updated `stg.yaml`: Changed the value of `DARTS_GATEWAY_URL` environment variable from `http://darts-gateway.staging.platform.hmcts.net/removeme` to `http://darts-gateway.staging.platform.hmcts.net`