### PR TITLE
stabilisation8 update for juror

### DIFF
--- a/apps/juror/juror-api/demo.yaml
+++ b/apps/juror/juror-api/demo.yaml
@@ -8,7 +8,7 @@ spec:
   values:
     java:
       # Uncomment and edit the line below to fix the environment at a specific image
-      image: sdshmctspublic.azurecr.io/juror/api:pr-665-16cd22a-20240731143058
+      image: sdshmctspublic.azurecr.io/juror/api:pr-673-2fe09ea-20240801144016
       ingressHost: juror-api.demo.platform.hmcts.net
       environment:
         RUN_DB_MIGRATION_ON_STARTUP: true

--- a/apps/juror/juror-api/ithc.yaml
+++ b/apps/juror/juror-api/ithc.yaml
@@ -8,7 +8,7 @@ spec:
   values:
     java:
       # Uncomment and edit the line below to fix the environment at a specific image
-      image: sdshmctspublic.azurecr.io/juror/api:pr-665-16cd22a-20240731143058
+      image: sdshmctspublic.azurecr.io/juror/api:pr-673-2fe09ea-20240801144016
       ingressHost: juror-api.ithc.platform.hmcts.net
       environment:
         RUN_DB_MIGRATION_ON_STARTUP: true

--- a/apps/juror/juror-bureau/demo.yaml
+++ b/apps/juror/juror-bureau/demo.yaml
@@ -8,7 +8,7 @@ spec:
   values:
     nodejs:
       # Uncomment and edit the line below to fix the environment at a specific image
-      image: sdshmctspublic.azurecr.io/juror/bureau:pr-676-6e39ac1-20240731120558
+      image: sdshmctspublic.azurecr.io/juror/bureau:pr-681-29488f4-20240801140824
       ingressHost: juror.demo.apps.hmcts.net
       environment:
         SKIP_SSO: true

--- a/apps/juror/juror-bureau/ithc.yaml
+++ b/apps/juror/juror-bureau/ithc.yaml
@@ -8,7 +8,7 @@ spec:
   values:
     nodejs:
       # Uncomment and edit the line below to fix the environment at a specific image
-      image: sdshmctspublic.azurecr.io/juror/bureau:pr-676-6e39ac1-20240731120558
+      image: sdshmctspublic.azurecr.io/juror/bureau:pr-681-29488f4-20240801140824
       ingressHost: juror.ithc.apps.hmcts.net
       environment:
         SKIP_SSO: true


### PR DESCRIPTION
### Jira link (if applicable)



### Change description ###

Stabilisation8 deployment into ITHC and Demo

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


- demo.yaml```: Updated the Java image from sdshmctspublic.azurecr.io/juror/api:pr-665-16cd22a-20240731143058 to sdshmctspublic.azurecr.io/juror/api:pr-673-2fe09ea-20240801144016 for the demo environment, along with the ingress host and environment settings.
- ```ithc.yaml```: Similar changes to the Java image, ingress host, and environment for the ithc environment.
- ```demo.yaml```: Updated the Nodejs image from sdshmctspublic.azurecr.io/juror/bureau:pr-676-6e39ac1-20240731120558 to sdshmctspublic.azurecr.io/juror/bureau:pr-681-29488f4-20240801140824 for the demo environment, along with the ingress host and environment settings.
- ```ithc.yaml```: Similar changes to the Nodejs image, ingress host, and environment for the ithc environment.