### PR TITLE
Initial lock of juror-api in ithc to PR-590

### DIFF
--- a/apps/juror/juror-api/ithc.yaml
+++ b/apps/juror/juror-api/ithc.yaml
@@ -8,7 +8,7 @@ spec:
   values:
     java:
       # Uncomment and edit the line below to fix the environment at a specific image
-      # image: sdshmctspublic.azurecr.io/juror/api:pr-581-59f53bd-20240712124925
+      image: sdshmctspublic.azurecr.io/juror/api:pr-590-95fd00a-20240715131301
       ingressHost: juror-api.ithc.platform.hmcts.net
       environment:
         EMPTY_VAR: one


### PR DESCRIPTION
### Change description ###
Initial lock of juror-api in ithc to PR-590

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


### apps/juror/juror-api/ithc.yaml
- Updated the image value to `sdshmctspublic.azurecr.io/juror/api:pr-590-95fd00a-20240715131301` and removed the `EMPTY_VAR` environment variable.