### PR TITLE
Changing media service to Mediakind

### DIFF
--- a/apps/pre/pre-api/stg.yaml
+++ b/apps/pre/pre-api/stg.yaml
@@ -15,4 +15,4 @@ spec:
         PLATFORM_ENV_TAG: Staging
         AZURE_INGEST_SA: preingestsatest
         AZURE_FINAL_SA: prefinalsatest
-        MEDIA_SERVICE: AzureMediaService
+        MEDIA_SERVICE: MediaKind


### PR DESCRIPTION




- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [x] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


- In `apps/pre/pre-api/stg.yaml`, the `MEDIA_SERVICE` value was changed from `AzureMediaService` to `MediaKind`. 🔄