### PR TITLE
Grant pod metrics access to readers

### DIFF
--- a/apps/rbac/reader-clusterrole.yaml
+++ b/apps/rbac/reader-clusterrole.yaml
@@ -45,6 +45,9 @@ rules:
 - apiGroups: ['kustomize.toolkit.fluxcd.io']
   resources: ['kustomizations']
   verbs: ['watch', 'list', 'get']
+- apiGroups: ['metrics.k8s.io']
+  resources: ['pods']
+  verbs: ['watch', 'list', 'get']
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
### Change description ###
To support devs being able to `top pod` for example. This is already enabled in `cnp-flux-config`.


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
