### PR TITLE
Revert "add pr image for test"

### DIFF
--- a/apps/pip/frontend/test.yaml
+++ b/apps/pip/frontend/test.yaml
@@ -7,7 +7,6 @@ spec:
   values:
     nodejs:
       replicas: 2
-      image: sdshmctspublic.azurecr.io/pip/frontend:pr-1330-dd1fbe7-20240829113917
       ingressHost: pip-frontend.test.platform.hmcts.net
       environment:
         DATA_MANAGEMENT_URL: https://pip-data-management.test.platform.hmcts.net


### PR DESCRIPTION
Reverts hmcts/sds-flux-config#5353

## 🤖AEP PR SUMMARY🤖


### apps/pip/frontend/test.yaml
- Removed an image reference for `sdshmctspublic.azurecr.io/pip/frontend:pr-1330-dd1fbe7-20240829113917`.
- Updated the replicas value to 2.