### PR TITLE
Rename Opal Auth service to Opal user service

### DIFF
--- a/apps/opal/automation/kustomization.yaml
+++ b/apps/opal/automation/kustomization.yaml
@@ -5,8 +5,8 @@ resources:
   - ../opal-fines-service/image-policy.yaml
   - ../opal-frontend/image-repo.yaml
   - ../opal-frontend/image-policy.yaml
-  - ../opal-auth-service/image-repo.yaml
-  - ../opal-auth-service/image-policy.yaml
+  - ../opal-user-service/image-repo.yaml
+  - ../opal-user-service/image-policy.yaml
   - ../opal-file-handler/image-repo.yaml
   - ../opal-file-handler/image-policy.yaml
   - ../opal-external-api/image-repo.yaml

--- a/apps/opal/opal-user-service/image-policy.yaml
+++ b/apps/opal/opal-user-service/image-policy.yaml
@@ -1,7 +1,7 @@
 apiVersion: image.toolkit.fluxcd.io/v1beta1
 kind: ImagePolicy
 metadata:
-  name: opal-auth-service
+  name: opal-user-service
 spec:
   imageRepositoryRef:
-    name: opal-auth-service
+    name: opal-user-service

--- a/apps/opal/opal-user-service/image-repo.yaml
+++ b/apps/opal/opal-user-service/image-repo.yaml
@@ -1,6 +1,6 @@
 apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImageRepository
 metadata:
-  name: opal-auth-service
+  name: opal-user-service
 spec:
-  image: sdshmctspublic.azurecr.io/opal/auth-service
+  image: sdshmctspublic.azurecr.io/opal/user-service

--- a/apps/opal/opal-user-service/opal-user-service.yaml
+++ b/apps/opal/opal-user-service/opal-user-service.yaml
@@ -1,13 +1,13 @@
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
-  name: opal-auth-service
+  name: opal-user-service
   namespace: opal
 spec:
-  releaseName: opal-auth-service
+  releaseName: opal-user-service
   chart:
     spec:
-      chart: ./stable/opal-auth-service
+      chart: ./stable/opal-user-service
       sourceRef:
         kind: GitRepository
         name: hmcts-charts
@@ -15,5 +15,5 @@ spec:
       interval: 1m
   values:
     java:
-      image: sdshmctspublic.azurecr.io/opal/auth-service
+      image: sdshmctspublic.azurecr.io/opal/user-service
       disableTraefikTls: true

--- a/apps/opal/opal-user-service/stg.yaml
+++ b/apps/opal/opal-user-service/stg.yaml
@@ -1,13 +1,13 @@
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
-  name: opal-auth-service
+  name: opal-user-service
   namespace: opal
 spec:
-  releaseName: opal-auth-service
+  releaseName: opal-user-service
   values:
     java:
-      ingressHost: opal-auth-service.staging.platform.hmcts.net
+      ingressHost: opal-user-service.staging.platform.hmcts.net
       environment:
         DUMMY_VAR: 0
         OPAL_FRONTEND_URL: https://opal-frontend.staging.platform.hmcts.net

--- a/apps/opal/stg/base/kustomization.yaml
+++ b/apps/opal/stg/base/kustomization.yaml
@@ -4,7 +4,7 @@ resources:
   - ../../base
   - ../../../rbac/nonprod-role.yaml
   - ../../opal-fines-service/opal-fines-service.yaml
-  - ../../opal-auth-service/opal-auth-service.yaml
+  - ../../opal-user-service/opal-user-service.yaml
   - ../../opal-file-handler/opal-file-handler.yaml
   - ../../opal-external-api/opal-external-api.yaml
   - ../../opal-frontend/opal-frontend.yaml
@@ -15,7 +15,7 @@ namespace: opal
 patches:
   - path: ../../serviceaccount/stg.yaml
   - path: ../../opal-fines-service/stg.yaml
-  - path: ../../opal-auth-service/stg.yaml
+  - path: ../../opal-user-service/stg.yaml
   - path: ../../opal-file-handler/stg.yaml
   - path: ../../opal-external-api/stg.yaml
   - path: ../../opal-frontend/stg.yaml


### PR DESCRIPTION

### Change description ###
Rename Opal Auth service to Opal user service

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change






## 🤖AEP PR SUMMARY🤖


- Updated `kustomization.yaml` in `apps/opal/automation/`
  - Renamed image repository and image policy for `opal-auth-service` to `opal-user-service`

- Renamed `image-policy.yaml` and `image-repo.yaml` in `apps/opal/opal-auth-service` to `image-policy.yaml` and `image-repo.yaml` respectively under `opal-user-service`

- Renamed `opal-auth-service.yaml` and `stg.yaml` in `apps/opal/opal-auth-service` to `opal-user-service.yaml` and `stg.yaml` respectively under `opal-user-service`

- Updated `kustomization.yaml` in `apps/opal/stg/base/`
  - Updated the reference from `opal-auth-service` to `opal-user-service`