### PR TITLE
PUB-2531 Removed ENABLE_CFT flag from PIP frontend

### DIFF
--- a/apps/pip/frontend/demo.yaml
+++ b/apps/pip/frontend/demo.yaml
@@ -17,7 +17,6 @@ spec:
         ADMIN_AUTH_RETURN_URL: https://pip-frontend.demo.platform.hmcts.net/login/admin/return
         FRONTEND_URL: https://pip-frontend.demo.platform.hmcts.net
         CFT_IDAM_URL: https://idam-web-public.demo.platform.hmcts.net
-        ENABLE_CFT: true
         CONFIG_ENDPOINT: https://sign-in.pip-frontend.demo.platform.hmcts.net/pip-frontend.demo.platform.hmcts.net/B2C_1_SignInUserFlow/v2.0/.well-known/openid-configuration
         CONFIG_ADMIN_ENDPOINT: https://staff.pip-frontend.demo.platform.hmcts.net/pip-frontend.demo.platform.hmcts.net/B2C_1_SignInAdminUserFlow/v2.0/.well-known/openid-configuration
         MEDIA_VERIFICATION_CONFIG_ENDPOINT: https://sign-in.pip-frontend.demo.platform.hmcts.net/pip-frontend.demo.platform.hmcts.net/B2C_1_SignInMediaVerification/v2.0/.well-known/openid-configuration

--- a/apps/pip/frontend/ithc.yaml
+++ b/apps/pip/frontend/ithc.yaml
@@ -17,7 +17,6 @@ spec:
         ADMIN_AUTH_RETURN_URL: https://pip-frontend.ithc.platform.hmcts.net/login/admin/return
         FRONTEND_URL: https://pip-frontend.ithc.platform.hmcts.net
         CFT_IDAM_URL: https://idam-web-public.ithc.platform.hmcts.net
-        ENABLE_CFT: true
         CONFIG_ENDPOINT: https://sign-in.pip-frontend.ithc.platform.hmcts.net/pip-frontend.ithc.platform.hmcts.net/B2C_1_SignInUserFlow/v2.0/.well-known/openid-configuration
         CONFIG_ADMIN_ENDPOINT: https://staff.pip-frontend.ithc.platform.hmcts.net/pip-frontend.ithc.platform.hmcts.net/B2C_1_SignInAdminUserFlow/v2.0/.well-known/openid-configuration
         MEDIA_VERIFICATION_CONFIG_ENDPOINT: https://sign-in.pip-frontend.ithc.platform.hmcts.net/pip-frontend.ithc.platform.hmcts.net/B2C_1_SignInMediaVerification/v2.0/.well-known/openid-configuration

--- a/apps/pip/frontend/prod.yaml
+++ b/apps/pip/frontend/prod.yaml
@@ -22,5 +22,4 @@ spec:
         B2C_URL: https://sign-in.court-tribunal-hearings.service.gov.uk/court-tribunal-hearings.service.gov.uk
         B2C_ADMIN_URL: https://staff.court-tribunal-hearings.service.gov.uk/court-tribunal-hearings.service.gov.uk
         CFT_IDAM_URL: https://hmcts-access.service.gov.uk
-        ENABLE_CFT: true
         RESTART_PROD: true

--- a/apps/pip/frontend/stg.yaml
+++ b/apps/pip/frontend/stg.yaml
@@ -23,5 +23,4 @@ spec:
         B2C_URL: https://sign-in.pip-frontend.staging.platform.hmcts.net/pip-frontend.staging.platform.hmcts.net
         B2C_ADMIN_URL: https://staff.pip-frontend.staging.platform.hmcts.net/pip-frontend.staging.platform.hmcts.net
         CFT_IDAM_URL: https://idam-web-public.aat.platform.hmcts.net
-        ENABLE_CFT: true
         CRIME_IDAM_URL: https://login.prp.cjscp.org.uk

--- a/apps/pip/frontend/test.yaml
+++ b/apps/pip/frontend/test.yaml
@@ -19,7 +19,6 @@ spec:
         ADMIN_AUTH_RETURN_URL: https://pip-frontend.test.platform.hmcts.net/login/admin/return
         FRONTEND_URL: https://pip-frontend.test.platform.hmcts.net
         CFT_IDAM_URL: https://idam-web-public.perftest.platform.hmcts.net
-        ENABLE_CFT: true
         CONFIG_ENDPOINT: https://sign-in.pip-frontend.test.platform.hmcts.net/pip-frontend.test.platform.hmcts.net/B2C_1_SignInUserFlow/v2.0/.well-known/openid-configuration
         CONFIG_ADMIN_ENDPOINT: https://staff.pip-frontend.test.platform.hmcts.net/pip-frontend.test.platform.hmcts.net/B2C_1_SignInAdminUserFlow/v2.0/.well-known/openid-configuration
         MEDIA_VERIFICATION_CONFIG_ENDPOINT: https://sign-in.pip-frontend.test.platform.hmcts.net/pip-frontend.test.platform.hmcts.net/B2C_1_SignInMediaVerification/v2.0/.well-known/openid-configuration


### PR DESCRIPTION
### Jira link

See [PUB-2531](https://tools.hmcts.net/jira/browse/PUB-2531)

### Change description

Removed ENABLE_CFT flag from PIP frontend

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change






## 🤖AEP PR SUMMARY🤖


- demo.yaml
  - Removed ENABLE_CFT: true from the spec.

- ithc.yaml
  - Removed ENABLE_CFT: true from the spec.

- prod.yaml
  - Removed ENABLE_CFT: true from the spec.

- stg.yaml
  - Removed ENABLE_CFT: true from the spec.

- test.yaml
  - Removed ENABLE_CFT: true from the spec.