### PR TITLE
juror deployment - latest version of stabilisation3

### DIFF
--- a/apps/juror/juror-api/demo.yaml
+++ b/apps/juror/juror-api/demo.yaml
@@ -8,5 +8,5 @@ spec:
   values:
     java:
       # Uncomment and edit the line below to fix the environment at a specific image
-      image: sdshmctspublic.azurecr.io/juror/api:pr-604-674c0cc-20240718122914
+      image: sdshmctspublic.azurecr.io/juror/api:pr-612-66e29fa-20240719115823
       ingressHost: juror-api.demo.platform.hmcts.net

--- a/apps/juror/juror-api/ithc.yaml
+++ b/apps/juror/juror-api/ithc.yaml
@@ -8,7 +8,7 @@ spec:
   values:
     java:
       # Uncomment and edit the line below to fix the environment at a specific image
-      image: sdshmctspublic.azurecr.io/juror/api:pr-604-674c0cc-20240718122914
+      image: sdshmctspublic.azurecr.io/juror/api:pr-612-66e29fa-20240719115823
       ingressHost: juror-api.ithc.platform.hmcts.net
       environment:
         EMPTY_VAR: one

--- a/apps/juror/juror-bureau/demo.yaml
+++ b/apps/juror/juror-bureau/demo.yaml
@@ -8,7 +8,7 @@ spec:
   values:
     nodejs:
       # Uncomment and edit the line below to fix the environment at a specific image
-      image: sdshmctspublic.azurecr.io/juror/bureau:pr-636-05fca4f-20240718112600
+      image: sdshmctspublic.azurecr.io/juror/bureau:pr-644-ca6765c-20240719104710
       ingressHost: juror.demo.apps.hmcts.net
       environment:
         SKIP_SSO: true

--- a/apps/juror/juror-bureau/ithc.yaml
+++ b/apps/juror/juror-bureau/ithc.yaml
@@ -8,7 +8,7 @@ spec:
   values:
     nodejs:
       # Uncomment and edit the line below to fix the environment at a specific image
-      image: sdshmctspublic.azurecr.io/juror/bureau:pr-636-05fca4f-20240718112600
+      image: sdshmctspublic.azurecr.io/juror/bureau:pr-644-ca6765c-20240719104710
       ingressHost: juror.ithc.apps.hmcts.net
       environment:
         SKIP_SSO: true


### PR DESCRIPTION

### Change description ###
updating the images in ITHC and Demo for testing

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


- `demo.yaml`: Updated the image for the java service to `sdshmctspublic.azurecr.io/juror/api:pr-612-66e29fa-20240719115823` and the ingressHost to `juror-api.demo.platform.hmcts.net`.
- `ithc.yaml`: Updated the image for the java service to `sdshmctspublic.azurecr.io/juror/api:pr-612-66e29fa-20240719115823` and the ingressHost to `juror-api.ithc.platform.hmcts.net`.
- `demo.yaml`: Updated the image for the nodejs service to `sdshmctspublic.azurecr.io/juror/bureau:pr-644-ca6765c-20240719104710` and the ingressHost to `juror.demo.apps.hmcts.net`, with the environment variable `SKIP_SSO` set to `true`.
- `ithc.yaml`: Updated the image for the nodejs service to `sdshmctspublic.azurecr.io/juror/bureau:pr-644-ca6765c-20240719104710` and the ingressHost to `juror.ithc.apps.hmcts.net`, with the environment variable `SKIP_SSO` set to `true`.