### PR TITLE
Juror deployments

### DIFF
--- a/apps/juror/juror-api/demo.yaml
+++ b/apps/juror/juror-api/demo.yaml
@@ -8,5 +8,5 @@ spec:
   values:
     java:
       # Uncomment and edit the line below to fix the environment at a specific image
-      image: sdshmctspublic.azurecr.io/juror/api:pr-655-3e9663d-20240730085827
+      image: sdshmctspublic.azurecr.io/juror/api:pr-665-2b00ea3-20240731122830
       ingressHost: juror-api.demo.platform.hmcts.net

--- a/apps/juror/juror-api/demo.yaml
+++ b/apps/juror/juror-api/demo.yaml
@@ -8,5 +8,5 @@ spec:
   values:
     java:
       # Uncomment and edit the line below to fix the environment at a specific image
-      image: sdshmctspublic.azurecr.io/juror/api:pr-649-194b76a-20240729130217
+      image: sdshmctspublic.azurecr.io/juror/api:pr-655-3e9663d-20240730085827
       ingressHost: juror-api.demo.platform.hmcts.net

--- a/apps/juror/juror-api/ithc.yaml
+++ b/apps/juror/juror-api/ithc.yaml
@@ -8,7 +8,7 @@ spec:
   values:
     java:
       # Uncomment and edit the line below to fix the environment at a specific image
-      image: sdshmctspublic.azurecr.io/juror/api:pr-655-3e9663d-20240730085827
+      image: sdshmctspublic.azurecr.io/juror/api:pr-665-2b00ea3-20240731122830
       ingressHost: juror-api.ithc.platform.hmcts.net
       environment:
         EMPTY_VAR: one

--- a/apps/juror/juror-api/ithc.yaml
+++ b/apps/juror/juror-api/ithc.yaml
@@ -8,7 +8,7 @@ spec:
   values:
     java:
       # Uncomment and edit the line below to fix the environment at a specific image
-      image: sdshmctspublic.azurecr.io/juror/api:pr-649-194b76a-20240729130217
+      image: sdshmctspublic.azurecr.io/juror/api:pr-655-3e9663d-20240730085827
       ingressHost: juror-api.ithc.platform.hmcts.net
       environment:
         EMPTY_VAR: one

--- a/apps/juror/juror-bureau/demo.yaml
+++ b/apps/juror/juror-bureau/demo.yaml
@@ -8,7 +8,7 @@ spec:
   values:
     nodejs:
       # Uncomment and edit the line below to fix the environment at a specific image
-      image: sdshmctspublic.azurecr.io/juror/bureau:pr-672-2b07f14-20240730095912
+      image: sdshmctspublic.azurecr.io/juror/bureau:pr-676-6e39ac1-20240731120558
       ingressHost: juror.demo.apps.hmcts.net
       environment:
         SKIP_SSO: true

--- a/apps/juror/juror-bureau/demo.yaml
+++ b/apps/juror/juror-bureau/demo.yaml
@@ -8,7 +8,7 @@ spec:
   values:
     nodejs:
       # Uncomment and edit the line below to fix the environment at a specific image
-      image: sdshmctspublic.azurecr.io/juror/bureau:pr-671-47f8b43-20240729125059
+      image: sdshmctspublic.azurecr.io/juror/bureau:pr-672-2b07f14-20240730095912
       ingressHost: juror.demo.apps.hmcts.net
       environment:
         SKIP_SSO: true

--- a/apps/juror/juror-bureau/ithc.yaml
+++ b/apps/juror/juror-bureau/ithc.yaml
@@ -8,7 +8,7 @@ spec:
   values:
     nodejs:
       # Uncomment and edit the line below to fix the environment at a specific image
-      image: sdshmctspublic.azurecr.io/juror/bureau:pr-672-2b07f14-20240730095912
+      image: sdshmctspublic.azurecr.io/juror/bureau:pr-676-6e39ac1-20240731120558
       ingressHost: juror.ithc.apps.hmcts.net
       environment:
         SKIP_SSO: true

--- a/apps/juror/juror-bureau/ithc.yaml
+++ b/apps/juror/juror-bureau/ithc.yaml
@@ -8,7 +8,7 @@ spec:
   values:
     nodejs:
       # Uncomment and edit the line below to fix the environment at a specific image
-      image: sdshmctspublic.azurecr.io/juror/bureau:pr-671-47f8b43-20240729125059
+      image: sdshmctspublic.azurecr.io/juror/bureau:pr-672-2b07f14-20240730095912
       ingressHost: juror.ithc.apps.hmcts.net
       environment:
         SKIP_SSO: true

--- a/apps/juror/juror-scheduler-api/ithc.yaml
+++ b/apps/juror/juror-scheduler-api/ithc.yaml
@@ -8,5 +8,5 @@ spec:
   values:
     java:
       # Uncomment and edit the line below to fix the environment at a specific image
-      # image: sdshmctspublic.azurecr.io/juror/scheduler-api:prod-85f5605-20240618074137
+      image: sdshmctspublic.azurecr.io/juror/scheduler-api:pr-228-b0108b6-20240730090229
       ingressHost: juror-scheduler-api.ithc.platform.hmcts.net


### PR DESCRIPTION
### Jira link (if applicable)



### Change description ###

Stabilisation7 deployment into ITHC and Demo for juror-api and juror-bureau

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change




## 🤖AEP PR SUMMARY🤖


### apps/juror/juror-api/demo.yaml
- Updated the image version to `pr-665-2b00ea3-20240731122830` and the `ingressHost` to `juror-api.demo.platform.hmcts.net`.

### apps/juror/juror-api/ithc.yaml
- Updated the image version to `pr-665-2b00ea3-20240731122830` and the `ingressHost` to `juror-api.ithc.platform.hmcts.net`.

### apps/juror/juror-bureau/demo.yaml
- Updated the image version to `pr-676-6e39ac1-20240731120558` and the `ingressHost` to `juror.demo.apps.hmcts.net`.

### apps/juror/juror-bureau/ithc.yaml
- Updated the image version to `pr-676-6e39ac1-20240731120558` and the `ingressHost` to `juror.ithc.apps.hmcts.net`.