### PR TITLE
Revert " temporarily stop darts gateway staging (#5019)"

### DIFF
--- a/apps/darts-modernisation/darts-gateway/stg.yaml
+++ b/apps/darts-modernisation/darts-gateway/stg.yaml
@@ -7,7 +7,6 @@ spec:
   releaseName: darts-gateway
   values:
     java:
-      replicas: 0
       ingressHost: darts-gateway.staging.platform.hmcts.net
       environment:
         DARTS_API_URL: https://darts-api.staging.platform.hmcts.net


### PR DESCRIPTION
This reverts commit e2be46bc7d19383772f3fbe03805bd4dfa1d6720.


## 🤖AEP PR SUMMARY🤖


- stg.yaml
- Removed a line specifying the number of replicas for the Java service in the staging environment.