### PR TITLE
Revert " temporarily stop darts gateway staging (#5019) (#5028)"

### DIFF
--- a/apps/darts-modernisation/darts-gateway/stg.yaml
+++ b/apps/darts-modernisation/darts-gateway/stg.yaml
@@ -7,7 +7,6 @@ spec:
   releaseName: darts-gateway
   values:
     java:
-      replicas: 0
       ingressHost: darts-gateway.staging.platform.hmcts.net
       environment:
         DARTS_API_URL: https://darts-api.staging.platform.hmcts.net


### PR DESCRIPTION
This reverts commit 926d5055b33bea06faa99415c720d42593c3234c.

### Change description ###
re-starting darts gateway on stg


## 🤖AEP PR SUMMARY🤖


### apps/darts-modernisation/darts-gateway/stg.yaml
- Removed one of the replicas for the `java` service.
- Updated the `ingressHost` to `darts-gateway.staging.platform.hmcts.net`.
- Set the `DARTS_API_URL` environment variable to `https://darts-api.staging.platform.hmcts.net`.