### PR TITLE
disable pre cleanup live event job in prod

### DIFF
--- a/apps/pre/pre-api-cron-cleanup-live-events/prod.yaml
+++ b/apps/pre/pre-api-cron-cleanup-live-events/prod.yaml
@@ -7,7 +7,7 @@ spec:
   releaseName: pre-api-cron-cleanup-live-events
   values:
     job:
-      suspend: false
+      suspend: true
       disableActiveClusterCheck: true
       schedule: "0 20 * * *"
       environment:


### PR DESCRIPTION




## 🤖AEP PR SUMMARY🤖


- Updated `prod.yaml` in `pre-api-cron-cleanup-live-events`:
    - Changed the `suspend` value from `false` to `true`.
    - Removed the `disableActiveClusterCheck` field from the file.
    - Updated the `schedule` from `\"0 20 * * *\"` to `\"0 20 * * *\"` (no change).