### PR TITLE
Patch grafana on sbox

### DIFF
--- a/apps/monitoring/kube-prometheus-stack-crds-upgrade/kustomization.yaml
+++ b/apps/monitoring/kube-prometheus-stack-crds-upgrade/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - https://raw.githubusercontent.com/prometheus-community/helm-charts/kube-prometheus-stack-61.9.0/charts/kube-prometheus-stack/charts/crds/crds/crd-alertmanagerconfigs.yaml
+  - https://raw.githubusercontent.com/prometheus-community/helm-charts/kube-prometheus-stack-61.9.0/charts/kube-prometheus-stack/charts/crds/crds/crd-alertmanagers.yaml
+  - https://raw.githubusercontent.com/prometheus-community/helm-charts/kube-prometheus-stack-61.9.0/charts/kube-prometheus-stack/charts/crds/crds/crd-podmonitors.yaml
+  - https://raw.githubusercontent.com/prometheus-community/helm-charts/kube-prometheus-stack-61.9.0/charts/kube-prometheus-stack/charts/crds/crds/crd-probes.yaml
+  - https://raw.githubusercontent.com/prometheus-community/helm-charts/kube-prometheus-stack-61.9.0/charts/kube-prometheus-stack/charts/crds/crds/crd-prometheuses.yaml
+  - https://raw.githubusercontent.com/prometheus-community/helm-charts/kube-prometheus-stack-61.9.0/charts/kube-prometheus-stack/charts/crds/crds/crd-prometheusrules.yaml
+  - https://raw.githubusercontent.com/prometheus-community/helm-charts/kube-prometheus-stack-61.9.0/charts/kube-prometheus-stack/charts/crds/crds/crd-servicemonitors.yaml
+  - https://raw.githubusercontent.com/prometheus-community/helm-charts/kube-prometheus-stack-61.9.0/charts/kube-prometheus-stack/charts/crds/crds/crd-thanosrulers.yaml

--- a/apps/monitoring/kube-prometheus-stack/kube-prometheus-stack-upgrade.yaml
+++ b/apps/monitoring/kube-prometheus-stack/kube-prometheus-stack-upgrade.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: kube-prometheus-stack
+  namespace: monitoring
+spec:
+  chart:
+    spec:
+      chart: kube-prometheus-stack
+      # update crds in kube-prometheus-stack-crds when changing this version
+      version: 58.5.1
+      sourceRef:
+        kind: HelmRepository
+        name: prometheus
+        namespace: monitoring

--- a/apps/monitoring/sbox/base/kustomization.yaml
+++ b/apps/monitoring/sbox/base/kustomization.yaml
@@ -4,3 +4,6 @@ resources:
   - ../../base
   - ../../kube-prometheus-stack/sbox/prometheus-values.enc.yaml
 namespace: monitoring
+patches:
+  - path: ../../kube-prometheus-stack/kube-prometheus-stack-upgrade.yaml
+  - path: ../../kube-prometheus-stack/kube-prometheus-stack-crds-upgrade


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-18307

### Change description

Patch grafana on sbox



## 🤖AEP PR SUMMARY🤖


- The file `apps/monitoring/kube-prometheus-stack-crds-upgrade-v56/kustomize.yaml` was deleted.
- A new file `apps/monitoring/kube-prometheus-stack-crds-upgrade/kustomization.yaml` was created, which includes references to various CRD yaml files.
- A new file `apps/monitoring/kube-prometheus-stack/kube-prometheus-stack-upgrade.yaml` was created, specifying the HelmRelease for the kube-prometheus-stack with version 58.5.1.
- The file `apps/monitoring/sbox/base/kustomization.yaml` was updated to include paths to `kube-prometheus-stack-upgrade.yaml` and `kube-prometheus-stack-crds-upgrade` for the monitoring namespace.