### PR TITLE
Revert "PUB-1692 - Autoscaling test"

### DIFF
--- a/apps/pip/account-management/test.yaml
+++ b/apps/pip/account-management/test.yaml
@@ -7,11 +7,7 @@ spec:
   releaseName: pip-account-management
   values:
     java:
-      autoscaling:
-        enabled: true
-        maxReplicas: 5
-        minReplicas: 2
-        targetCPUUtilizationPercentage: 80
+      replicas: 2
       ingressHost: pip-account-management.test.platform.hmcts.net
       environment:
         PUBLICATION_SERVICES_URL: https://pip-publication-services.test.platform.hmcts.net

--- a/apps/pip/data-management/test.yaml
+++ b/apps/pip/data-management/test.yaml
@@ -6,11 +6,7 @@ spec:
   releaseName: pip-data-management
   values:
     java:
-      autoscaling:
-        enabled: true
-        maxReplicas: 5
-        minReplicas: 2
-        targetCPUUtilizationPercentage: 80
+      replicas: 2
       ingressHost: pip-data-management.test.platform.hmcts.net
       environment:
         SUBSCRIPTION_MANAGEMENT_URL: https://pip-subscription-management.test.platform.hmcts.net

--- a/apps/pip/frontend/test.yaml
+++ b/apps/pip/frontend/test.yaml
@@ -6,11 +6,7 @@ spec:
   releaseName: pip-frontend
   values:
     nodejs:
-      autoscaling:
-        enabled: true
-        maxReplicas: 5
-        minReplicas: 2
-        targetCPUUtilizationPercentage: 80
+      replicas: 2
       ingressHost: pip-frontend.test.platform.hmcts.net
       environment:
         DATA_MANAGEMENT_URL: https://pip-data-management.test.platform.hmcts.net

--- a/apps/pip/publication-services/test.yaml
+++ b/apps/pip/publication-services/test.yaml
@@ -7,11 +7,7 @@ spec:
   releaseName: pip-publication-services
   values:
     java:
-      autoscaling:
-        enabled: true
-        maxReplicas: 5
-        minReplicas: 2
-        targetCPUUtilizationPercentage: 80
+      replicas: 2
       ingressHost: pip-publication-services.test.platform.hmcts.net
       environment:
         DATA_MANAGEMENT_URL: https://pip-data-management.test.platform.hmcts.net

--- a/apps/pip/subscription-management/test.yaml
+++ b/apps/pip/subscription-management/test.yaml
@@ -7,11 +7,7 @@ spec:
   releaseName: pip-subscription-management
   values:
     java:
-      autoscaling:
-        enabled: true
-        maxReplicas: 5
-        minReplicas: 2
-        targetCPUUtilizationPercentage: 80
+      replicas: 2
       ingressHost: pip-subscription-management.test.platform.hmcts.net
       environment:
         DATA_MANAGEMENT_URL: https://pip-data-management.test.platform.hmcts.net


### PR DESCRIPTION
Reverts hmcts/sds-flux-config#5425

## 🤖AEP PR SUMMARY🤖


- Modified files: 
  - test.yaml in account-management, data-management, frontend, publication-services, and subscription-management

- In each file:
  - Replaced the autoscaling configuration with a simple replicas field, setting its value to 2
  - Updated the ingress host to point to the test environment platform URL
  - Updated the environment variables for each service to point to the appropriate test environment URLs