### PR TITLE
dmp-2526: update PROD config for Azure AD B2C

### DIFF
--- a/apps/darts-modernisation/darts-api/prod.yaml
+++ b/apps/darts-modernisation/darts-api/prod.yaml
@@ -14,8 +14,8 @@ spec:
         DARTS_LOG_LEVEL: INFO
         RESTART_ME: '007'
         ARM_PROPERTY_FILE_ENVIRONMENT: live
-        ACTIVE_DIRECTORY_B2C_BASE_URI: https://hmctsextid.b2clogin.com
-        ACTIVE_DIRECTORY_B2C_AUTH_URI: https://hmctsextid.b2clogin.com/hmctsextid.onmicrosoft.com
+        ACTIVE_DIRECTORY_B2C_BASE_URI: https://hmctsprodextid.b2clogin.com
+        ACTIVE_DIRECTORY_B2C_AUTH_URI: https://hmctsprodextid.b2clogin.com/hmctsprodextid.onmicrosoft.com
         ARM_URL: https://www.court-tribunal-records-archive.service.justice.gov.uk
       pdb:
         enabled: false

--- a/apps/darts-modernisation/darts-gateway/prod.yaml
+++ b/apps/darts-modernisation/darts-gateway/prod.yaml
@@ -12,8 +12,8 @@ spec:
         DARTS_API_URL: https://darts-api.platform.hmcts.net
         DARTS_LOG_LEVEL: INFO
         DAR_NOTIFY_ENABLED: true
-        ACTIVE_DIRECTORY_B2C_BASE_URI: https://hmctsextid.b2clogin.com
-        ACTIVE_DIRECTORY_B2C_AUTH_URI: https://hmctsextid.b2clogin.com/hmctsextid.onmicrosoft.com
-        ACTIVE_DIRECTORY_B2C_ON_MICROSOFT_URI: https://hmctsextid.onmicrosoft.com
+        ACTIVE_DIRECTORY_B2C_BASE_URI: https://hmctsprodextid.b2clogin.com
+        ACTIVE_DIRECTORY_B2C_AUTH_URI: https://hmctsprodextid.b2clogin.com/hmctsprodextid.onmicrosoft.com
+        ACTIVE_DIRECTORY_B2C_ON_MICROSOFT_URI: https://hmctsprodextid.onmicrosoft.com
       pdb:
         enabled: false

--- a/apps/darts-modernisation/darts-portal/prod.yaml
+++ b/apps/darts-modernisation/darts-portal/prod.yaml
@@ -11,4 +11,4 @@ spec:
       environment:
         DARTS_API_URL: https://darts-api.platform.hmcts.net
         DARTS_PORTAL_URL: https://darts.apps.hmcts.net
-        DARTS_AZUREAD_B2C_ORIGIN_HOST: https://hmctsextid.b2clogin.com
+        DARTS_AZUREAD_B2C_ORIGIN_HOST: https://hmctsprodextid.b2clogin.com


### PR DESCRIPTION
### Jira link (if applicable)

DMP-2526

### Change description ###
Updated PROD Azure Ad B2C configs

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


- `prod.yaml`:
  - Changed the `ACTIVE_DIRECTORY_B2C_BASE_URI` and `ACTIVE_DIRECTORY_B2C_AUTH_URI` from the old URLs to the new URLs.
  - Updated the `ACTIVE_DIRECTORY_B2C_ON_MICROSOFT_URI` to the new URL.
  - Updated the `DARTS_AZUREAD_B2C_ORIGIN_HOST` to a new URL.