### PR TITLE
PUB-2327 Remove test image with rate limiting prototype

### DIFF
--- a/apps/pip/frontend/test.yaml
+++ b/apps/pip/frontend/test.yaml
@@ -7,7 +7,6 @@ spec:
   values:
     nodejs:
       replicas: 2
-      image: sdshmctspublic.azurecr.io/pip/frontend:pr-1328-bb76672-20240827081522
       ingressHost: pip-frontend.test.platform.hmcts.net
       environment:
         DATA_MANAGEMENT_URL: https://pip-data-management.test.platform.hmcts.net


### PR DESCRIPTION
### Change description

 Remove test image with rate limiting prototype

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


### apps/pip/frontend/test.yaml
- Removed one instance of `replicas: 2` 
- Removed the `image` field
- Updated `ingressHost` to `pip-frontend.test.platform.hmcts.net`
- Updated `DATA_MANAGEMENT_URL` to point to `https://pip-data-management.test.platform.hmcts.net`