### PR TITLE
juror: break ithc bais

### DIFF
--- a/apps/juror/juror-scheduler-execution/ithc.yaml
+++ b/apps/juror/juror-scheduler-execution/ithc.yaml
@@ -10,3 +10,5 @@ spec:
       # Uncomment and edit the line below to fix the environment at a specific image
       # image: sdshmctspublic.azurecr.io/juror/scheduler-execution:prod-8f7a84e-20240618062930
       ingressHost: juror-scheduler-execution.ithc.platform.hmcts.net
+      environment:
+        BAIS_PORT: 2220


### PR DESCRIPTION
Reverts hmcts/sds-flux-config#4965

## 🤖AEP PR SUMMARY🤖


### apps/juror/juror-scheduler-execution/ithc.yaml
- Added environment variable \"BAIS_PORT\" with a value of 2220 🌐