### PR TITLE
juror deployment into ITHC and DEMO

### DIFF
--- a/apps/juror/juror-api/demo.yaml
+++ b/apps/juror/juror-api/demo.yaml
@@ -8,7 +8,7 @@ spec:
   values:
     java:
       # Uncomment and edit the line below to fix the environment at a specific image
-      image: sdshmctspublic.azurecr.io/juror/api:pr-696-0ba8b12-20240809102412
+      image: sdshmctspublic.azurecr.io/juror/api:pr-697-1c27578-20240813095335
       ingressHost: juror-api.demo.platform.hmcts.net
       environment:
         RUN_DB_MIGRATION_ON_STARTUP: true

--- a/apps/juror/juror-api/ithc.yaml
+++ b/apps/juror/juror-api/ithc.yaml
@@ -8,7 +8,7 @@ spec:
   values:
     java:
       # Uncomment and edit the line below to fix the environment at a specific image
-      image: sdshmctspublic.azurecr.io/juror/api:pr-696-0ba8b12-20240809102412
+      image: sdshmctspublic.azurecr.io/juror/api:pr-697-1c27578-20240813095335
       ingressHost: juror-api.ithc.platform.hmcts.net
       environment:
         RUN_DB_MIGRATION_ON_STARTUP: true

--- a/apps/juror/juror-bureau/demo.yaml
+++ b/apps/juror/juror-bureau/demo.yaml
@@ -8,7 +8,7 @@ spec:
   values:
     nodejs:
       # Uncomment and edit the line below to fix the environment at a specific image
-      image: sdshmctspublic.azurecr.io/juror/bureau:pr-705-5900b39-20240808105945
+      image: sdshmctspublic.azurecr.io/juror/bureau:pr-715-6fd316a-20240813090115
       ingressHost: juror.demo.apps.hmcts.net
       environment:
         SKIP_SSO: true

--- a/apps/juror/juror-bureau/ithc.yaml
+++ b/apps/juror/juror-bureau/ithc.yaml
@@ -8,7 +8,7 @@ spec:
   values:
     nodejs:
       # Uncomment and edit the line below to fix the environment at a specific image
-      image: sdshmctspublic.azurecr.io/juror/bureau:pr-705-5900b39-20240808105945
+      image: sdshmctspublic.azurecr.io/juror/bureau:pr-715-6fd316a-20240813090115
       ingressHost: juror.ithc.apps.hmcts.net
       environment:
         SKIP_SSO: true

--- a/apps/juror/juror-public/demo.yaml
+++ b/apps/juror/juror-public/demo.yaml
@@ -8,5 +8,5 @@ spec:
   values:
     nodejs:
       # Uncomment and edit the line below to fix the environment at a specific image
-      image: sdshmctspublic.azurecr.io/juror/public:pr-238-4dd791d-20240806115937
+      image: sdshmctspublic.azurecr.io/juror/public:pr-239-0fba62b-20240813081009
       ingressHost: juror-public.demo.apps.hmcts.net

--- a/apps/juror/juror-public/ithc.yaml
+++ b/apps/juror/juror-public/ithc.yaml
@@ -8,5 +8,5 @@ spec:
   values:
     nodejs:
       # Uncomment and edit the line below to fix the environment at a specific image
-      image: sdshmctspublic.azurecr.io/juror/public:pr-238-4dd791d-20240806115937
+      image: sdshmctspublic.azurecr.io/juror/public:pr-239-0fba62b-20240813081009
       ingressHost: juror-public.ithc.apps.hmcts.net


### PR DESCRIPTION
### Jira link (if applicable)

juror deployment into ITHC and Demo for Stabilisation11 updates: juror-public, juror-bureau, juror-api

### Change description ###


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


- In `demo.yaml` and `ithc.yaml` files under `apps/juror/juror-api/`, the image has been updated from `sdshmctspublic.azurecr.io/juror/api:pr-696-0ba8b12-20240809102412` to `sdshmctspublic.azurecr.io/juror/api:pr-697-1c27578-20240813095335`.
- In `demo.yaml` and `ithc.yaml` files under `apps/juror/juror-bureau/`, the image has been updated from `sdshmctspublic.azurecr.io/juror/bureau:pr-705-5900b39-20240808105945` to `sdshmctspublic.azurecr.io/juror/bureau:pr-715-6fd316a-20240813090115`.
- In `demo.yaml` and `ithc.yaml` files under `apps/juror/juror-public/`, the image has been updated from `sdshmctspublic.azurecr.io/juror/public:pr-238-4dd791d-20240806115937` to `sdshmctspublic.azurecr.io/juror/public:pr-239-0fba62b-20240813081009`.