### PR TITLE
Ugpgrade dynatrace in ss-demo

### DIFF
--- a/apps/dynatrace/demo/base/kustomization.yaml
+++ b/apps/dynatrace/demo/base/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
 namespace: dynatrace
 patches:
   - path: dynakube.yaml
+  - path: ../../dynatrace-operator-upgrade.yaml

--- a/apps/dynatrace/dynatrace-crds-upgrade/kustomization.yaml
+++ b/apps/dynatrace/dynatrace-crds-upgrade/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - https://github.com/Dynatrace/dynatrace-operator/releases/download/v1.2.1/dynatrace-operator-crd.yaml

--- a/apps/dynatrace/dynatrace-operator-upgrade.yaml
+++ b/apps/dynatrace/dynatrace-operator-upgrade.yaml
@@ -1,4 +1,3 @@
-
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/apps/dynatrace/dynatrace-operator-upgrade.yaml
+++ b/apps/dynatrace/dynatrace-operator-upgrade.yaml
@@ -1,0 +1,14 @@
+
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: dynatrace-operator
+  namespace: dynatrace
+spec:
+  releaseName: dynatrace-operator
+  interval: 5m
+  chart:
+    spec:
+      chart: dynatrace-operator
+      # update the CRDs in dynatrace-crds when changing this value
+      version: 1.2.1

--- a/clusters/demo/base/kustomization.yaml
+++ b/clusters/demo/base/kustomization.yaml
@@ -23,3 +23,4 @@ patches:
   - path: ../../../apps/toffee/demo/base/kustomize.yaml
   - path: ../../../apps/admin/demo/base/kustomize.yaml
   - path: ../../../apps/admin/traefik-crds-upgrade-v27.0.2/kustomize.yaml
+  - path: ../../../apps/dynatrace/base/kustomize-upgrade.yaml


### PR DESCRIPTION
1.1.0 has this bug
```
Helm install failed for release dynatrace/dynatrace-operator with chart dynatrace-operator@1.1.0: Unable to continue with install: CustomResourceDefinition "dynakubes.dynatrace.com" in namespace "" exists and cannot be imported into the current release: invalid ownership metadata; label validation error: missing key "app.kubernetes.io/managed-by": must be set to "Helm"; annotation validation error: missing key "meta.helm.sh/release-name": must be set to "dynatrace-operator"; annotation validation error: missing key "meta.helm.sh/release-namespace": must be set to "dynatrace"
```
https://github.com/Dynatrace/dynatrace-operator/issues/3215

Don't see it mentioned in release notes.. but a pr for it was merged a while back so it should be in the latest release

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change






## 🤖AEP PR SUMMARY🤖


### apps/dynatrace/demo/base/kustomization.yaml
- Added a path to dynatrace-operator-upgrade.yaml file.
  
### apps/dynatrace/dynatrace-crds-upgrade/kustomization.yaml
- Added a new file that specifies the resource for the Dynatrace operator upgrade.

### apps/dynatrace/dynatrace-operator-upgrade.yaml
- Added the HelmRelease for dynatrace-operator with version 1.2.1 and a 5 minutes renewal interval.

### clusters/demo/base/kustomization.yaml
- Added a path to apps/dynatrace/base/kustomize-upgrade.yaml for upgrade.