### PR TITLE
move demo pre-portal to use prod image and reenable auto update

### DIFF
--- a/apps/pre/pre-portal/demo-image-policy.yaml
+++ b/apps/pre/pre-portal/demo-image-policy.yaml
@@ -3,10 +3,10 @@ kind: ImagePolicy
 metadata:
   name: demo-pre-portal
   annotations:
-    hmcts.github.com/prod-automated: disabled
+    hmcts.github.com/prod-automated: enabled
 spec:
   filterTags:
-    pattern: '^pr-392-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:

--- a/apps/pre/pre-portal/demo.yaml
+++ b/apps/pre/pre-portal/demo.yaml
@@ -8,7 +8,6 @@ spec:
   values:
     nodejs:
       replicas: 2
-      image: sdshmctspublic.azurecr.io/pre/portal:pr-392-eef27bd-20240820103228 # {"$imagepolicy": "flux-system:demo-pre-portal"}
       ingressHost: pre-portal.demo.platform.hmcts.net
       environment:
         PRE_API_URL: https://sds-api-mgmt.demo.platform.hmcts.net/pre-api


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/S28-3233

Demo is using PR 392 image. require master image to be deployed for pre-prortal
this PR reverts previous image change and back to automated.
### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


- demo-image-policy.yaml```: 
  - Changed the annotation `hmcts.github.com/prod-automated` from `disabled` to `enabled`.
  - Updated the `filterTags` pattern to `^prod-[a-f0-9]+-(?P<ts>[0-9]+)`.
- ```demo.yaml```: 
  - Removed the `image` field with value `sdshmctspublic.azurecr.io/pre/portal:pr-392-eef27bd-20240820103228`.