### PR TITLE
change vh-notification-api ithc to use stg image policy

### DIFF
--- a/apps/vh/notification-api/ithc.yaml
+++ b/apps/vh/notification-api/ithc.yaml
@@ -9,4 +9,4 @@ spec:
     java:
       ingressHost: vh-notification-api.ithc.platform.hmcts.net
       environment:
-      image: sdshmctspublic.azurecr.io/vh/notification-api:prod-661abad-202408191246 #{"$imagepolicy": "flux-system:vh-notification-api"}
+      image: sdshmctspublic.azurecr.io/vh/notification-api:staging-661abad-202408151250 # {"$imagepolicy": "flux-system:vh-notification-api-staging"}


### PR DESCRIPTION
### Jira link

See [VIH-10911](https://tools.hmcts.net/jira/browse/VIH-10911)

### Change description

Changes vh-notification-api to use staging image


## 🤖AEP PR SUMMARY🤖


### apps/vh/notification-api/ithc.yaml
- Updated the image from `prod` to `staging` with a different timestamp.