### PR TITLE
juror-api deployment of stabilisation5 in Demo and ITHC

### DIFF
--- a/apps/juror/juror-api/demo.yaml
+++ b/apps/juror/juror-api/demo.yaml
@@ -8,5 +8,5 @@ spec:
   values:
     java:
       # Uncomment and edit the line below to fix the environment at a specific image
-      image: sdshmctspublic.azurecr.io/juror/api:pr-644-6fea0e0-20240725161921
+      image: sdshmctspublic.azurecr.io/juror/api:pr-644-bcd5d4f-20240726130544
       ingressHost: juror-api.demo.platform.hmcts.net

--- a/apps/juror/juror-api/ithc.yaml
+++ b/apps/juror/juror-api/ithc.yaml
@@ -8,7 +8,7 @@ spec:
   values:
     java:
       # Uncomment and edit the line below to fix the environment at a specific image
-      image: sdshmctspublic.azurecr.io/juror/api:pr-644-6fea0e0-20240725161921
+      image: sdshmctspublic.azurecr.io/juror/api:pr-644-bcd5d4f-20240726130544
       ingressHost: juror-api.ithc.platform.hmcts.net
       environment:
         EMPTY_VAR: one


### PR DESCRIPTION
### Jira link (if applicable)



### Change description ###

Juror api deployment of stabilisation5 branch into ITHC and Demo

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


### Changes in `demo.yaml`
- Updated the Java image from `sdshmctspublic.azurecr.io/juror/api:pr-644-6fea0e0-20240725161921` to `sdshmctspublic.azurecr.io/juror/api:pr-644-bcd5d4f-20240726130544`
- Modified the `ingressHost` to `juror-api.demo.platform.hmcts.net`

### Changes in `ithc.yaml`
- Updated the Java image from `sdshmctspublic.azurecr.io/juror/api:pr-644-6fea0e0-20240725161921` to `sdshmctspublic.azurecr.io/juror/api:pr-644-bcd5d4f-20240726130544`
- Added `EMPTY_VAR: one` to the environment