### PR TITLE
unlock API in ithc

### DIFF
--- a/apps/juror/juror-api/ithc.yaml
+++ b/apps/juror/juror-api/ithc.yaml
@@ -8,7 +8,7 @@ spec:
   values:
     java:
       # Uncomment and edit the line below to fix the environment at a specific image
-      image: sdshmctspublic.azurecr.io/juror/api:pr-541-e95fdad-20240701113008
+      # image: sdshmctspublic.azurecr.io/juror/api:pr-541-e95fdad-20240701113008
       ingressHost: juror-api.ithc.platform.hmcts.net
       environment:
         EMPTY_VAR: one


### PR DESCRIPTION
### Change description ###
unlock API in ithc

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


### apps/juror/juror-api/ithc.yaml
- Updated the value of the `image` key under `java` to `sdshmctspublic.azurecr.io/juror/api:pr-541-e95fdad-20240701113008`
- Added `ingressHost` key with the value `juror-api.ithc.platform.hmcts.net` under `java` section.