### PR TITLE
set vm apps to use dev image for demo env

### DIFF
--- a/apps/vh/admin-web/demo.yaml
+++ b/apps/vh/admin-web/demo.yaml
@@ -8,7 +8,7 @@ spec:
   values:
     java:
       ingressHost: vh-admin-web.demo.platform.hmcts.net
-      image: sdshmctspublic.azurecr.io/vh/admin-web:prod-c065873-202408191245 #{"$imagepolicy": "flux-system:vh-admin-web"}
-  chart:
-    spec:
-      chart: ./stable/vh-admin-web/prod
+      image: sdshmctspublic.azurecr.io/vh/admin-web:dev-8b76cb6-202408150929 #{"$imagepolicy": "flux-system:vh-admin-web-dev"}
+  # chart:
+  #   spec:
+  #     chart: ./stable/vh-admin-web/prod

--- a/apps/vh/booking-queue-subscriber/demo.yaml
+++ b/apps/vh/booking-queue-subscriber/demo.yaml
@@ -7,7 +7,7 @@ spec:
   releaseName: vh-booking-queue-subscriber
   values:
     java:
-      image: sdshmctspublic.azurecr.io/vh/booking-queue-subscriber:prod-5137449-202408191239 # {"$imagepolicy": "flux-system:vh-booking-queue-subscriber"}
+      image: sdshmctspublic.azurecr.io/vh/booking-queue-subscriber:dev-89bc8f3-202408060944 # {"$imagepolicy": "flux-system:vh-booking-queue-subscriber-dev"}
     function:
       triggers:
       - type: azure-servicebus
@@ -20,6 +20,6 @@ spec:
         idleReplicaCount: 1
         maxReplicaCount: 2
         minReplicaCount: 1
-  chart:
-    spec:
-      chart: ./stable/vh-booking-queue-subscriber/prod
+  # chart:
+  #   spec:
+  #     chart: ./stable/vh-booking-queue-subscriber/prod

--- a/apps/vh/bookings-api/demo.yaml
+++ b/apps/vh/bookings-api/demo.yaml
@@ -8,7 +8,7 @@ spec:
   values:
     java:
       ingressHost: vh-bookings-api.demo.platform.hmcts.net
-      image: sdshmctspublic.azurecr.io/vh/bookings-api:prod-b147a9d-202408191242 #{"$imagepolicy": "flux-system:vh-bookings-api"}
-  chart:
-    spec:
-      chart: ./stable/vh-bookings-api/prod
+      image: sdshmctspublic.azurecr.io/vh/bookings-api:dev-3f9f0e3-202408200915 #{"$imagepolicy": "flux-system:vh-bookings-api-dev"}
+  # chart:
+  #   spec:
+  #     chart: ./stable/vh-bookings-api/prod

--- a/apps/vh/notification-api/demo.yaml
+++ b/apps/vh/notification-api/demo.yaml
@@ -8,7 +8,7 @@ spec:
   values:
     java:
       ingressHost: vh-notification-api.demo.platform.hmcts.net
-      image: sdshmctspublic.azurecr.io/vh/notification-api:prod-661abad-202408191246 #{"$imagepolicy": "flux-system:vh-notification-api"}
-  chart:
-    spec:
-      chart: ./stable/vh-notification-api/prod
+      image: sdshmctspublic.azurecr.io/vh/notification-api:dev-f3bea10-202405291308 #{"$imagepolicy": "flux-system:vh-notification-api-dev"}
+  # chart:
+  #   spec:
+  #     chart: ./stable/vh-notification-api/prod

--- a/apps/vh/scheduler-jobs/demo.yaml
+++ b/apps/vh/scheduler-jobs/demo.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   releaseName: vh-scheduler-jobs
   values:
-    image: sdshmctspublic.azurecr.io/vh/scheduler-jobs-sds:prod-a2dd498-202408191239 #{"$imagepolicy": "flux-system:vh-scheduler-jobs"}
-  chart:
-    spec:
-      chart: ./stable/vh-scheduler-jobs/prod
+    image: sdshmctspublic.azurecr.io/vh/scheduler-jobs-sds:dev-b97efcf-202407231200 #{"$imagepolicy": "flux-system:vh-scheduler-jobs-dev"}
+  # chart:
+  #   spec:
+  #     chart: ./stable/vh-scheduler-jobs/prod

--- a/apps/vh/test-api/demo.yaml
+++ b/apps/vh/test-api/demo.yaml
@@ -1,0 +1,11 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: vh-test-api
+  namespace: vh
+spec:
+  releaseName: vh-test-api
+  values:
+    java:
+      ingressHost: vh-test-api.demo.platform.hmcts.net
+      image: sdshmctspublic.azurecr.io/vh/test-api:staging-80e7d10-202303151145 #{"$imagepolicy": "flux-system:vh-test-api"}

--- a/apps/vh/test-web/demo.yaml
+++ b/apps/vh/test-web/demo.yaml
@@ -1,0 +1,11 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: vh-test-web
+  namespace: vh
+spec:
+  releaseName: vh-test-web
+  values:
+    java:
+      ingressHost: vh-test-web.demo.platform.hmcts.net
+      image: sdshmctspublic.azurecr.io/vh/test-web:staging-235af6b-202303131005 # {"$imagepolicy": "flux-system:vh-test-web"}

--- a/apps/vh/user-api/demo.yaml
+++ b/apps/vh/user-api/demo.yaml
@@ -8,7 +8,7 @@ spec:
   values:
     java:
       ingressHost: vh-user-api.demo.platform.hmcts.net
-      image: sdshmctspublic.azurecr.io/vh/user-api:prod-8254c61-202408191240 #{"$imagepolicy": "flux-system:vh-user-api"}
-  chart:
-    spec:
-      chart: ./stable/vh-user-api/prod
+      image: sdshmctspublic.azurecr.io/vh/user-api:dev-0171edd-202405291305 #{"$imagepolicy": "flux-system:vh-user-api-dev"}
+  # chart:
+  #   spec:
+  #     chart: ./stable/vh-user-api/prod

--- a/apps/vh/video-api/demo.yaml
+++ b/apps/vh/video-api/demo.yaml
@@ -8,8 +8,7 @@ spec:
   values:
     java:
       ingressHost: vh-video-api.demo.platform.hmcts.net
-      image: sdshmctspublic.azurecr.io/vh/video-api:pr-633-202406281304-1 #{"$imagepolicy": "flux-system:vh-video-api-demo"}
-      #image: sdshmctspublic.azurecr.io/vh/video-api:pr-633-202403251634-1 #{"$imagepolicy": "flux-system:vh-video-api-demo"}
-  chart:
-    spec:
-      chart: ./stable/vh-video-api/demo
+      image: sdshmctspublic.azurecr.io/vh/video-api:dev-19943aa-202408160843 #{"$imagepolicy": "flux-system:vh-video-api-dev"}
+  # chart:
+  #   spec:
+  #     chart: ./stable/vh-video-api/demo

--- a/apps/vh/video-api/image-policy.yaml
+++ b/apps/vh/video-api/image-policy.yaml
@@ -17,22 +17,6 @@ spec:
 apiVersion: image.toolkit.fluxcd.io/v1beta1
 kind: ImagePolicy
 metadata:
-  name: vh-video-api-demo
-  annotations:
-    hmcts.github.com/prod-automated: disabled
-spec:
-  filterTags:
-    extract: $ts
-    pattern: '^pr-633-(?P<ts>[0-9]+)-[0-9]'
-  imageRepositoryRef:
-    name: vh-video-api
-  policy:
-    alphabetical:
-      order: asc
----
-apiVersion: image.toolkit.fluxcd.io/v1beta1
-kind: ImagePolicy
-metadata:
   name: vh-video-api-staging
   annotations:
     hmcts.github.com/prod-automated: disabled

--- a/apps/vh/video-web/demo.yaml
+++ b/apps/vh/video-web/demo.yaml
@@ -8,7 +8,7 @@ spec:
   values:
     java:
       ingressHost: vh-video-web.demo.platform.hmcts.net
-      image: sdshmctspublic.azurecr.io/vh/video-web:pr-2122-202406281156-1 # {"$imagepolicy": "flux-system:vh-video-web-demo"}
-  chart:
-    spec:
-      chart: ./stable/vh-video-web/non-prod
+      image: sdshmctspublic.azurecr.io/vh/video-web:dev-aecaed7-202408160857 # {"$imagepolicy": "flux-system:vh-video-web-dev"}
+  # chart:
+  #   spec:
+  #     chart: ./stable/vh-video-web/non-prod

--- a/apps/vh/video-web/image-policy.yaml
+++ b/apps/vh/video-web/image-policy.yaml
@@ -17,22 +17,6 @@ spec:
 apiVersion: image.toolkit.fluxcd.io/v1beta1
 kind: ImagePolicy
 metadata:
-  name: vh-video-web-demo
-  annotations:
-    hmcts.github.com/prod-automated: disabled
-spec:
-  filterTags:
-    extract: $ts
-    pattern: '^pr-2122-(?P<ts>[0-9]+)-[0-9]'
-  imageRepositoryRef:
-    name: vh-video-web
-  policy:
-    alphabetical:
-      order: asc
----
-apiVersion: image.toolkit.fluxcd.io/v1beta1
-kind: ImagePolicy
-metadata:
   name: vh-video-web-staging
   annotations:
     hmcts.github.com/prod-automated: disabled


### PR DESCRIPTION
See [VIH-10889](https://tools.hmcts.net/jira/browse/VIH-10889)

### Change description

Updates all vh app's Flux Demo env patches to trigger on Dev image pushes 

### Testing done

Testing can only be done via Flux on PR completion






## 🤖AEP PR SUMMARY🤖


- Modified apps/vh/admin-web/demo.yaml
  - Updated image tag from prod-c065873-202408191245 to dev-8b76cb6-202408150929

- Modified apps/vh/booking-queue-subscriber/demo.yaml
  - Updated image tag from prod-5137449-202408191239 to dev-89bc8f3-202408060944

- Modified apps/vh/bookings-api/demo.yaml
  - Updated image tag from prod-b147a9d-202408191242 to dev-3f9f0e3-202408200915

- Modified apps/vh/notification-api/demo.yaml
  - Updated image tag from prod-661abad-202408191246 to dev-f3bea10-202405291308

- Modified apps/vh/scheduler-jobs/demo.yaml
  - Updated image tag from prod-a2dd498-202408191239 to dev-b97efcf-202407231200

- Added apps/vh/test-api/demo.yaml
  - Defined new HelmRelease for the vh-test-api with staging image

- Added apps/vh/test-web/demo.yaml
  - Defined new HelmRelease for the vh-test-web with staging image

- Modified apps/vh/user-api/demo.yaml
  - Updated image tag from prod-8254c61-202408191240 to dev-0171edd-202405291305

- Modified apps/vh/video-api/demo.yaml
  - Updated image tag from pr-633-202406281304-1 to dev-19943aa-202408160843

- Modified apps/vh/video-api/image-policy.yaml
  - Removed ImagePolicy configuration for prod-automated

- Modified apps/vh/video-web/demo.yaml
  - Updated image tag from pr-2122-202406281156-1 to dev-aecaed7-202408160857

- Modified apps/vh/video-web/image-policy.yaml
  - Removed ImagePolicy configuration for prod-automated