### PR TITLE
ASO: beta resources update - needed for ASO upgrade

### DIFF
--- a/apps/azureserviceoperator-system/resources/resource-group.yaml
+++ b/apps/azureserviceoperator-system/resources/resource-group.yaml
@@ -1,4 +1,4 @@
-apiVersion: resources.azure.com/v1beta20200601
+apiVersion: resources.azure.com/v1api20200601
 kind: ResourceGroup
 metadata:
   name: ${NAMESPACE}-aso-${ENVIRONMENT}-rg

--- a/apps/base/workload-identity/workload-identity-federated-credential.yaml
+++ b/apps/base/workload-identity/workload-identity-federated-credential.yaml
@@ -1,4 +1,4 @@
-apiVersion: managedidentity.azure.com/v1beta20220131preview
+apiVersion: managedidentity.azure.com/v1api20220131preview
 kind: FederatedIdentityCredential
 metadata:
   name: ${WI_NAME}-${WI_CLUSTER}-fic

--- a/apps/base/workload-identity/workload-identity-rg.yaml
+++ b/apps/base/workload-identity/workload-identity-rg.yaml
@@ -1,4 +1,4 @@
-apiVersion: resources.azure.com/v1beta20200601
+apiVersion: resources.azure.com/v1api20200601
 kind: ResourceGroup
 metadata:
   name: managed-identities-${WI_ENVIRONMENT}-rg

--- a/apps/base/workload-identity/workload-identity-ua-identity.yaml
+++ b/apps/base/workload-identity/workload-identity-ua-identity.yaml
@@ -1,4 +1,4 @@
-apiVersion: managedidentity.azure.com/v1beta20181130
+apiVersion: managedidentity.azure.com/v1api20181130
 kind: UserAssignedIdentity
 metadata:
   name: ${WI_NAME}-${WI_ENVIRONMENT}-mi


### PR DESCRIPTION
### Jira link

[DTSPO-18113](https://tools.hmcts.net/jira/browse/DTSPO-18113)

### Change description

Enable ASO upgrade by updating any beta versions for aso resources
2.4 breaking changes detailed here: https://github.com/Azure/azure-service-operator/releases/tag/v2.4.0

### Testing done

Same work was done on CFT previously

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change




## 🤖AEP PR SUMMARY🤖


### apps/azureserviceoperator-system/resources/resource-group.yaml
- Updated the `apiVersion` from `v1beta20200601` to `v1api20200601`.

### apps/base/workload-identity/workload-identity-federated-credential.yaml
- Changed the `apiVersion` from `v1beta20220131preview` to `v1api20220131preview`.

### apps/base/workload-identity/workload-identity-rg.yaml
- Modified the `apiVersion` from `v1beta20200601` to `v1api20200601`.

### apps/base/workload-identity/workload-identity-ua-identity.yaml
- Updated the `apiVersion` from `v1beta20181130` to `v1api20181130`.