### PR TITLE
juror deployment to ITHC and Demo

### DIFF
--- a/apps/juror/juror-api/demo.yaml
+++ b/apps/juror/juror-api/demo.yaml
@@ -8,7 +8,7 @@ spec:
   values:
     java:
       # Uncomment and edit the line below to fix the environment at a specific image
-      image: sdshmctspublic.azurecr.io/juror/api:pr-685-2afcc24-20240807172533
+      image: sdshmctspublic.azurecr.io/juror/api:pr-685-3674b98-20240808112849
       ingressHost: juror-api.demo.platform.hmcts.net
       environment:
         RUN_DB_MIGRATION_ON_STARTUP: true

--- a/apps/juror/juror-api/ithc.yaml
+++ b/apps/juror/juror-api/ithc.yaml
@@ -8,7 +8,7 @@ spec:
   values:
     java:
       # Uncomment and edit the line below to fix the environment at a specific image
-      image: sdshmctspublic.azurecr.io/juror/api:pr-685-2afcc24-20240807172533
+      image: sdshmctspublic.azurecr.io/juror/api:pr-685-3674b98-20240808112849
       ingressHost: juror-api.ithc.platform.hmcts.net
       environment:
         RUN_DB_MIGRATION_ON_STARTUP: true

--- a/apps/juror/juror-bureau/demo.yaml
+++ b/apps/juror/juror-bureau/demo.yaml
@@ -8,7 +8,7 @@ spec:
   values:
     nodejs:
       # Uncomment and edit the line below to fix the environment at a specific image
-      image: sdshmctspublic.azurecr.io/juror/bureau:pr-705-821ea80-20240807151520
+      image: sdshmctspublic.azurecr.io/juror/bureau:pr-705-5900b39-20240808105945
       ingressHost: juror.demo.apps.hmcts.net
       environment:
         SKIP_SSO: true

--- a/apps/juror/juror-bureau/ithc.yaml
+++ b/apps/juror/juror-bureau/ithc.yaml
@@ -8,7 +8,7 @@ spec:
   values:
     nodejs:
       # Uncomment and edit the line below to fix the environment at a specific image
-      image: sdshmctspublic.azurecr.io/juror/bureau:pr-705-821ea80-20240807151520
+      image: sdshmctspublic.azurecr.io/juror/bureau:pr-705-5900b39-20240808105945
       ingressHost: juror.ithc.apps.hmcts.net
       environment:
         SKIP_SSO: true


### PR DESCRIPTION
### Jira link (if applicable)



### Change description ###

Juror Stabilisation10 deployment to ITHC and Demo for juror-api and juror-bureau
### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


### apps/juror/juror-api/demo.yaml
- Updated the image version for the `juror-api` to `pr-685-3674b98-20240808112849`.
- Updated the ingress host to `juror-api.demo.platform.hmcts.net`.

### apps/juror/juror-api/ithc.yaml
- Updated the image version for the `juror-api` to `pr-685-3674b98-20240808112849`.
- Updated the ingress host to `juror-api.ithc.platform.hmcts.net`.

### apps/juror/juror-bureau/demo.yaml
- Updated the image version for the `juror-bureau` to `pr-705-5900b39-20240808105945`.
- Informed to skip SSO for the bureau in the `demo` environment.

### apps/juror/juror-bureau/ithc.yaml
- Updated the image version for the `juror-bureau` to `pr-705-5900b39-20240808105945`.
- Informed to skip SSO for the bureau in the `ithc` environment.