### PR TITLE
Point jenkins to stg00 whilst upgrading 01

### DIFF
--- a/apps/jenkins/jenkins/ptl/jenkins.yaml
+++ b/apps/jenkins/jenkins/ptl/jenkins.yaml
@@ -55,9 +55,9 @@ spec:
                       - key: PTL_AKS_RESOURCE_GROUP
                         value: ss-ptl-00-rg
                       - key: STG_AKS_CLUSTER_NAME
-                        value: ss-stg-01-aks
+                        value: ss-stg-00-aks
                       - key: STG_AKS_RESOURCE_GROUP
-                        value: ss-stg-01-rg
+                        value: ss-stg-00-rg
                       - key: DEV_AKS_CLUSTER_NAME
                         value: ss-dev-01-aks
                       - key: DEV_AKS_RESOURCE_GROUP


### PR DESCRIPTION
Before removing 01 from appgw for the AKS upgrade

## 🤖AEP PR SUMMARY🤖


### apps/jenkins/jenkins/ptl/jenkins.yaml
- Updated the value of \"STG_AKS_CLUSTER_NAME\" from \"ss-stg-01-aks\" to \"ss-stg-00-aks\"
- Updated the value of \"STG_AKS_RESOURCE_GROUP\" from \"ss-stg-01-rg\" to \"ss-stg-00-rg\"