### PR TITLE
add slack-tokens for flux alerts to app teams namespaces

### DIFF
--- a/apps/darts-modernisation/demo/base/kustomization.yaml
+++ b/apps/darts-modernisation/demo/base/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - ../../base
   - ../../../rbac/nonprod-role.yaml
   - ./darts-api-function.enc.yaml
+  - ../../../base/slack-provider/demo
 namespace: darts-modernisation
 patches:
   - path: ../../darts-api/demo.yaml

--- a/apps/darts-modernisation/dev/base/kustomization.yaml
+++ b/apps/darts-modernisation/dev/base/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - ../../../azureserviceoperator-system/resources/flexibleserver-postgres.yaml
   - ../../../azureserviceoperator-system/resources/flexibleserver-postgres-config.yaml
   - ../sops-secrets
+  - ../../../base/slack-provider/dev
 namespace: darts-modernisation
 patches:
   - path: ../../identity/stg.yaml

--- a/apps/darts-modernisation/ithc/base/kustomization.yaml
+++ b/apps/darts-modernisation/ithc/base/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - ../../base
   - ../../../rbac/nonprod-role.yaml
   - ../../darts-stub-services/darts-stub-services.yaml
+  - ../../../base/slack-provider/ithc
 namespace: darts-modernisation
 patches:
   - path: ../../darts-api/ithc.yaml

--- a/apps/darts-modernisation/prod/base/kustomization.yaml
+++ b/apps/darts-modernisation/prod/base/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
+  - ../../../base/slack-provider/prod
 namespace: darts-modernisation
 patches:
   - path: ../../darts-api/prod.yaml

--- a/apps/darts-modernisation/sbox/base/kustomization.yaml
+++ b/apps/darts-modernisation/sbox/base/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
+  - ../../../base/slack-provider/sbox
 namespace: darts-modernisation
 patches:
   - path: ../../darts-api/sbox.yaml

--- a/apps/darts-modernisation/stg/base/kustomization.yaml
+++ b/apps/darts-modernisation/stg/base/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - ../../base
   - ../../../rbac/nonprod-role.yaml
   - ./darts-api-function.enc.yaml
+  - ../../../base/slack-provider/stg
 namespace: darts-modernisation
 patches:
   - path: ../../darts-api/stg.yaml

--- a/apps/darts-modernisation/test/base/kustomization.yaml
+++ b/apps/darts-modernisation/test/base/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - ../../base
   - ../../../rbac/nonprod-role.yaml
   - darts-api-function.enc.yaml
+  - ../../../base/slack-provider/test
 namespace: darts-modernisation
 patches:
   - path: ../../darts-api/test.yaml

--- a/apps/hmi/demo/base/kustomization.yaml
+++ b/apps/hmi/demo/base/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
+  - ../../../base/slack-provider/demo
 namespace: hmi
 patches:
   - path: ../../hmi-rota-dtu/demo.yaml

--- a/apps/hmi/dev/base/kustomization.yaml
+++ b/apps/hmi/dev/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ../../../base
   - ../../../base/workload-identity
+  - ../../../base/slack-provider/dev
 namespace: hmi
 patches:
   - path: ../../serviceaccount/stg.yaml

--- a/apps/hmi/ithc/base/kustomization.yaml
+++ b/apps/hmi/ithc/base/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
+  - ../../../base/slack-provider/ithc
 namespace: hmi
 patches:
   - path: ../../hmi-rota-dtu/ithc.yaml

--- a/apps/hmi/prod/base/kustomization.yaml
+++ b/apps/hmi/prod/base/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
+  - ../../../base/slack-provider/prod
 namespace: hmi
 patches:
   - path: ../../hmi-rota-dtu/prod.yaml

--- a/apps/hmi/sbox/base/kustomization.yaml
+++ b/apps/hmi/sbox/base/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
+  - ../../../base/slack-provider/sbox
 namespace: hmi
 patches:
   - path: ../../hmi-rota-dtu/sbox.yaml

--- a/apps/hmi/stg/base/kustomization.yaml
+++ b/apps/hmi/stg/base/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
+  - ../../../base/slack-provider/stg
 namespace: hmi
 patches:
   - path: ../../hmi-rota-dtu/stg.yaml

--- a/apps/hmi/test/base/kustomization.yaml
+++ b/apps/hmi/test/base/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
+  - ../../../base/slack-provider/test
 namespace: hmi
 patches:
   - path: ../../hmi-rota-dtu/test.yaml

--- a/apps/juror-digital/dev/base/kustomization.yaml
+++ b/apps/juror-digital/dev/base/kustomization.yaml
@@ -1,9 +1,9 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ../../base
-- ../../../rbac/dev-role.yaml
+  - ../../base
+  - ../../../rbac/dev-role.yaml
+  - ../../../base/slack-provider/dev
 namespace: jd
-
 patches:
-- path: ../../identity/dev.yaml
+  - path: ../../identity/dev.yaml

--- a/apps/juror-digital/prod/base/kustomization.yaml
+++ b/apps/juror-digital/prod/base/kustomization.yaml
@@ -1,11 +1,11 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-- ../../base
+  - ../../base
+  - ../../../base/slack-provider/prod
 namespace: jd
-
 patches:
-- path: ../../identity/prod.yaml
-- path: ../../jd-bureau/prod.yaml
-- path: ../../jd-public/prod.yaml
-- path: ../../moj-reverse-proxy/prod.yaml
+  - path: ../../identity/prod.yaml
+  - path: ../../jd-bureau/prod.yaml
+  - path: ../../jd-public/prod.yaml
+  - path: ../../moj-reverse-proxy/prod.yaml

--- a/apps/juror/demo/base/kustomization.yaml
+++ b/apps/juror/demo/base/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
+  - ../../../base/slack-provider/demo
 namespace: juror
 patches:
   - path: ../../juror-scheduler-api/demo.yaml

--- a/apps/juror/dev/base/kustomization.yaml
+++ b/apps/juror/dev/base/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
   - ../../../azureserviceoperator-system/resources/flexibleserver-postgres.yaml
   - ../../../azureserviceoperator-system/resources/flexibleserver-postgres-config.yaml
   - ../sops-secrets
+  - ../../../base/slack-provider/dev
 namespace: juror
 patches:
   - path: ../../serviceaccount/stg.yaml

--- a/apps/juror/ithc/base/kustomization.yaml
+++ b/apps/juror/ithc/base/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
+  - ../../../base/slack-provider/ithc
 namespace: juror
 patches:
   - path: ../../juror-scheduler-api/ithc.yaml

--- a/apps/juror/prod/base/kustomization.yaml
+++ b/apps/juror/prod/base/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
+  - ../../../base/slack-provider/prod
 namespace: juror
 patches:
   - path: ../../juror-scheduler-api/prod.yaml

--- a/apps/juror/sbox/base/kustomization.yaml
+++ b/apps/juror/sbox/base/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
+  - ../../../base/slack-provider/sbox
 namespace: juror
 patches:
   - path: ../../juror-scheduler-api/sbox.yaml

--- a/apps/juror/stg/base/kustomization.yaml
+++ b/apps/juror/stg/base/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
+  - ../../../base/slack-provider/stg
 namespace: juror
 patches:
   - path: ../../juror-scheduler-api/stg.yaml

--- a/apps/juror/test/base/kustomization.yaml
+++ b/apps/juror/test/base/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
+  - ../../../base/slack-provider/test
 namespace: juror
 patches:
   - path: ../../juror-scheduler-api/test.yaml

--- a/apps/mi/dev/base/kustomization.yaml
+++ b/apps/mi/dev/base/kustomization.yaml
@@ -9,22 +9,17 @@ resources:
   - ../../../rbac/dev-role.yaml
   - ../../mi-sftp-server/mi-sftp-server.yaml
   - ../../mi-sftp-server/mi-sftp-server-secret-provider.yaml
+  - ../../../base/slack-provider/dev
 patches:
-  #overlays for mi-azure-functions
   - path: ../../mi-azure-functions/dev.yaml
-  #overlays for mi-adf-shir
   - path: ../../mi-adf-shir/dev.yaml
-  #overlays for mi-adf-shir-2
   - path: ../../mi-adf-shir-2/dev.yaml
-  #overlays for mi-house-keeping-service
   - path: ../../mi-house-keeping-service/dev.yaml
-  #overlays for mi-reverse-proxy-secret-provider
   - path: ../../mi-reverse-proxy/dev-secret-provider-patch.yaml
     target:
       group: secrets-store.csi.x-k8s.io
       kind: SecretProviderClass
       name: mi-reverse-proxy-secret-provider
-  #overlays for mi-sftp-server-secret-provider
   - path: ../../mi-sftp-server/dev-secret-provider-patch.yaml
     target:
       group: secrets-store.csi.x-k8s.io

--- a/apps/mi/ithc/base/kustomization.yaml
+++ b/apps/mi/ithc/base/kustomization.yaml
@@ -7,16 +7,12 @@ resources:
   - ../../../rbac/nonprod-role.yaml
   - ../../mi-sftp-server/mi-sftp-server.yaml
   - ../../mi-sftp-server/mi-sftp-server-secret-provider.yaml
+  - ../../../base/slack-provider/ithc
 patches:
-  #overlays for mi-azure-functions
   - path: ../../mi-azure-functions/ithc.yaml
-  #overlays for mi-adf-shir
   - path: ../../mi-adf-shir/ithc.yaml
-  #overlays for mi-adf-shir-2
   - path: ../../mi-adf-shir-2/ithc.yaml
-  #overlays for mi-house-keeping-service
   - path: ../../mi-house-keeping-service/ithc.yaml
-  #overlays for mi-sftp-server-secret-provider
   - path: ../../mi-sftp-server/ithc-secret-provider-patch.yaml
     target:
       group: secrets-store.csi.x-k8s.io

--- a/apps/mi/prod/base/kustomization.yaml
+++ b/apps/mi/prod/base/kustomization.yaml
@@ -4,14 +4,11 @@ namespace: mi
 resources:
   - ../../base
   - mi-adf-auth-values.enc.yaml
+  - ../../../base/slack-provider/prod
 patches:
-  #overlays for mi-azure-functions
   - path: ../../mi-azure-functions/prod.yaml
-  #overlays for mi-adf-shir
   - path: ../../mi-adf-shir/prod.yaml
-  #overlays for mi-adf-shir-2
   - path: ../../mi-adf-shir-2/prod.yaml
-  #overlays for mi-house-keeping-service
   - path: ../../mi-house-keeping-service/prod.yaml
   - path: ../../identity/mi-azure-functions-identity-prod.yaml
   - path: ../../identity/mi-house-keeping-service-identity-prod.yaml

--- a/apps/mi/sbox/base/kustomization.yaml
+++ b/apps/mi/sbox/base/kustomization.yaml
@@ -7,16 +7,12 @@ resources:
   - ../../../rbac/nonprod-role.yaml
   - ../../mi-sftp-server/mi-sftp-server.yaml
   - ../../mi-sftp-server/mi-sftp-server-secret-provider.yaml
+  - ../../../base/slack-provider/sbox
 patches:
-  #overlays for mi-azure-functions
   - path: ../../mi-azure-functions/sbox.yaml
-  #overlays for mi-adf-shir
   - path: ../../mi-adf-shir/sbox.yaml
-  #overlays for mi-adf-shir-2
   - path: ../../mi-adf-shir-2/sbox.yaml
-  #overlays for mi-house-keeping-service
   - path: ../../mi-house-keeping-service/sbox.yaml
-  #overlays for mi-sftp-server-secret-provider
   - path: ../../mi-sftp-server/sbox-secret-provider-patch.yaml
     target:
       group: secrets-store.csi.x-k8s.io

--- a/apps/mi/stg/base/kustomization.yaml
+++ b/apps/mi/stg/base/kustomization.yaml
@@ -7,16 +7,12 @@ resources:
   - ../../../rbac/nonprod-role.yaml
   - ../../mi-sftp-server/mi-sftp-server.yaml
   - ../../mi-sftp-server/mi-sftp-server-secret-provider.yaml
+  - ../../../base/slack-provider/stg
 patches:
-  #overlays for mi-azure-functions
   - path: ../../mi-azure-functions/stg.yaml
-  #overlays for mi-adf-shir
   - path: ../../mi-adf-shir/stg.yaml
-  #overlays for mi-adf-shir-2
   - path: ../../mi-adf-shir-2/stg.yaml
-  #overlays for mi-house-keeping-service
   - path: ../../mi-house-keeping-service/stg.yaml
-  #overlays for mi-sftp-server-secret-provider
   - path: ../../mi-sftp-server/stg-secret-provider-patch.yaml
     target:
       group: secrets-store.csi.x-k8s.io

--- a/apps/mi/test/base/kustomization.yaml
+++ b/apps/mi/test/base/kustomization.yaml
@@ -9,22 +9,17 @@ resources:
   - ../../../rbac/nonprod-role.yaml
   - ../../mi-sftp-server/mi-sftp-server.yaml
   - ../../mi-sftp-server/mi-sftp-server-secret-provider.yaml
+  - ../../../base/slack-provider/test
 patches:
-  #overlays for mi-azure-functions
   - path: ../../mi-azure-functions/test.yaml
-  #overlays for mi-adf-shir
   - path: ../../mi-adf-shir/test.yaml
-  #overlays for mi-adf-shir-2
   - path: ../../mi-adf-shir-2/test.yaml
-  #overlays for mi-house-keeping-service
   - path: ../../mi-house-keeping-service/test.yaml
-  #overlays for mi-reverse-proxy-secret-provider
   - path: ../../mi-reverse-proxy/test-secret-provider-patch.yaml
     target:
       group: secrets-store.csi.x-k8s.io
       kind: SecretProviderClass
       name: mi-reverse-proxy-secret-provider
-  #overlays for mi-sftp-server-secret-provider
   - path: ../../mi-sftp-server/test-secret-provider-patch.yaml
     target:
       group: secrets-store.csi.x-k8s.io

--- a/apps/my-time/demo/base/kustomization.yaml
+++ b/apps/my-time/demo/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ../../base
   - ../../../rbac/nonprod-role.yaml
+  - ../../../base/slack-provider/demo
 namespace: my-time
 patches:
   - path: ../../identity/demo.yaml

--- a/apps/my-time/dev/base/kustomization.yaml
+++ b/apps/my-time/dev/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ../../base
   - ../../../rbac/dev-role.yaml
+  - ../../../base/slack-provider/dev
 namespace: my-time
 patches:
   - path: ../../identity/dev.yaml

--- a/apps/my-time/ithc/base/kustomization.yaml
+++ b/apps/my-time/ithc/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ../../base
   - ../../../rbac/nonprod-role.yaml
+  - ../../../base/slack-provider/ithc
 namespace: my-time
 patches:
   - path: ../../identity/ithc.yaml

--- a/apps/my-time/stg/base/kustomization.yaml
+++ b/apps/my-time/stg/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ../../base
   - ../../../rbac/nonprod-role.yaml
+  - ../../../base/slack-provider/stg
 namespace: my-time
 patches:
   - path: ../../identity/my-time-azure-identity.yaml

--- a/apps/opal/dev/base/kustomization.yaml
+++ b/apps/opal/dev/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ../../base
   - ../../../rbac/dev-role.yaml
+  - ../../../base/slack-provider/dev
 namespace: opal
 patches:
   - path: ../../serviceaccount/stg.yaml

--- a/apps/opal/stg/base/kustomization.yaml
+++ b/apps/opal/stg/base/kustomization.yaml
@@ -10,7 +10,7 @@ resources:
   - ../../opal-frontend/opal-frontend.yaml
   - ../../opal-legacy-db-stub/opal-legacy-db-stub.yaml
   - ../../opal-log-audit-service/opal-log-audit-service.yaml
-
+  - ../../../base/slack-provider/stg
 namespace: opal
 patches:
   - path: ../../serviceaccount/stg.yaml

--- a/apps/pdda/demo/base/kustomization.yaml
+++ b/apps/pdda/demo/base/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - ../../base
   - ../../../rbac/dev-role.yaml
   - ../../../base/workload-identity
+  - ../../../base/slack-provider/demo
 namespace: pdda
 patches:
   - path: ../../serviceaccount/demo.yaml

--- a/apps/pdda/dev/base/kustomization.yaml
+++ b/apps/pdda/dev/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ../../base
   - ../../../rbac/dev-role.yaml
+  - ../../../base/slack-provider/dev
 namespace: pdda
 patches:
   - path: ../../serviceaccount/stg.yaml

--- a/apps/pdda/stg/base/kustomization.yaml
+++ b/apps/pdda/stg/base/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - ../../../rbac/nonprod-role.yaml
   - ../../pdda-public-display-data-aggregator/pdda-public-display-data-aggregator.yaml
   - ../../pdda-public-display-manager/pdda-public-display-manager.yaml
+  - ../../../base/slack-provider/stg
 namespace: pdda
 patches:
   - path: ../../serviceaccount/stg.yaml

--- a/apps/pdm/dev/base/kustomization.yaml
+++ b/apps/pdm/dev/base/kustomization.yaml
@@ -3,4 +3,5 @@ kind: Kustomization
 resources:
   - ../../base
   - ../../../rbac/dev-role.yaml
+  - ../../../base/slack-provider/dev
 namespace: pdm

--- a/apps/pip/demo/base/kustomization.yaml
+++ b/apps/pip/demo/base/kustomization.yaml
@@ -13,6 +13,7 @@ resources:
   - ../../refresh-views-cron/pip-refresh-views-cron.yaml
   - ../../data-management/pip-data-management.yaml
   - ../../frontend/pip-frontend.yaml
+  - ../../../base/slack-provider/demo
 namespace: pip
 patches:
   - path: ../../identity/demo.yaml

--- a/apps/pip/dev/base/kustomization.yaml
+++ b/apps/pip/dev/base/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - ../../identity/pip-azure-identity.yaml
   - ../../../rbac/dev-role.yaml
   - ../../../base/workload-identity
+  - ../../../base/slack-provider/dev
 namespace: pip
 patches:
   - path: ../../identity/dev.yaml

--- a/apps/pip/ithc/base/kustomization.yaml
+++ b/apps/pip/ithc/base/kustomization.yaml
@@ -13,6 +13,7 @@ resources:
   - ../../refresh-views-cron/pip-refresh-views-cron.yaml
   - ../../data-management/pip-data-management.yaml
   - ../../frontend/pip-frontend.yaml
+  - ../../../base/slack-provider/ithc
 namespace: pip
 patches:
   - path: ../../identity/ithc.yaml

--- a/apps/pip/prod/base/kustomization.yaml
+++ b/apps/pip/prod/base/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
   - ../../refresh-views-cron/pip-refresh-views-cron.yaml
   - ../../data-management/pip-data-management.yaml
   - ../../frontend/pip-frontend.yaml
+  - ../../../base/slack-provider/prod
 namespace: pip
 patches:
   - path: ../../identity/prod.yaml

--- a/apps/pip/sbox/base/kustomization.yaml
+++ b/apps/pip/sbox/base/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - ../../base
   - ../../../rbac/nonprod-role.yaml
   - ../../data-management/pip-data-management.yaml
+  - ../../../base/slack-provider/sbox
 namespace: pip
 patches:
   - path: ../../identity/sbox.yaml

--- a/apps/pip/stg/base/kustomization.yaml
+++ b/apps/pip/stg/base/kustomization.yaml
@@ -13,6 +13,7 @@ resources:
   - ../../refresh-views-cron/pip-refresh-views-cron.yaml
   - ../../data-management/pip-data-management.yaml
   - ../../frontend/pip-frontend.yaml
+  - ../../../base/slack-provider/stg
 namespace: pip
 patches:
   - path: ../../identity/stg.yaml

--- a/apps/pip/test/base/kustomization.yaml
+++ b/apps/pip/test/base/kustomization.yaml
@@ -13,6 +13,7 @@ resources:
   - ../../refresh-views-cron/pip-refresh-views-cron.yaml
   - ../../data-management/pip-data-management.yaml
   - ../../frontend/pip-frontend.yaml
+  - ../../../base/slack-provider/test
 namespace: pip
 patches:
   - path: ../../identity/test.yaml

--- a/apps/pre/demo/base/kustomization.yaml
+++ b/apps/pre/demo/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ../../base
   - ../../../rbac/nonprod-role.yaml
+  - ../../../base/slack-provider/demo
 namespace: pre
 patches:
   - path: ../../identity/demo.yaml

--- a/apps/pre/dev/base/kustomization.yaml
+++ b/apps/pre/dev/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ../../base
   - ../../../rbac/nonprod-role.yaml
+  - ../../../base/slack-provider/dev
 namespace: pre
 patches:
   - path: ../../identity/dev.yaml

--- a/apps/pre/prod/base/kustomization.yaml
+++ b/apps/pre/prod/base/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
+  - ../../../base/slack-provider/prod
 namespace: pre
 patches:
   - path: ../../identity/prod.yaml

--- a/apps/pre/sbox/base/kustomization.yaml
+++ b/apps/pre/sbox/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ../../base
   - ../../../rbac/nonprod-role.yaml
+  - ../../../base/slack-provider/sbox
 namespace: pre
 patches:
   - path: ../../identity/sbox.yaml

--- a/apps/pre/stg/base/kustomization.yaml
+++ b/apps/pre/stg/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ../../base
   - ../../../rbac/nonprod-role.yaml
+  - ../../../base/slack-provider/stg
 namespace: pre
 patches:
   - path: ../../identity/stg.yaml

--- a/apps/pre/test/base/kustomization.yaml
+++ b/apps/pre/test/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ../../base
   - ../../../rbac/nonprod-role.yaml
+  - ../../../base/slack-provider/test
 namespace: pre
 patches:
   - path: ../../identity/test.yaml

--- a/apps/vh/demo/base/kustomization.yaml
+++ b/apps/vh/demo/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ../../base
   - ../../../rbac/dev-role.yaml
+  - ../../../base/slack-provider/demo
 namespace: vh
 patches:
   - path: ../../identity/demo.yaml

--- a/apps/vh/dev/base/kustomization.yaml
+++ b/apps/vh/dev/base/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - ../../base
   - ../../../rbac/dev-role.yaml
   - ../../../rbac/temp-cronjob-role.yaml
+  - ../../../base/slack-provider/dev
 namespace: vh
 patches:
   - path: ../../identity/dev.yaml

--- a/apps/vh/ithc/base/kustomization.yaml
+++ b/apps/vh/ithc/base/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - ../../base
   - ../../../rbac/nonprod-role.yaml
   - ../../../rbac/temp-cronjob-role.yaml
+  - ../../../base/slack-provider/ithc
 namespace: vh
 patches:
   - path: ../../identity/ithc.yaml

--- a/apps/vh/prod/base/kustomization.yaml
+++ b/apps/vh/prod/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ../../base
   - ../../../rbac/temp-cronjob-role.yaml
+  - ../../../base/slack-provider/prod
 namespace: vh
 patches:
   - path: ../../identity/prod.yaml

--- a/apps/vh/stg/base/kustomization.yaml
+++ b/apps/vh/stg/base/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - ../../base
   - ../../../rbac/nonprod-role.yaml
   - ../../../rbac/temp-cronjob-role.yaml
+  - ../../../base/slack-provider/stg
 namespace: vh
 patches:
   - path: ../../identity/stg.yaml

--- a/apps/vh/test/base/kustomization.yaml
+++ b/apps/vh/test/base/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - ../../base
   - ../../../rbac/nonprod-role.yaml
   - ../../../rbac/temp-cronjob-role.yaml
+  - ../../../base/slack-provider/test
 namespace: vh
 patches:
   - path: ../../identity/test.yaml


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DTSPO-15798


### Change description ###

- add slack tokens for flux alert integration for app team namespaces only


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


- Updated various kustomization.yaml files to include a new slack-provider resource in different environments such as demo, dev, prod, ithc, sbox, stg, and test for different applications like apps/darts-modernisation, apps/hmi, apps/juror-digital, apps/mi, apps/my-time, apps/opal, apps/pdda, apps/pdm, apps/pip, apps/pre, and apps/vh.