### PR TITLE
updated deployment of stabilisation3 juror-api

### DIFF
--- a/apps/juror/juror-api/demo.yaml
+++ b/apps/juror/juror-api/demo.yaml
@@ -8,5 +8,5 @@ spec:
   values:
     java:
       # Uncomment and edit the line below to fix the environment at a specific image
-      image: sdshmctspublic.azurecr.io/juror/api:pr-612-54a70b2-20240722111907
+      image: sdshmctspublic.azurecr.io/juror/api:pr-612-04a4647-20240722131513
       ingressHost: juror-api.demo.platform.hmcts.net


### PR DESCRIPTION

### Change description ###

Updated deployment of stabilisation3 for juror-api, taking out the index creation steps to reduce deployment time in prod

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ x] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


### apps/juror/juror-api/demo.yaml
- Updated the `image` value for Java to `sdshmctspublic.azurecr.io/juror/api:pr-612-04a4647-20240722131513`.