### PR TITLE
 DMP-3354 temporarily stopping darts gateway on stg

### DIFF
--- a/apps/darts-modernisation/darts-gateway/stg.yaml
+++ b/apps/darts-modernisation/darts-gateway/stg.yaml
@@ -7,6 +7,7 @@ spec:
   releaseName: darts-gateway
   values:
     java:
+      replicas: 0
       ingressHost: darts-gateway.staging.platform.hmcts.net
       environment:
         DARTS_API_URL: https://darts-api.staging.platform.hmcts.net


### PR DESCRIPTION
### Change description ###

needed to QA DMP-3354


## 🤖AEP PR SUMMARY🤖


### apps/darts-modernisation/darts-gateway/stg.yaml
- Added `replicas: 0` under `java` values.
- Added `ingressHost: darts-gateway.staging.platform.hmcts.net` under `values`.