### PR TITLE
Revert "PUB-1692 - Testing autoscaling"

### DIFF
--- a/apps/pip/data-management/test.yaml
+++ b/apps/pip/data-management/test.yaml
@@ -6,11 +6,7 @@ spec:
   releaseName: pip-data-management
   values:
     java:
-      autoscaling:
-        enabled: true
-        maxReplicas: 5
-        minReplicas: 2
-        targetCPUUtilizationPercentage: 80
+      replicas: 2
       ingressHost: pip-data-management.test.platform.hmcts.net
       environment:
         SUBSCRIPTION_MANAGEMENT_URL: https://pip-subscription-management.test.platform.hmcts.net


### PR DESCRIPTION
Reverts hmcts/sds-flux-config#5389

## 🤖AEP PR SUMMARY🤖


### apps/pip/data-management/test.yaml
- Changed the autoscaling configuration to specify the number of replicas (replicas: 2) instead of using autoscaling with a minReplicas of 2, maxReplicas of 5, and targetCPUUtilizationPercentage of 80.