### PR TITLE
PUB-2545 - Added old max payload size

### DIFF
--- a/apps/pip/data-management/demo.yaml
+++ b/apps/pip/data-management/demo.yaml
@@ -12,3 +12,4 @@ spec:
         CHANNEL_MANAGEMENT_URL: https://pip-channel-management.demo.platform.hmcts.net
         PUBLICATION_SERVICES_URL: https://pip-publication-services.demo.platform.hmcts.net
         MANAGED_IDENTITY_CLIENT_ID: 2979592b-7abf-4461-b0d7-95fdfae46c91
+        OLD_MAX_PAYLOAD_SIZE: 2048

--- a/apps/pip/data-management/ithc.yaml
+++ b/apps/pip/data-management/ithc.yaml
@@ -13,3 +13,4 @@ spec:
         PUBLICATION_SERVICES_URL: https://pip-publication-services.ithc.platform.hmcts.net
         CHANNEL_MANAGEMENT_URL: https://pip-channel-management.ithc.platform.hmcts.net
         MANAGED_IDENTITY_CLIENT_ID: 6eadcd84-611f-4d93-b2c4-5e3ff2dc239e
+        OLD_MAX_PAYLOAD_SIZE: 2048

--- a/apps/pip/data-management/prod.yaml
+++ b/apps/pip/data-management/prod.yaml
@@ -14,3 +14,4 @@ spec:
         PUBLICATION_SERVICES_URL: https://pip-publication-services.platform.hmcts.net
         CHANNEL_MANAGEMENT_URL: https://pip-channel-management.platform.hmcts.net
         MANAGED_IDENTITY_CLIENT_ID: a48b526e-e843-4c01-864b-45dcb6b44862
+        OLD_MAX_PAYLOAD_SIZE: 2048

--- a/apps/pip/data-management/stg.yaml
+++ b/apps/pip/data-management/stg.yaml
@@ -13,3 +13,4 @@ spec:
         PUBLICATION_SERVICES_URL: https://pip-publication-services.staging.platform.hmcts.net
         ENABLE_TESTING_SUPPORT_API: true
         MANAGED_IDENTITY_CLIENT_ID: 8d0ead51-3b31-44df-a78e-ada4eea9fe87
+        OLD_MAX_PAYLOAD_SIZE: 2048

--- a/apps/pip/data-management/test.yaml
+++ b/apps/pip/data-management/test.yaml
@@ -15,3 +15,4 @@ spec:
         CHANNEL_MANAGEMENT_URL: https://pip-channel-management.test.platform.hmcts.net
         ENABLE_TESTING_SUPPORT_API: true
         MANAGED_IDENTITY_CLIENT_ID: 0e0c8682-a038-4aa8-9619-bb88a7ba9357
+        OLD_MAX_PAYLOAD_SIZE: 2048


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/PUB-2545

### Change description ###

Set old max payload size

## 🤖AEP PR SUMMARY🤖


- Updated `demo.yaml`, `ithc.yaml`, `prod.yaml`, `stg.yaml`, and `test.yaml` in the `apps/pip/data-management` directory to include a new property `OLD_MAX_PAYLOAD_SIZE` with a value of 2048.