### PR TITLE
VIH-10983 set Test env to use test image policy

### DIFF
--- a/apps/vh/admin-web/image-policy.yaml
+++ b/apps/vh/admin-web/image-policy.yaml
@@ -17,6 +17,22 @@ spec:
 apiVersion: image.toolkit.fluxcd.io/v1beta1
 kind: ImagePolicy
 metadata:
+  name: vh-admin-web-test
+  annotations:
+    hmcts.github.com/prod-automated: disabled
+spec:
+  filterTags:
+    extract: $ts
+    pattern: '^test-[a-f0-9]+-(?P<ts>[0-9]+)'
+  imageRepositoryRef:
+    name: vh-admin-web
+  policy:
+    alphabetical:
+      order: asc
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta1
+kind: ImagePolicy
+metadata:
   name: vh-admin-web
   annotations:
     hmcts.github.com/prod-automated: disabled

--- a/apps/vh/admin-web/test.yaml
+++ b/apps/vh/admin-web/test.yaml
@@ -8,4 +8,4 @@ spec:
   values:
     java:
       ingressHost: vh-admin-web.test.platform.hmcts.net
-      image: sdshmctspublic.azurecr.io/vh/admin-web:dev-164fb43-202409121738 #{"$imagepolicy": "flux-system:vh-admin-web-dev"}
+      image: sdshmctspublic.azurecr.io/vh/admin-web:dev-164fb43-202409121738 #{"$imagepolicy": "flux-system:vh-admin-web-test"}

--- a/apps/vh/booking-queue-subscriber/image-policy.yaml
+++ b/apps/vh/booking-queue-subscriber/image-policy.yaml
@@ -17,6 +17,22 @@ spec:
 apiVersion: image.toolkit.fluxcd.io/v1beta1
 kind: ImagePolicy
 metadata:
+  name: vh-booking-queue-subscriber-test
+  annotations:
+    hmcts.github.com/prod-automated: disabled
+spec:
+  filterTags:
+    extract: $ts
+    pattern: '^test-[a-f0-9]+-(?P<ts>[0-9]+)'
+  imageRepositoryRef:
+    name: vh-booking-queue-subscriber
+  policy:
+    alphabetical:
+      order: asc
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta1
+kind: ImagePolicy
+metadata:
   name: vh-booking-queue-subscriber-staging
   annotations:
     hmcts.github.com/prod-automated: disabled

--- a/apps/vh/booking-queue-subscriber/test.yaml
+++ b/apps/vh/booking-queue-subscriber/test.yaml
@@ -7,7 +7,7 @@ spec:
   releaseName: vh-booking-queue-subscriber
   values:
     java:
-      image: sdshmctspublic.azurecr.io/vh/booking-queue-subscriber:dev-b42d6c3-202409161232 # {"$imagepolicy": "flux-system:vh-booking-queue-subscriber-dev"}
+      image: sdshmctspublic.azurecr.io/vh/booking-queue-subscriber:dev-b42d6c3-202409161232 # {"$imagepolicy": "flux-system:vh-booking-queue-subscriber-test"}
     function:
       triggers:
       - type: azure-servicebus

--- a/apps/vh/bookings-api/image-policy.yaml
+++ b/apps/vh/bookings-api/image-policy.yaml
@@ -17,6 +17,22 @@ spec:
 apiVersion: image.toolkit.fluxcd.io/v1beta1
 kind: ImagePolicy
 metadata:
+  name: vh-bookings-api-test
+  annotations:
+    hmcts.github.com/prod-automated: disabled
+spec:
+  filterTags:
+    extract: $ts
+    pattern: '^test-[a-f0-9]+-(?P<ts>[0-9]+)'
+  imageRepositoryRef:
+    name: vh-bookings-api
+  policy:
+    alphabetical:
+      order: asc
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta1
+kind: ImagePolicy
+metadata:
   name: vh-bookings-api-staging
   annotations:
     hmcts.github.com/prod-automated: disabled

--- a/apps/vh/bookings-api/test.yaml
+++ b/apps/vh/bookings-api/test.yaml
@@ -8,4 +8,4 @@ spec:
   values:
     java:
       ingressHost: vh-bookings-api.test.platform.hmcts.net
-      image: sdshmctspublic.azurecr.io/vh/bookings-api:dev-b9dc4bb-202409121646 #{"$imagepolicy": "flux-system:vh-bookings-api-dev"}
+      image: sdshmctspublic.azurecr.io/vh/bookings-api:dev-b9dc4bb-202409121646 #{"$imagepolicy": "flux-system:vh-bookings-api-test"}

--- a/apps/vh/notification-api/image-policy.yaml
+++ b/apps/vh/notification-api/image-policy.yaml
@@ -17,6 +17,22 @@ spec:
 apiVersion: image.toolkit.fluxcd.io/v1beta1
 kind: ImagePolicy
 metadata:
+  name: vh-notification-api-test
+  annotations:
+    hmcts.github.com/prod-automated: disabled
+spec:
+  filterTags:
+    extract: $ts
+    pattern: '^test-[a-f0-9]+-(?P<ts>[0-9]+)'
+  imageRepositoryRef:
+    name: vh-notification-api
+  policy:
+    alphabetical:
+      order: asc
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta1
+kind: ImagePolicy
+metadata:
   name: vh-notification-api-staging
   annotations:
     hmcts.github.com/prod-automated: disabled

--- a/apps/vh/notification-api/test.yaml
+++ b/apps/vh/notification-api/test.yaml
@@ -8,4 +8,4 @@ spec:
   values:
     java:
       ingressHost: vh-notification-api.test.platform.hmcts.net
-      image: sdshmctspublic.azurecr.io/vh/notification-api:dev-52fd379-202409201629 #{"$imagepolicy": "flux-system:vh-notification-api-dev"}
+      image: sdshmctspublic.azurecr.io/vh/notification-api:dev-52fd379-202409201629 #{"$imagepolicy": "flux-system:vh-notification-api-test"}

--- a/apps/vh/scheduler-jobs/image-policy.yaml
+++ b/apps/vh/scheduler-jobs/image-policy.yaml
@@ -17,6 +17,22 @@ spec:
 apiVersion: image.toolkit.fluxcd.io/v1beta1
 kind: ImagePolicy
 metadata:
+  name: vh-scheduler-jobs-test
+  annotations:
+    hmcts.github.com/prod-automated: disabled
+spec:
+  filterTags:
+    extract: $ts
+    pattern: '^test-[a-f0-9]+-(?P<ts>[0-9]+)'
+  imageRepositoryRef:
+    name: vh-scheduler-jobs
+  policy:
+    alphabetical:
+      order: asc
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta1
+kind: ImagePolicy
+metadata:
   name: vh-scheduler-jobs-staging
   annotations:
     hmcts.github.com/prod-automated: disabled

--- a/apps/vh/scheduler-jobs/test.yaml
+++ b/apps/vh/scheduler-jobs/test.yaml
@@ -6,4 +6,4 @@ metadata:
 spec:
   releaseName: vh-scheduler-jobs
   values:
-    image: sdshmctspublic.azurecr.io/vh/scheduler-jobs-sds:dev-6ec1fef-202408201532 #{"$imagepolicy": "flux-system:vh-scheduler-jobs-dev"}
+    image: sdshmctspublic.azurecr.io/vh/scheduler-jobs-sds:dev-6ec1fef-202408201532 #{"$imagepolicy": "flux-system:vh-scheduler-jobs-test"}

--- a/apps/vh/user-api/image-policy.yaml
+++ b/apps/vh/user-api/image-policy.yaml
@@ -17,6 +17,22 @@ spec:
 apiVersion: image.toolkit.fluxcd.io/v1beta1
 kind: ImagePolicy
 metadata:
+  name: vh-user-api-test
+  annotations:
+    hmcts.github.com/prod-automated: disabled
+spec:
+  filterTags:
+    extract: $ts
+    pattern: '^test-[a-f0-9]+-(?P<ts>[0-9]+)'
+  imageRepositoryRef:
+    name: vh-user-api
+  policy:
+    alphabetical:
+      order: asc
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta1
+kind: ImagePolicy
+metadata:
   name: vh-user-api
   annotations:
     hmcts.github.com/prod-automated: disabled

--- a/apps/vh/user-api/test.yaml
+++ b/apps/vh/user-api/test.yaml
@@ -8,4 +8,4 @@ spec:
   values:
     java:
       ingressHost: vh-user-api.test.platform.hmcts.net
-      image: sdshmctspublic.azurecr.io/vh/user-api:dev-0d0f776-202409111332 #{"$imagepolicy": "flux-system:vh-user-api-dev"}
+      image: sdshmctspublic.azurecr.io/vh/user-api:dev-0d0f776-202409111332 #{"$imagepolicy": "flux-system:vh-user-api-test"}

--- a/apps/vh/video-api/image-policy.yaml
+++ b/apps/vh/video-api/image-policy.yaml
@@ -17,6 +17,22 @@ spec:
 apiVersion: image.toolkit.fluxcd.io/v1beta1
 kind: ImagePolicy
 metadata:
+  name: vh-video-api-test
+  annotations:
+    hmcts.github.com/prod-automated: disabled
+spec:
+  filterTags:
+    extract: $ts
+    pattern: '^test-[a-f0-9]+-(?P<ts>[0-9]+)'
+  imageRepositoryRef:
+    name: vh-video-api
+  policy:
+    alphabetical:
+      order: asc
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta1
+kind: ImagePolicy
+metadata:
   name: vh-video-api-staging
   annotations:
     hmcts.github.com/prod-automated: disabled

--- a/apps/vh/video-api/test.yaml
+++ b/apps/vh/video-api/test.yaml
@@ -8,4 +8,4 @@ spec:
   values:
     java:
       ingressHost: vh-video-api.test.platform.hmcts.net
-      image: sdshmctspublic.azurecr.io/vh/video-api:dev-edfedb1-202409201440 #{"$imagepolicy": "flux-system:vh-video-api-dev"}
+      image: sdshmctspublic.azurecr.io/vh/video-api:dev-edfedb1-202409201440 #{"$imagepolicy": "flux-system:vh-video-api-test"}

--- a/apps/vh/video-web/image-policy.yaml
+++ b/apps/vh/video-web/image-policy.yaml
@@ -17,6 +17,22 @@ spec:
 apiVersion: image.toolkit.fluxcd.io/v1beta1
 kind: ImagePolicy
 metadata:
+  name: vh-video-web-test
+  annotations:
+    hmcts.github.com/prod-automated: disabled
+spec:
+  filterTags:
+    extract: $ts
+    pattern: '^test-[a-f0-9]+-(?P<ts>[0-9]+)'
+  imageRepositoryRef:
+    name: vh-video-web
+  policy:
+    alphabetical:
+      order: asc
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta1
+kind: ImagePolicy
+metadata:
   name: vh-video-web-staging
   annotations:
     hmcts.github.com/prod-automated: disabled

--- a/apps/vh/video-web/test.yaml
+++ b/apps/vh/video-web/test.yaml
@@ -8,4 +8,4 @@ spec:
   values:
     java:
       ingressHost: vh-video-web.test.platform.hmcts.net
-      image: sdshmctspublic.azurecr.io/vh/video-web:dev-d94b1e1-202409161205 # {"$imagepolicy": "flux-system:vh-video-web-dev"}
+      image: sdshmctspublic.azurecr.io/vh/video-web:dev-d94b1e1-202409161205 # {"$imagepolicy": "flux-system:vh-video-web-test"}


### PR DESCRIPTION
### Jira link

See [VIH-10983](https://tools.hmcts.net/jira/browse/VIH-10983)

### Change description

Creates new test image policy for all VH apps to use in test env config.







## 🤖AEP PR SUMMARY🤖


- Updated `image-policy.yaml` files for `vh-admin-web`, `vh-booking-queue-subscriber`, `vh-bookings-api`, `vh-notification-api`, `vh-scheduler-jobs`, `vh-user-api`, `vh-video-api`, and `vh-video-web` to add a new test policy with disabled prod-automated annotations and filterTags pattern.
- Updated `test.yaml` files for `vh-admin-web`, `vh-booking-queue-subscriber`, `vh-bookings-api`, `vh-notification-api`, `vh-scheduler-jobs`, `vh-user-api`, `vh-video-api`, and `vh-video-web` to update the dev image versions.