### PR TITLE
PUB-2359 Update frontend and PS image, and disable CM in test env

### DIFF
--- a/apps/pip/channel-management/test.yaml
+++ b/apps/pip/channel-management/test.yaml
@@ -7,7 +7,7 @@ spec:
   releaseName: pip-channel-management
   values:
     java:
-      replicas: 2
+      replicas: 0
       ingressHost: pip-channel-management.test.platform.hmcts.net
       environment:
         ACCOUNT_MANAGEMENT_URL: https://pip-account-management.test.platform.hmcts.net

--- a/apps/pip/frontend/test.yaml
+++ b/apps/pip/frontend/test.yaml
@@ -6,6 +6,7 @@ spec:
   releaseName: pip-frontend
   values:
     nodejs:
+      image: sdshmctspublic.azurecr.io/pip/frontend:pr-1311-ec1fc47-20240809075846
       replicas: 2
       ingressHost: pip-frontend.test.platform.hmcts.net
       environment:

--- a/apps/pip/publication-services/test.yaml
+++ b/apps/pip/publication-services/test.yaml
@@ -7,6 +7,7 @@ spec:
   releaseName: pip-publication-services
   values:
     java:
+      image: sdshmctspublic.azurecr.io/pip/publication-services:pr-447-4e4baa1-20240809081246
       replicas: 2
       ingressHost: pip-publication-services.test.platform.hmcts.net
       environment:


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/PUB-2359

### Change description ###

Update frontend and publication-services image, and disable channel-management in test env

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


### `test.yaml`
- Decreased the number of replicas for `pip-channel-management` from 2 to 0. 
- Updated the image for `pip-frontend` to `sdshmctspublic.azurecr.io/pip/frontend:pr-1311-ec1fc47-20240809075846` and increased replicas to 2.
- Updated the image for `pip-publication-services` to `sdshmctspublic.azurecr.io/pip/publication-services:pr-447-4e4baa1-20240809081246` and increased replicas to 2.