### PR TITLE
Add env var to enable mk watch page in stg

### DIFF
--- a/apps/pre/pre-portal/stg.yaml
+++ b/apps/pre/pre-portal/stg.yaml
@@ -12,3 +12,4 @@ spec:
         PRE_API_URL: https://sds-api-mgmt.staging.platform.hmcts.net/pre-api
         PORTAL_URL: https://pre-portal.staging.platform.hmcts.net
         B2C_APP_CLIENT_ID: d20a7462-f222-46b8-a363-d2e30eb274eb
+        ENABLE_MK_WATCH_PAGE: true


### PR DESCRIPTION
### Change description ###

Enable mk watch page in stg




## 🤖AEP PR SUMMARY🤖


### apps/pre/pre-portal/stg.yaml
- Added the `ENABLE_MK_WATCH_PAGE` environment variable with the value `true`. 🆕