### PR TITLE
DMP-3365: Setting MODERNISED_DARTS_START_DATE for prod

### DIFF
--- a/apps/darts-modernisation/darts-api/prod.yaml
+++ b/apps/darts-modernisation/darts-api/prod.yaml
@@ -17,6 +17,7 @@ spec:
         ACTIVE_DIRECTORY_B2C_BASE_URI: https://hmctsprodextid.b2clogin.com
         ACTIVE_DIRECTORY_B2C_AUTH_URI: https://hmctsprodextid.b2clogin.com/hmctsprodextid.onmicrosoft.com
         ARM_URL: https://www.court-tribunal-records-archive.service.justice.gov.uk
+        MODERNISED_DARTS_START_DATE: 2099-01-01 # MODERNISED_DARTS_START_DATE to be updated before go-live
       pdb:
         enabled: false
     function:


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DMP-3365

Setting MODERNISED_DARTS_START_DATE for prod

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change




## 🤖AEP PR SUMMARY🤖


### apps/darts-modernisation/darts-api/prod.yaml
- Added MODERNISED_DARTS_START_DATE with value 2099-01-01 🚀