### PR TITLE
NO_JIRA: log Darts feign clients requests/responses full details on Demo

### DIFF
--- a/apps/darts-modernisation/darts-api/demo.yaml
+++ b/apps/darts-modernisation/darts-api/demo.yaml
@@ -19,3 +19,4 @@ spec:
       image: sdshmctspublic.azurecr.io/darts/api:prod-dab3909-20240828101200 # {"$imagepolicy": "flux-system:darts-api"}
       environment:
         ARM_URL: https://www.test.court-tribunal-records-archive.service.justice.gov.uk
+        FEIGN_LOG_LEVEL: full

--- a/apps/darts-modernisation/darts-automated-tasks/demo.yaml
+++ b/apps/darts-modernisation/darts-automated-tasks/demo.yaml
@@ -12,3 +12,4 @@ spec:
         DARTS_PORTAL_URL: https://darts.demo.apps.hmcts.net
         DARTS_LOG_LEVEL: DEBUG
         ARM_URL: https://www.test.court-tribunal-records-archive.service.justice.gov.uk
+        FEIGN_LOG_LEVEL: full


### PR DESCRIPTION
Changes:
During QA it it sometimes important to see the full details of http requests and responses Darts is making to external services, e.g. ARM.
This PR configures Feign clients to log headers, body, and metadata for both requests and responses on Demo

depends on: 
https://github.com/hmcts/darts-api/pull/1916