### PR TITLE
DMP-3863: Add DARTS_PORTAL_URL env var to Demo env

### DIFF
--- a/apps/darts-modernisation/darts-portal/demo.yaml
+++ b/apps/darts-modernisation/darts-portal/demo.yaml
@@ -11,4 +11,5 @@ spec:
       environment:
         RESTART_ME: '001'
         DARTS_AZUREAD_B2C_ORIGIN_HOST: https://hmctsstgextid.b2clogin.com
-        DARTS_PORTAL_ALLOW_STUB_DATA: true
+        DARTS_PORTAL_ALLOW_STUB_DATA: true,
+        DARTS_PORTAL_URL: https://darts.demo.apps.hmcts.net


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DMP-3863

### Change description

The link on the B2C screen is derived from this environment variable

## 🤖AEP PR SUMMARY🤖


### apps/darts-modernisation/darts-portal/demo.yaml
- Added a new environment variable `DARTS_PORTAL_URL` with the value `https://darts.demo.apps.hmcts.net` to the `demo.yaml` file 🚀