### PR TITLE
fix: pre-api use Staging AMS + Demo Tasks use MediaKind

### DIFF
--- a/apps/pre/pre-api-cron-cleanup-live-events/demo.yaml
+++ b/apps/pre/pre-api-cron-cleanup-live-events/demo.yaml
@@ -15,6 +15,7 @@ spec:
         AZURE_RESOURCE_GROUP: pre-demo
         AZURE_SUBSCRIPTION_ID: c68a4bed-4c3d-4956-af51-4ae164c1957c
         PLATFORM_ENV_TAG: Demo
+        MEDIA_SERVICE: MediaKind
     global:
       jobKind: CronJob
       enableKeyVaults: true

--- a/apps/pre/pre-api-cron-cleanup-live-events/stg.yaml
+++ b/apps/pre/pre-api-cron-cleanup-live-events/stg.yaml
@@ -11,9 +11,9 @@ spec:
       disableActiveClusterCheck: true
       schedule: "0 20 * * *"
       environment:
-        AZURE_MEDIA_SERVICES_ACCOUNT_NAME: preamstest
-        AZURE_RESOURCE_GROUP: pre-test
-        AZURE_SUBSCRIPTION_ID: 3eec5bde-7feb-4566-bfb6-805df6e10b90
+        AZURE_MEDIA_SERVICES_ACCOUNT_NAME: preamsstg
+        AZURE_RESOURCE_GROUP: pre-stg
+        AZURE_SUBSCRIPTION_ID: 74dacd4f-a248-45bb-a2f0-af700dc4cf68
         PLATFORM_ENV_TAG: Staging
         AZURE_INGEST_SA: preingestsastg
         AZURE_FINAL_SA: prefinalsastg

--- a/apps/pre/pre-api-cron-cleanup-streaming-locators/demo.yaml
+++ b/apps/pre/pre-api-cron-cleanup-streaming-locators/demo.yaml
@@ -15,6 +15,7 @@ spec:
         AZURE_RESOURCE_GROUP: pre-demo
         AZURE_SUBSCRIPTION_ID: c68a4bed-4c3d-4956-af51-4ae164c1957c
         PLATFORM_ENV_TAG: Demo
+        MEDIA_SERVICE: MediaKind
     global:
       jobKind: CronJob
       enableKeyVaults: true

--- a/apps/pre/pre-api-cron-cleanup-streaming-locators/stg.yaml
+++ b/apps/pre/pre-api-cron-cleanup-streaming-locators/stg.yaml
@@ -11,9 +11,9 @@ spec:
       disableActiveClusterCheck: true
       schedule: "0 0 * * *"
       environment:
-        AZURE_MEDIA_SERVICES_ACCOUNT_NAME: preamstest
-        AZURE_RESOURCE_GROUP: pre-test
-        AZURE_SUBSCRIPTION_ID: 3eec5bde-7feb-4566-bfb6-805df6e10b90
+        AZURE_MEDIA_SERVICES_ACCOUNT_NAME: preamsstg
+        AZURE_RESOURCE_GROUP: pre-stg
+        AZURE_SUBSCRIPTION_ID: 74dacd4f-a248-45bb-a2f0-af700dc4cf68
         PLATFORM_ENV_TAG: Staging
         AZURE_INGEST_SA: preingestsastg
         AZURE_FINAL_SA: prefinalsastg

--- a/apps/pre/pre-api/stg.yaml
+++ b/apps/pre/pre-api/stg.yaml
@@ -9,9 +9,9 @@ spec:
     java:
       ingressHost: pre-api.staging.platform.hmcts.net
       environment:
-        AZURE_MEDIA_SERVICES_ACCOUNT_NAME: preamstest
-        AZURE_RESOURCE_GROUP: pre-test
-        AZURE_SUBSCRIPTION_ID: 3eec5bde-7feb-4566-bfb6-805df6e10b90
+        AZURE_MEDIA_SERVICES_ACCOUNT_NAME: preamsstg
+        AZURE_RESOURCE_GROUP: pre-stg
+        AZURE_SUBSCRIPTION_ID: 74dacd4f-a248-45bb-a2f0-af700dc4cf68
         PLATFORM_ENV_TAG: Staging
         AZURE_INGEST_SA: preingestsastg
         AZURE_FINAL_SA: prefinalsastg


### PR DESCRIPTION
### Jira link

### Change description
- pre-api (stg)
    - Update resource group, subscription id, AMS account name to stg
- pre-api crons (demo)
    - Update media service implementation to MediaKind

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


- Modified `demo.yaml` and `stg.yaml` files in `pre-api-cron-cleanup-live-events` and `pre-api-cron-cleanup-streaming-locators` folders respectively
- Updated `AZURE_MEDIA_SERVICES_ACCOUNT_NAME`, `AZURE_RESOURCE_GROUP`, `AZURE_SUBSCRIPTION_ID`, and `PLATFORM_ENV_TAG` values for the staging environment
- Added a new `MEDIA_SERVICE` key with value `MediaKind` in the `demo.yaml` files to specify the media service
- Updated `ingressHost` value in `stg.yaml` of `pre-api` folder to `pre-api.staging.platform.hmcts.net`