### PR TITLE
NOJIRA stop darts gateway stg

### DIFF
--- a/apps/darts-modernisation/darts-gateway/stg.yaml
+++ b/apps/darts-modernisation/darts-gateway/stg.yaml
@@ -7,6 +7,7 @@ spec:
   releaseName: darts-gateway
   values:
     java:
+      replicas: 0
       ingressHost: darts-gateway.staging.platform.hmcts.net
       environment:
         DARTS_API_URL: https://darts-api.staging.platform.hmcts.net


### PR DESCRIPTION


## 🤖AEP PR SUMMARY🤖


- **stg.yaml**
  - Added a new configuration for the `java` part, setting `replicas` to 0.
  - Modified the `ingressHost` to `darts-gateway.staging.platform.hmcts.net`.