### PR TITLE
Enable the clean endpoint in test gateway

### DIFF
--- a/apps/darts-modernisation/darts-gateway/test.yaml
+++ b/apps/darts-modernisation/darts-gateway/test.yaml
@@ -15,3 +15,4 @@ spec:
         ACTIVE_DIRECTORY_B2C_AUTH_URI: https://hmctsstgextid.b2clogin.com/hmctsstgextid.onmicrosoft.com
         ACTIVE_DIRECTORY_B2C_ON_MICROSOFT_URI: https://hmctsstgextid.onmicrosoft.com
         APPLICATIONINSIGHTS_INSTRUMENTATION_LOGGING_LEVEL: ALL
+        TESTING_SUPPORT_ENDPOINTS_ENABLED: true


### PR DESCRIPTION
### Jira link (if applicable)

N/A

### Change description ###

Enable the clean test endpoint on the test darts gateway deployment. This endpoint is required for performance testing the gateway.

## 🤖AEP PR SUMMARY🤖


- Updated `test.yaml`: Added `TESTING_SUPPORT_ENDPOINTS_ENABLED: true` and modified `APPLICATIONINSIGHTS_INSTRUMENTATION_LOGGING_LEVEL` from `ALL` to `ALL` 🚀