### PR TITLE
DMP-3354 temporarily stop darts gateway staging

### DIFF
--- a/apps/darts-modernisation/darts-gateway/stg.yaml
+++ b/apps/darts-modernisation/darts-gateway/stg.yaml
@@ -7,6 +7,7 @@ spec:
   releaseName: darts-gateway
   values:
     java:
+      replicas: 0
       ingressHost: darts-gateway.staging.platform.hmcts.net
       environment:
         DARTS_API_URL: https://darts-api.staging.platform.hmcts.net


### PR DESCRIPTION
temporarily stop darts gateway staging to QA https://tools.hmcts.net/jira/browse/DMP-3354


## 🤖AEP PR SUMMARY🤖


### File Changed: stg.yaml
- Added a new configuration for the `darts-gateway` to manage replicas.
- Updated the `ingressHost` to `darts-gateway.staging.platform.hmcts.net`.
- Updated the `DARTS_API_URL` to `https://darts-api.staging.platform.hmcts.net`.