### PR TITLE
PUB-2340 - Updated test image

### DIFF
--- a/apps/pip/data-management/test.yaml
+++ b/apps/pip/data-management/test.yaml
@@ -6,7 +6,6 @@ spec:
   releaseName: pip-data-management
   values:
     java:
-      image: sdshmctspublic.azurecr.io/pip/data-management:pr-625-28ad495-20240912081348
       ingressHost: pip-data-management.test.platform.hmcts.net
       environment:
         SUBSCRIPTION_MANAGEMENT_URL: https://pip-subscription-management.test.platform.hmcts.net


### PR DESCRIPTION
### Jira link

N/A

### Change description

Changed back test image for PIP



## 🤖AEP PR SUMMARY🤖


### apps/pip/data-management/test.yaml
- Removed the `ingressHost` configuration for `pip-data-management.test.platform.hmcts.net`.
- Updated the `SUBSCRIPTION_MANAGEMENT_URL` environment variable to `https://pip-subscription-management.test.platform.hmcts.net`.