### PR TITLE
Attempt DynaKube v1beta1 again sds-demo

### DIFF
--- a/apps/dynatrace/demo/base/dynakube.yaml
+++ b/apps/dynatrace/demo/base/dynakube.yaml
@@ -1,4 +1,4 @@
-apiVersion: dynatrace.com/v1beta2
+apiVersion: dynatrace.com/v1beta1
 kind: DynaKube
 metadata:
   name: dynakube

--- a/apps/dynatrace/dynakube-upgrade.yaml
+++ b/apps/dynatrace/dynakube-upgrade.yaml
@@ -10,8 +10,6 @@ metadata:
 spec:
   apiUrl: https://ENVIRONMENTID.live.dynatrace.com/api
   networkZone: azure.sds
-  conversion:
-    strategy: None
   namespaceSelector:
     matchExpressions:
       - key: kubernetes.io/metadata.name

--- a/apps/dynatrace/dynakube-upgrade.yaml
+++ b/apps/dynatrace/dynakube-upgrade.yaml
@@ -10,16 +10,16 @@ metadata:
 spec:
   apiUrl: https://ENVIRONMENTID.live.dynatrace.com/api
   networkZone: azure.sds
-  metadataEnrichment:
-    enabled: true
-    namespaceSelector:
-      matchExpressions:
-        - key: kubernetes.io/metadata.name
-          operator: NotIn
-          values:
-            - mi
-            - mailrelay2
-            - monitoring
+  conversion:
+    strategy: None
+  namespaceSelector:
+    matchExpressions:
+      - key: kubernetes.io/metadata.name
+        operator: NotIn
+        values:
+          - mi
+          - mailrelay2
+          - monitoring
   oneAgent:
     cloudNativeFullStack:
       priorityClassName: system-node-critical

--- a/apps/dynatrace/dynakube-upgrade.yaml
+++ b/apps/dynatrace/dynakube-upgrade.yaml
@@ -1,5 +1,5 @@
 # from: https://github.com/Dynatrace/dynatrace-operator/blob/v0.9.1/assets/samples/cloudNativeFullStack.yaml
-apiVersion: dynatrace.com/v1beta2
+apiVersion: dynatrace.com/v1beta1
 kind: DynaKube
 metadata:
   name: dynakube


### PR DESCRIPTION
Try to force upgrade and get around broken kustomization

Moving to v1beta2 at the same time as 1.2.1 seems to give problems. Rolling this back first to see if the webhook conversion service will no longer be needed to try and get some pods deployed. After that, can try to re-upgrade 🤦🏻 




<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change












## 🤖AEP PR SUMMARY🤖


- Updated `dynakube.yaml` 🔄: 
  - Changed `apiVersion` from `dynatrace.com/v1beta2` to `dynatrace.com/v1beta1`.
- Updated `dynakube-upgrade.yaml` 🔄: 
  - Changed `apiVersion` from `dynatrace.com/v1beta2` to `dynatrace.com/v1beta1`.
  - Updated the `metadataEnrichment` section within `spec`.