### PR TITLE
Setting DARTS portal DARTS_AZUREAD_B2C_HOSTNAME appropriately

### DIFF
--- a/apps/darts-modernisation/darts-portal/prod.yaml
+++ b/apps/darts-modernisation/darts-portal/prod.yaml
@@ -12,3 +12,4 @@ spec:
         DARTS_API_URL: https://darts-api.platform.hmcts.net
         DARTS_PORTAL_URL: https://darts.apps.hmcts.net
         DARTS_AZUREAD_B2C_ORIGIN_HOST: https://hmctsprodextid.b2clogin.com
+        DARTS_AZUREAD_B2C_HOSTNAME: https://darts.apps.hmcts.net

--- a/apps/darts-modernisation/darts-portal/sbox.yaml
+++ b/apps/darts-modernisation/darts-portal/sbox.yaml
@@ -11,3 +11,4 @@ spec:
       environment:
         DARTS_API_URL: https://darts-api.sandbox.platform.hmcts.net
         DARTS_PORTAL_URL: https://darts.sandbox.apps.hmcts.net
+        DARTS_AZUREAD_B2C_HOSTNAME: https://darts.sandbox.apps.hmcts.net

--- a/apps/darts-modernisation/darts-portal/stg.yaml
+++ b/apps/darts-modernisation/darts-portal/stg.yaml
@@ -14,3 +14,7 @@ spec:
         DARTS_AZUREAD_B2C_ORIGIN_HOST: https://hmctsstgextid.b2clogin.com
         DARTS_DYNATRACE_SCRIPT_URL: https://js-cdn.dynatrace.com/jstag/17177a07246/bf24054dsx/274641a9600eefc2_complete.js
         DARTS_PORTAL_ALLOW_STUB_DATA: true
+        # this might seem strange, but it is intentional, see DMP-3863
+        # it's only used in the HTML template provided for Azure AD B2C customisation, and the staging B2C is used for staging and demo
+        # this means that the URL used for assets and hyperlink to the internal login will be the demo env
+        DARTS_AZUREAD_B2C_HOSTNAME: https://darts.demo.apps.hmcts.net


### PR DESCRIPTION
- demo and staging use the staging B2C
- set the URL on staging to demo so that a link we provide to the internal login page points to demo

### Jira link

<!-- 
Replace PROJ-XXXXXX with your Jira key
Remove this section if its not applicable, or replace it with another reference link
-->
https://tools.hmcts.net/jira/browse/DMP-3863

### Change description

<!--
Provide a description of what change you are proposing.
A short summary here and then you can add comments in your pull request explaining your change to others.
-->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change










## 🤖AEP PR SUMMARY🤖


### apps/darts-modernisation/darts-portal/prod.yaml
- Added a new environment variable `DARTS_AZUREAD_B2C_HOSTNAME` with value `https://darts.apps.hmcts.net`.

### apps/darts-modernisation/darts-portal/sbox.yaml
- Added a new environment variable `DARTS_AZUREAD_B2C_HOSTNAME` with value `https://darts.sandbox.apps.hmcts.net`.

### apps/darts-modernisation/darts-portal/stg.yaml
- Added a new environment variable `DARTS_AZUREAD_B2C_HOSTNAME` with value `https://darts.demo.apps.hmcts.net`.