### PR TITLE
Remove prod approvals group from codeowners - legacy

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,10 +6,6 @@ CODEOWNERS @hmcts/platform-operations
 apps/ @hmcts/platform-operations
 clusters/ @hmcts/platform-operations
 
-# Production applications
-## environment rules
-clusters/prod/ @hmcts/production-apps-approvals
-
 ## Platform rules
 
 apps/kube-system/ @hmcts/platform-operations


### PR DESCRIPTION
### Change description

- remove prod approvals group from codeowners file
- prod approvals group is legacy and not used anymore


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change






## 🤖AEP PR SUMMARY🤖


md
- Removed clusters/prod/ from the list of CODEOWNERS for @hmcts/production-apps-approvals
```