### PR TITLE
DTSPO-15798 - toffee sbox: Add working slack-token, alerts to error severity again

### DIFF
--- a/apps/base/alert.yaml
+++ b/apps/base/alert.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
   providerRef:
     name: slack
-  eventSeverity: info
+  eventSeverity: error
   eventSources:
     - kind: Kustomization
       namespace: flux-system

--- a/apps/darts-modernisation/darts-portal/darts-portal.yaml
+++ b/apps/darts-modernisation/darts-portal/darts-portal.yaml
@@ -15,5 +15,5 @@ spec:
   values:
     nodejs:
       replicas: 2
-      image: sdshmctspublic.azurecr.io/darts/portal:prod-5c8e008-20240725095430 # {"$imagepolicy": "flux-system:darts-portal"}
+      image: sdshmctspublic.azurecr.io/darts/portal:prod-f003cc1-20240725104651 # {"$imagepolicy": "flux-system:darts-portal"}
       disableTraefikTls: true

--- a/apps/toffee/sbox/base/slack-token.enc.yaml
+++ b/apps/toffee/sbox/base/slack-token.enc.yaml
@@ -1,0 +1,25 @@
+apiVersion: v1
+data:
+    token: ENC[AES256_GCM,data:OzXyN7YPdulBv4YYyIfWcb4SGQ9e1uNVooUETrbhPOsUzkl3T0S1g3ut2DE89H7+d6mxA+WChuj6/ZLBh01TZFjB9DF23kj20GzaTA==,iv:0A5I2OvdsHsaxXbz6n04MaNXekAQx/pHDscCvaBb8wc=,tag:6ok2ru5QwF0Wqlq6MH7qHA==,type:str]
+kind: Secret
+metadata:
+    creationTimestamp: null
+    name: slack-token
+    namespace: toffee
+type: Opaque
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv:
+        - vault_url: https://dtssharedservicessboxkv.vault.azure.net
+          name: sops-key
+          version: 743d27d4b20644a6bd1936f3e55d1db3
+          created_at: "2024-07-25T11:15:10Z"
+          enc: k92vPc66XD2U6_A8JV9voxGuDrq0qPMk0szMhOPWXvq9Lij8d0xUo0VscLbkXJGgnoH-_toKbRA2Pb8wZdGhE4m6Bofw5RtLry2eU0HpbpTTg_SvlA_UXk2as8mcMD1k1EOQvOQltG5_GxtDZRmIOtiPcPYCFEda4flyqOtHL3pCDzwCmh33yCH0x0IbSnG0OdQxXNGDZ2qz86EytaaHB7TCFaMq8x4hK83j_ly-BnuGaSdRwPUX7KsGZSY-K6plzMkKM5j1WA8J6Wq8YoquO835IDcRuMxG9sf1D2u__uf6bxkHmOs3heLrApOcRDhXkzAL9Zyk2VXU3ImJy-fT2Q
+    hc_vault: []
+    age: []
+    lastmodified: "2024-07-25T11:15:11Z"
+    mac: ENC[AES256_GCM,data:xtdE9ZTjt5tgBJvgjfZJ8XmFWBcpHJlKhkhfumGTeToq5crhaYvelYu+etPh4eLRWhtEJ3Sk5IZWJGzG1TqHMl+nPqDGRZ4BzJmAcqH+YoGgldnz6Pfr+D4F1uOsDVsBmQeE9CoxpUfpBZomu1d0DSxDkHjB9rQDfAZxTWo6lrY=,iv:aWQ9wOfm/xbq8/fndEU8XGbthUkc+5d3XyLVvu4OqQc=,tag:xGK8SfX65vVUB+TN0nop1w==,type:str]
+    pgp: []
+    encrypted_regex: ^(data|stringData)$
+    version: 3.7.3

--- a/apps/toffee/sbox/base/slack-token.enc.yaml
+++ b/apps/toffee/sbox/base/slack-token.enc.yaml
@@ -1,25 +1,25 @@
 apiVersion: v1
 data:
-    token: ENC[AES256_GCM,data:OzXyN7YPdulBv4YYyIfWcb4SGQ9e1uNVooUETrbhPOsUzkl3T0S1g3ut2DE89H7+d6mxA+WChuj6/ZLBh01TZFjB9DF23kj20GzaTA==,iv:0A5I2OvdsHsaxXbz6n04MaNXekAQx/pHDscCvaBb8wc=,tag:6ok2ru5QwF0Wqlq6MH7qHA==,type:str]
+  token: ENC[AES256_GCM,data:OzXyN7YPdulBv4YYyIfWcb4SGQ9e1uNVooUETrbhPOsUzkl3T0S1g3ut2DE89H7+d6mxA+WChuj6/ZLBh01TZFjB9DF23kj20GzaTA==,iv:0A5I2OvdsHsaxXbz6n04MaNXekAQx/pHDscCvaBb8wc=,tag:6ok2ru5QwF0Wqlq6MH7qHA==,type:str]
 kind: Secret
 metadata:
-    creationTimestamp: null
-    name: slack-token
-    namespace: toffee
+  creationTimestamp: null
+  name: slack-token
+  namespace: toffee
 type: Opaque
 sops:
-    kms: []
-    gcp_kms: []
-    azure_kv:
-        - vault_url: https://dtssharedservicessboxkv.vault.azure.net
-          name: sops-key
-          version: 743d27d4b20644a6bd1936f3e55d1db3
-          created_at: "2024-07-25T11:15:10Z"
-          enc: k92vPc66XD2U6_A8JV9voxGuDrq0qPMk0szMhOPWXvq9Lij8d0xUo0VscLbkXJGgnoH-_toKbRA2Pb8wZdGhE4m6Bofw5RtLry2eU0HpbpTTg_SvlA_UXk2as8mcMD1k1EOQvOQltG5_GxtDZRmIOtiPcPYCFEda4flyqOtHL3pCDzwCmh33yCH0x0IbSnG0OdQxXNGDZ2qz86EytaaHB7TCFaMq8x4hK83j_ly-BnuGaSdRwPUX7KsGZSY-K6plzMkKM5j1WA8J6Wq8YoquO835IDcRuMxG9sf1D2u__uf6bxkHmOs3heLrApOcRDhXkzAL9Zyk2VXU3ImJy-fT2Q
-    hc_vault: []
-    age: []
-    lastmodified: "2024-07-25T11:15:11Z"
-    mac: ENC[AES256_GCM,data:xtdE9ZTjt5tgBJvgjfZJ8XmFWBcpHJlKhkhfumGTeToq5crhaYvelYu+etPh4eLRWhtEJ3Sk5IZWJGzG1TqHMl+nPqDGRZ4BzJmAcqH+YoGgldnz6Pfr+D4F1uOsDVsBmQeE9CoxpUfpBZomu1d0DSxDkHjB9rQDfAZxTWo6lrY=,iv:aWQ9wOfm/xbq8/fndEU8XGbthUkc+5d3XyLVvu4OqQc=,tag:xGK8SfX65vVUB+TN0nop1w==,type:str]
-    pgp: []
-    encrypted_regex: ^(data|stringData)$
-    version: 3.7.3
+  kms: []
+  gcp_kms: []
+  azure_kv:
+    - vault_url: https://dtssharedservicessboxkv.vault.azure.net
+      name: sops-key
+      version: 743d27d4b20644a6bd1936f3e55d1db3
+      created_at: "2024-07-25T11:15:10Z"
+      enc: k92vPc66XD2U6_A8JV9voxGuDrq0qPMk0szMhOPWXvq9Lij8d0xUo0VscLbkXJGgnoH-_toKbRA2Pb8wZdGhE4m6Bofw5RtLry2eU0HpbpTTg_SvlA_UXk2as8mcMD1k1EOQvOQltG5_GxtDZRmIOtiPcPYCFEda4flyqOtHL3pCDzwCmh33yCH0x0IbSnG0OdQxXNGDZ2qz86EytaaHB7TCFaMq8x4hK83j_ly-BnuGaSdRwPUX7KsGZSY-K6plzMkKM5j1WA8J6Wq8YoquO835IDcRuMxG9sf1D2u__uf6bxkHmOs3heLrApOcRDhXkzAL9Zyk2VXU3ImJy-fT2Q
+  hc_vault: []
+  age: []
+  lastmodified: "2024-07-25T11:15:11Z"
+  mac: ENC[AES256_GCM,data:xtdE9ZTjt5tgBJvgjfZJ8XmFWBcpHJlKhkhfumGTeToq5crhaYvelYu+etPh4eLRWhtEJ3Sk5IZWJGzG1TqHMl+nPqDGRZ4BzJmAcqH+YoGgldnz6Pfr+D4F1uOsDVsBmQeE9CoxpUfpBZomu1d0DSxDkHjB9rQDfAZxTWo6lrY=,iv:aWQ9wOfm/xbq8/fndEU8XGbthUkc+5d3XyLVvu4OqQc=,tag:xGK8SfX65vVUB+TN0nop1w==,type:str]
+  pgp: []
+  encrypted_regex: ^(data|stringData)$
+  version: 3.7.3


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DTSPO-15798


### Change description ###

- add working slack-token
- increase severity for alerts to error again


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change




## 🤖AEP PR SUMMARY🤖


- Modified `alert.yaml` in `apps/base`:
  - Changed `eventSeverity` from `info` to `error`.

- Added `slack-token.enc.yaml` to `apps/toffee/sbox/base`:
  - Contains encrypted Slack token information as a Kubernetes Secret.
  - Includes creation and modification timestamps.