### PR TITLE
 NOJIRA start darts gateway

### DIFF
--- a/apps/darts-modernisation/darts-gateway/stg.yaml
+++ b/apps/darts-modernisation/darts-gateway/stg.yaml
@@ -7,7 +7,6 @@ spec:
   releaseName: darts-gateway
   values:
     java:
-      replicas: 0
       ingressHost: darts-gateway.staging.platform.hmcts.net
       environment:
         DARTS_API_URL: https://darts-api.staging.platform.hmcts.net


### PR DESCRIPTION


## 🤖AEP PR SUMMARY🤖


### apps/darts-modernisation/darts-gateway/stg.yaml
- Removed the `replicas: 0` configuration for the `java` component.
- Updated the `ingressHost` to `darts-gateway.staging.platform.hmcts.net`.
- Set the `DARTS_API_URL` environment variable to `https://darts-api.staging.platform.hmcts.net`.