### PR TITLE
juror: lock ithc with a pr image

### DIFF
--- a/apps/juror/juror-api/ithc.yaml
+++ b/apps/juror/juror-api/ithc.yaml
@@ -8,7 +8,7 @@ spec:
   values:
     java:
       # Uncomment and edit the line below to fix the environment at a specific image
-      # image: sdshmctspublic.azurecr.io/juror/api:prod-e7cd1c1-20240618085838
+      image: sdshmctspublic.azurecr.io/juror/api:pr-541-90ff1e3-20240627105900
       ingressHost: juror-api.ithc.platform.hmcts.net
       environment:
         EMPTY_VAR: one


### PR DESCRIPTION
### Jira link (if applicable)



### Change description ###


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


### apps/juror/juror-api/ithc.yaml
- Modified the image value to `sdshmctspublic.azurecr.io/juror/api:pr-541-90ff1e3-20240627105900` for the Java environment.
- Also updated the ingressHost to `juror-api.ithc.platform.hmcts.net`.