### PR TITLE
Revert "Update stg.yaml to the correct client id for pdda and pdm"

### DIFF
--- a/apps/pdda/serviceaccount/stg.yaml
+++ b/apps/pdda/serviceaccount/stg.yaml
@@ -4,4 +4,4 @@ metadata:
   name: ${NAMESPACE}
   namespace: ${NAMESPACE}
   annotations:
-    azure.workload.identity/client-id: "76981322-2cf0-44ea-a49c-bda08c7878c5"
+    azure.workload.identity/client-id: "ee71b40f-90bf-49af-936d-04fbde2023fc"


### PR DESCRIPTION
Reverts hmcts/sds-flux-config#5208

## 🤖AEP PR SUMMARY🤖


- Updated file: `apps/pdda/serviceaccount/stg.yaml`
    - Changed the `azure.workload.identity/client-id` annotation value from \"76981322-2cf0-44ea-a49c-bda08c7878c5\" to \"ee71b40f-90bf-49af-936d-04fbde2023fc\" 🔄