### PR TITLE
Update dev.yaml  - Added Vodafone configuration

### DIFF
--- a/apps/vh/video-api/dev.yaml
+++ b/apps/vh/video-api/dev.yaml
@@ -74,8 +74,8 @@ spec:
           - vodafoneconfiguration--apiurl
           - vodafoneconfiguration--selftestapiurl
           - vodafoneconfiguration--pexipnode
-          - vodafoneconfiguration--pexipselftestnode     
-          - vodafoneconfiguration--callbacksecret   
+          - vodafoneconfiguration--pexipselftestnode
+          - vodafoneconfiguration--callbacksecret
           - name: kinlyconfiguration--telephoneconferencenumber
             alias: vodafoneconfiguration--conferencephonenumber
           - name: kinlyconfiguration--telephoneconferencenumberwelsh

--- a/apps/vh/video-api/dev.yaml
+++ b/apps/vh/video-api/dev.yaml
@@ -65,8 +65,21 @@ spec:
             alias: kinlyconfiguration--conferencephonenumber
           - name: kinlyconfiguration--telephoneconferencenumberwelsh
             alias: kinlyconfiguration--conferencephonenumberwelsh
-          - kinlyconfiguration--kinlyapiurl
-          - kinlyconfiguration--kinlyselftestapiurl
+          - name: kinlyconfiguration--kinlyapiurl
+            alias: kinlyconfiguration--apiurl
+          - name: kinlyconfiguration--kinlyselftestapiurl
+            alias: kinlyconfiguration--selftestapiurl
+          - vodafoneconfiguration--apisecret
+          - vodafoneconfiguration--selftestapikey
+          - vodafoneconfiguration--apiurl
+          - vodafoneconfiguration--selftestapiurl
+          - vodafoneconfiguration--pexipnode
+          - vodafoneconfiguration--pexipselftestnode     
+          - vodafoneconfiguration--callbacksecret   
+          - name: kinlyconfiguration--telephoneconferencenumber
+            alias: vodafoneconfiguration--conferencephonenumber
+          - name: kinlyconfiguration--telephoneconferencenumberwelsh
+            alias: vodafoneconfiguration--conferencephonenumberwelsh
           - kinlyconfiguration--conferenceusername
           - kinlyconfiguration--pexipnode
           - kinlyconfiguration--pexipselftestnode


### PR DESCRIPTION
Added Vodafone configuration

### Jira link (if applicable)



### Change description ###


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change






## 🤖AEP PR SUMMARY🤖


### apps/vh/video-api/dev.yaml
- Added new aliases for kinlyconfiguration--kinlyapiurl and kinlyconfiguration--kinlyselftestapiurl.
- Renamed aliases for kinlyconfiguration--telephoneconferencenumber and kinlyconfiguration--telephoneconferencenumberwelsh to vodafoneconfiguration--conferencephonenumber and vodafoneconfiguration--conferencephonenumberwelsh.
- Added vodafoneconfiguration parameters: apisecret, selftestapikey, apiurl, selftestapiurl, pexipnode, pexipselftestnode, and callbacksecret.