### PR TITLE
PUB-2564 Add Azure Service Operator resource group for dev env to provision blob storage

### DIFF
--- a/apps/pip/dev/base/kustomization.yaml
+++ b/apps/pip/dev/base/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - ../../../rbac/dev-role.yaml
   - ../../../base/workload-identity
   - ../../../base/slack-provider/dev
+  - ../../../azureserviceoperator-system/resources/resource-group.yaml
 namespace: pip
 patches:
   - path: ../../identity/dev.yaml


### PR DESCRIPTION
### Jira link

See [PUB-2564](https://tools.hmcts.net/jira/browse/PUB-2564)

### Change description

Add Azure Service Operator resource group for dev env to provision blob storage

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change








## 🤖AEP PR SUMMARY🤖


### apps/pip/dev/base/kustomization.yaml
- Added a resource for Azure Service Operator system resource group.
- Updated the namespace to \"pip\".
- Added a patch for dev identity.