### PR TITLE
juror: update demo images

### DIFF
--- a/apps/juror/juror-api/demo.yaml
+++ b/apps/juror/juror-api/demo.yaml
@@ -8,5 +8,5 @@ spec:
   values:
     java:
       # Uncomment and edit the line below to fix the environment at a specific image
-      image: sdshmctspublic.azurecr.io/juror/api:prod-a1820ca-20240627091218
+      image: sdshmctspublic.azurecr.io/juror/api:prod-cc9d090-20240627171952
       ingressHost: juror-api.demo.platform.hmcts.net

--- a/apps/juror/juror-bureau/demo.yaml
+++ b/apps/juror/juror-bureau/demo.yaml
@@ -8,7 +8,7 @@ spec:
   values:
     nodejs:
       # Uncomment and edit the line below to fix the environment at a specific image
-      image: sdshmctspublic.azurecr.io/juror/bureau:prod-b054874-20240627093741
+      image: sdshmctspublic.azurecr.io/juror/bureau:prod-9c2f3f0-20240628075655
       ingressHost: juror.demo.apps.hmcts.net
       environment:
         SKIP_SSO: true

--- a/apps/juror/juror-pnc/demo.yaml
+++ b/apps/juror/juror-pnc/demo.yaml
@@ -8,7 +8,7 @@ spec:
   values:
     java:
       # Uncomment and edit the line below to fix the environment at a specific image
-      image: sdshmctspublic.azurecr.io/juror/pnc:prod-2916075-20240625110444
+      image: sdshmctspublic.azurecr.io/juror/pnc:prod-3b928ce-20240628065426
       ingressHost: juror-pnc.demo.platform.hmcts.net
       environment:
         PNC_SERVICE_PNC_TRAN_CODE: '#L0'

--- a/apps/juror/juror-public/demo.yaml
+++ b/apps/juror/juror-public/demo.yaml
@@ -8,5 +8,5 @@ spec:
   values:
     nodejs:
       # Uncomment and edit the line below to fix the environment at a specific image
-      image: sdshmctspublic.azurecr.io/juror/public:prod-3c44ef2-20240627062531
+      image: sdshmctspublic.azurecr.io/juror/public:prod-71e7cc9-20240628063330
       ingressHost: juror-public.demo.apps.hmcts.net

--- a/apps/juror/juror-scheduler-api/demo.yaml
+++ b/apps/juror/juror-scheduler-api/demo.yaml
@@ -8,5 +8,5 @@ spec:
   values:
     java:
       # Uncomment and edit the line below to fix the environment at a specific image
-      image: sdshmctspublic.azurecr.io/juror/scheduler-api:prod-b799edc-20240621103937
+      image: sdshmctspublic.azurecr.io/juror/scheduler-api:prod-c388671-20240628073923
       ingressHost: juror-scheduler-api.demo.platform.hmcts.net

--- a/apps/juror/juror-scheduler-execution/demo.yaml
+++ b/apps/juror/juror-scheduler-execution/demo.yaml
@@ -8,5 +8,5 @@ spec:
   values:
     java:
       # Uncomment and edit the line below to fix the environment at a specific image
-      image: sdshmctspublic.azurecr.io/juror/scheduler-execution:prod-ac4d7e9-20240626184347
+      image: sdshmctspublic.azurecr.io/juror/scheduler-execution:prod-5639966-20240628065044
       ingressHost: juror-scheduler-execution.demo.platform.hmcts.net


### PR DESCRIPTION
### Jira link (if applicable)



### Change description ###


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


- Updated image tag for juror-api, juror-bureau, juror-pnc, juror-public, juror-scheduler-api, and juror-scheduler-execution in their respective demo.yaml files
- Updated the image tag for each service to a new version with a timestamp ending in 20240628073923, 20240628075655, 20240628065426, 20240628063330, 20240628073923, and 20240628065044 respectively