### PR TITLE
Adding KEDA patching yaml file and patch to each non-prod environment

### DIFF
--- a/apps/keda/demo/base/kustomization.yaml
+++ b/apps/keda/demo/base/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
 namespace: keda
 patches:
   - path: workload-identity.yaml
+  - path: ../../keda/patching.yaml

--- a/apps/keda/dev/base/kustomization.yaml
+++ b/apps/keda/dev/base/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
 namespace: keda
 patches:
   - path: workload-identity.yaml
+  - path: ../../keda/patching.yaml

--- a/apps/keda/ithc/base/kustomization.yaml
+++ b/apps/keda/ithc/base/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
 namespace: keda
 patches:
   - path: workload-identity.yaml
+  - path: ../../keda/patching.yaml

--- a/apps/keda/keda/patching.yaml
+++ b/apps/keda/keda/patching.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: keda
+  namespace: keda
+spec:
+  values:
+    serviceAccount:
+      operator:
+        create: false
+        name: keda
+  chart:
+    spec:
+      chart: keda
+      version: 2.14.3

--- a/apps/keda/ptlsbox/base/kustomization.yaml
+++ b/apps/keda/ptlsbox/base/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
 namespace: keda
 patches:
   - path: workload-identity.yaml
+  - path: ../../keda/patching.yaml

--- a/apps/keda/sbox/base/kustomization.yaml
+++ b/apps/keda/sbox/base/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
 namespace: keda
 patches:
   - path: workload-identity.yaml
+  - path: ../../keda/patching.yaml

--- a/apps/keda/stg/base/kustomization.yaml
+++ b/apps/keda/stg/base/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
 namespace: keda
 patches:
   - path: workload-identity.yaml
+  - path: ../../keda/patching.yaml

--- a/apps/keda/test/base/kustomization.yaml
+++ b/apps/keda/test/base/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
 namespace: keda
 patches:
   - path: workload-identity.yaml
+  - path: ../../keda/patching.yaml

--- a/apps/toffee/recipe-receiver/toffee-recipe-receiver.yaml
+++ b/apps/toffee/recipe-receiver/toffee-recipe-receiver.yaml
@@ -25,7 +25,7 @@ spec:
       image: sdshmctspublic.azurecr.io/toffee/recipe-receiver:prod-1100a0e-20220609130124
       triggers:
         - type: azure-servicebus
-          namespace: toffee-servicebus-${ENVIRONMENT}
+          serviceBusName: toffee-servicebus-${ENVIRONMENT}
           queueName: recipes
           queueLength: "5"
       environment:


### PR DESCRIPTION
### Jira link (if applicable)
https://tools.hmcts.net/jira/browse/DTSPO-18304


### Change description ###
Adding KEDA patching yaml file and patch to each non-prod environment








## 🤖AEP PR SUMMARY🤖


- Updated files in the `apps/keda` directory:
  - Updated kustomization.yaml files in the `base`, `dev`, `ithc`, `ptlsbox`, `sbox`, `stg`, and `test` directories to add a new `patching.yaml` file.
  - Added a new `keda/patching.yaml` file with HelmRelease configuration.
- Updated the `apps/toffee/recipe-receiver/toffee-recipe-receiver.yaml` file to change the value of `namespace` to `serviceBusName` under triggers.