### PR TITLE
Use dynakube api v1beta2

### DIFF
--- a/apps/dynatrace/demo/base/dynakube.yaml
+++ b/apps/dynatrace/demo/base/dynakube.yaml
@@ -1,4 +1,4 @@
-apiVersion: dynatrace.com/v1beta1
+apiVersion: dynatrace.com/v1beta2
 kind: DynaKube
 metadata:
   name: dynakube

--- a/apps/dynatrace/demo/base/kustomization.yaml
+++ b/apps/dynatrace/demo/base/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
-  - ../../dynakube.yaml
+  - ../../dynakube-upgrade.yaml
   - dynakube-secret.enc.yaml
 namespace: dynatrace
 patches:


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-18307

### Change description

Using dynakube api version v1beta2 to try and get dynatrace agent upgrade running



## 🤖AEP PR SUMMARY🤖


- Updated `apps/dynatrace/demo/base/dynakube.yaml` 🔄
  - Changed the `apiVersion` from `dynatrace.com/v1beta1` to `dynatrace.com/v1beta2`.

- Updated `apps/dynatrace/demo/base/kustomization.yaml` 🔄
  - Replaced `././dynakube.yaml` with `././dynakube-upgrade.yaml` in the list of resources.