### PR TITLE
juror: break ithc BAIS_PORT

### DIFF
--- a/apps/juror/juror-scheduler-execution/ithc.yaml
+++ b/apps/juror/juror-scheduler-execution/ithc.yaml
@@ -10,3 +10,4 @@ spec:
       # Uncomment and edit the line below to fix the environment at a specific image
       # image: sdshmctspublic.azurecr.io/juror/scheduler-execution:prod-8f7a84e-20240618062930
       ingressHost: juror-scheduler-execution.ithc.platform.hmcts.net
+      BAIS_PORT: 2220


### PR DESCRIPTION
### Jira link (if applicable)



### Change description ###


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


### apps/juror/juror-scheduler-execution/ithc.yaml
- Added a new environment variable `BAIS_PORT` with the value of `2220`. 🚀