### PR TITLE
Change demo back to 1.1.0 to test

### DIFF
--- a/apps/dynatrace/demo/base/dynakube.yaml
+++ b/apps/dynatrace/demo/base/dynakube.yaml
@@ -1,4 +1,4 @@
-apiVersion: dynatrace.com/v1beta2
+apiVersion: dynatrace.com/v1beta1
 kind: DynaKube
 metadata:
   name: dynakube

--- a/apps/dynatrace/demo/base/kustomization.yaml
+++ b/apps/dynatrace/demo/base/kustomization.yaml
@@ -2,9 +2,8 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
-  - ../../dynakube-upgrade.yaml
+  - ../../dynakube.yaml
   - dynakube-secret.enc.yaml
 namespace: dynatrace
 patches:
   - path: dynakube.yaml
-  - path: ../../dynatrace-operator-upgrade.yaml


### PR DESCRIPTION
### Jira link (if applicable)

https://tools.hmcts.net/jira/browse/DTSPO-18307

### Change description ###

Change demo back to 1.1.0 to test





## 🤖AEP PR SUMMARY🤖


### File Changes
- **dynakube.yaml**
  - Changed `apiVersion` from `dynatrace.com/v1beta2` to `dynatrace.com/v1beta1` for `DynaKube`.

- **kustomization.yaml**
  - Removed `././dynakube-upgrade.yaml` and added `././dynakube.yaml` as a resource.
  - Removed `././dynatrace-operator-upgrade.yaml` as a patch.