### PR TITLE
Set PRE STG to use MediaKind now

### DIFF
--- a/apps/pre/pre-api-cron-cleanup-live-events/stg.yaml
+++ b/apps/pre/pre-api-cron-cleanup-live-events/stg.yaml
@@ -13,4 +13,4 @@ spec:
       environment:
         AZURE_SUBSCRIPTION_ID: 74dacd4f-a248-45bb-a2f0-af700dc4cf68
         PLATFORM_ENV_TAG: Staging
-        MEDIA_SERVICE: AzureMediaService
+        MEDIA_SERVICE: MediaKind

--- a/apps/pre/pre-api-cron-cleanup-streaming-locators/stg.yaml
+++ b/apps/pre/pre-api-cron-cleanup-streaming-locators/stg.yaml
@@ -13,4 +13,4 @@ spec:
       environment:
         AZURE_SUBSCRIPTION_ID: 74dacd4f-a248-45bb-a2f0-af700dc4cf68
         PLATFORM_ENV_TAG: Staging
-        MEDIA_SERVICE: AzureMediaService
+        MEDIA_SERVICE: MediaKind

--- a/apps/pre/pre-api/stg.yaml
+++ b/apps/pre/pre-api/stg.yaml
@@ -15,4 +15,4 @@ spec:
         PLATFORM_ENV_TAG: Staging
         AZURE_INGEST_SA: preingestsastg
         AZURE_FINAL_SA: prefinalsastg
-        MEDIA_SERVICE: AzureMediaService
+        MEDIA_SERVICE: MediaKind


### PR DESCRIPTION




## 🤖AEP PR SUMMARY🤖


- `pre-api-cron-cleanup-live-events/stg.yaml` 🔄
  - Changed `MEDIA_SERVICE` from `AzureMediaService` to `MediaKind`.
  
- `pre-api-cron-cleanup-streaming-locators/stg.yaml` 🔄
  - Changed `MEDIA_SERVICE` from `AzureMediaService` to `MediaKind`.
  
- `pre-api/stg.yaml` 🔄
  - Changed `MEDIA_SERVICE` from `AzureMediaService` to `MediaKind`.