### PR TITLE
PUB-2359 - Scale down replicas for channel management

### DIFF
--- a/apps/pip/channel-management/pip-channel-management.yaml
+++ b/apps/pip/channel-management/pip-channel-management.yaml
@@ -6,6 +6,7 @@ spec:
   releaseName: pip-channel-management
   values:
     java:
+      replicas: 0
       image: sdshmctspublic.azurecr.io/pip/channel-management:prod-737f843-20240813125024 # {"$imagepolicy": "flux-system:pip-channel-management"}
       disableTraefikTls: true
   chart:

--- a/apps/pip/channel-management/prod.yaml
+++ b/apps/pip/channel-management/prod.yaml
@@ -7,7 +7,6 @@ spec:
   releaseName: pip-channel-management
   values:
     java:
-      replicas: 2
       ingressHost: pip-channel-management.platform.hmcts.net
       environment:
         ACCOUNT_MANAGEMENT_URL: https://pip-account-management.platform.hmcts.net

--- a/apps/pip/channel-management/stg.yaml
+++ b/apps/pip/channel-management/stg.yaml
@@ -7,7 +7,6 @@ spec:
   releaseName: pip-channel-management
   values:
     java:
-      replicas: 2
       ingressHost: pip-channel-management.staging.platform.hmcts.net
       environment:
         MANAGED_IDENTITY_CLIENT_ID: 8d0ead51-3b31-44df-a78e-ada4eea9fe87

--- a/apps/pip/channel-management/test.yaml
+++ b/apps/pip/channel-management/test.yaml
@@ -7,7 +7,6 @@ spec:
   releaseName: pip-channel-management
   values:
     java:
-      replicas: 2
       ingressHost: pip-channel-management.test.platform.hmcts.net
       environment:
         ACCOUNT_MANAGEMENT_URL: https://pip-account-management.test.platform.hmcts.net


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/PUB-2359

### Change description

Scale down replicas for channel management





## 🤖AEP PR SUMMARY🤖


- `pip-channel-management.yaml`
  - Added a `replicas: 0` for the `java` service
  - Updated the image to `sdshmctspublic.azurecr.io/pip/channel-management:prod-737f843-20240813125024`
  - Added `disableTraefikTls: true` to the chart

- `prod.yaml`
  - Changed the number of replicas for `java` service from 2 to unspecified
  - Updated `ingressHost` to `pip-channel-management.platform.hmcts.net`
  - Added `ACCOUNT_MANAGEMENT_URL: https://pip-account-management.platform.hmcts.net`

- `stg.yaml`
  - Changed the number of replicas for `java` service from 2 to unspecified
  - Updated `ingressHost` to `pip-channel-management.staging.platform.hmcts.net`
  - Added `MANAGED_IDENTITY_CLIENT_ID: 8d0ead51-3b31-44df-a78e-ada4eea9fe87`

- `test.yaml`
  - Changed the number of replicas for `java` service from 2 to unspecified
  - Updated `ingressHost` to `pip-channel-management.test.platform.hmcts.net`
  - Added `ACCOUNT_MANAGEMENT_URL: https://pip-account-management.test.platform.hmcts.net`