### PR TITLE
feat: prod pod restart nightly

### DIFF
--- a/apps/met/pod-delete-cron/prod.yaml
+++ b/apps/met/pod-delete-cron/prod.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: libragob-pod-delete-nightly
+  namespace: met
+spec:
+  releaseName: libragob-pod-delete-nightly
+  interval: 5m
+  values:
+    schedule: "50 22 * * *"
+    suspend: false

--- a/apps/met/prod/base/kustomization.yaml
+++ b/apps/met/prod/base/kustomization.yaml
@@ -3,9 +3,12 @@ kind: Kustomization
 resources:
   - ../../base
   - ../../batch-jobs/batch-jobs.yaml
+  - ../../pod-delete-cron/pod-delete-cron-rbac.yaml
+  - ../../pod-delete-cron/pod-delete-cron.yaml
 namespace: met
 patches:
   - path: ../../identity/prod.yaml
   - path: ../../themis-fe/prod.yaml
   - path: ../../serviceaccount/prod.yaml
   - path: ../../batch-jobs/prod.yaml
+  - path: ../../pod-delete-cron/prod.yaml


### PR DESCRIPTION
### Jira link (if applicable)
N/A


### Change description ###
Added nightly pod "restarts" in prod

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change




## 🤖AEP PR SUMMARY🤖


- Created new file `prod.yaml` in `apps/met/pod-delete-cron/` to define a HelmRelease for deleting pods nightly at 22:50 with a 5-minute interval.
- Updated `kustomization.yaml` in `apps/met/prod/base/` to add references to the new pod-delete-cron resources.