### PR TITLE
update juror-api

### DIFF
--- a/apps/juror/juror-api/demo.yaml
+++ b/apps/juror/juror-api/demo.yaml
@@ -8,5 +8,5 @@ spec:
   values:
     java:
       # Uncomment and edit the line below to fix the environment at a specific image
-      image: sdshmctspublic.azurecr.io/juror/api:pr-612-66e29fa-20240719115823
+      image: sdshmctspublic.azurecr.io/juror/api:pr-612-4f29272-20240719162304
       ingressHost: juror-api.demo.platform.hmcts.net

--- a/apps/juror/juror-api/ithc.yaml
+++ b/apps/juror/juror-api/ithc.yaml
@@ -8,7 +8,7 @@ spec:
   values:
     java:
       # Uncomment and edit the line below to fix the environment at a specific image
-      image: sdshmctspublic.azurecr.io/juror/api:pr-612-66e29fa-20240719115823
+      image: sdshmctspublic.azurecr.io/juror/api:pr-612-4f29272-20240719162304
       ingressHost: juror-api.ithc.platform.hmcts.net
       environment:
         EMPTY_VAR: one


### PR DESCRIPTION
### Change description ###
update juror-api in ITHC and DEMO for testing Stabilisation3 branch

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


- Updated `demo.yaml` and `ithc.yaml` in `apps/juror/juror-api/`:
  - Changed the image version from `pr-612-66e29fa-20240719115823` to `pr-612-4f29272-20240719162304` for the `java` values.
  - Updated the `ingressHost` for both environments.