### PR TITLE
juror: switch juror-scheduler-api to master as pr228 now merged

### DIFF
--- a/apps/juror/juror-scheduler-api/ithc.yaml
+++ b/apps/juror/juror-scheduler-api/ithc.yaml
@@ -8,5 +8,5 @@ spec:
   values:
     java:
       # Uncomment and edit the line below to fix the environment at a specific image
-      image: sdshmctspublic.azurecr.io/juror/scheduler-api:pr-228-b0108b6-20240730090229
+      # image: sdshmctspublic.azurecr.io/juror/scheduler-api:pr-228-b0108b6-20240730090229
       ingressHost: juror-scheduler-api.ithc.platform.hmcts.net


### PR DESCRIPTION
### Jira link



### Change description
switch juror scheduler to master now pr228 has been merged

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


### apps/juror/juror-scheduler-api/ithc.yaml
- Updated the `java` image to `sdshmctspublic.azurecr.io/juror/scheduler-api:pr-228-b0108b6-20240730090229`
- Added `ingressHost: juror-scheduler-api.ithc.platform.hmcts.net`  🚀