### PR TITLE
PUB-1692 - Update reference name for autoscaling config

### DIFF
--- a/apps/pip/account-management/test.yaml
+++ b/apps/pip/account-management/test.yaml
@@ -17,4 +17,4 @@ spec:
         enabled: true
         maxReplicas: 5
         minReplicas: 2
-        targetCPUUtilizationPercentage: 40
+        averageUtilization: 40

--- a/apps/pip/account-management/test.yaml
+++ b/apps/pip/account-management/test.yaml
@@ -17,4 +17,9 @@ spec:
         enabled: true
         maxReplicas: 5
         minReplicas: 2
-        averageUtilization: 40
+        cpu:
+          enabled: true
+          averageUtilization: 40
+        memory:
+          enabled: true
+          averageUtilization: 40

--- a/apps/pip/data-management/test.yaml
+++ b/apps/pip/data-management/test.yaml
@@ -17,4 +17,4 @@ spec:
         enabled: true
         maxReplicas: 5
         minReplicas: 2
-        targetCPUUtilizationPercentage: 40
+        averageUtilization: 40

--- a/apps/pip/data-management/test.yaml
+++ b/apps/pip/data-management/test.yaml
@@ -17,4 +17,9 @@ spec:
         enabled: true
         maxReplicas: 5
         minReplicas: 2
-        averageUtilization: 40
+        cpu:
+          enabled: true
+          averageUtilization: 40
+        memory:
+          enabled: true
+          averageUtilization: 40

--- a/apps/pip/frontend/test.yaml
+++ b/apps/pip/frontend/test.yaml
@@ -27,4 +27,9 @@ spec:
         enabled: true
         maxReplicas: 5
         minReplicas: 2
-        averageUtilization: 40
+        cpu:
+          enabled: true
+          averageUtilization: 40
+        memory:
+          enabled: true
+          averageUtilization: 40

--- a/apps/pip/frontend/test.yaml
+++ b/apps/pip/frontend/test.yaml
@@ -27,4 +27,4 @@ spec:
         enabled: true
         maxReplicas: 5
         minReplicas: 2
-        targetCPUUtilizationPercentage: 40
+        averageUtilization: 40

--- a/apps/pip/publication-services/test.yaml
+++ b/apps/pip/publication-services/test.yaml
@@ -21,4 +21,9 @@ spec:
         enabled: true
         maxReplicas: 5
         minReplicas: 2
-        averageUtilization: 40
+        cpu:
+          enabled: true
+          averageUtilization: 40
+        memory:
+          enabled: true
+          averageUtilization: 40

--- a/apps/pip/publication-services/test.yaml
+++ b/apps/pip/publication-services/test.yaml
@@ -21,4 +21,4 @@ spec:
         enabled: true
         maxReplicas: 5
         minReplicas: 2
-        targetCPUUtilizationPercentage: 40
+        averageUtilization: 40

--- a/apps/pip/subscription-management/test.yaml
+++ b/apps/pip/subscription-management/test.yaml
@@ -17,4 +17,4 @@ spec:
         enabled: true
         maxReplicas: 5
         minReplicas: 2
-        targetCPUUtilizationPercentage: 40
+        averageUtilization: 40

--- a/apps/pip/subscription-management/test.yaml
+++ b/apps/pip/subscription-management/test.yaml
@@ -17,4 +17,9 @@ spec:
         enabled: true
         maxReplicas: 5
         minReplicas: 2
-        averageUtilization: 40
+        cpu:
+          enabled: true
+          averageUtilization: 40
+        memory:
+          enabled: true
+          averageUtilization: 40


### PR DESCRIPTION
### Jira link

<!-- 
Replace PROJ-XXXXXX with your Jira key
Remove this section if its not applicable, or replace it with another reference link
-->
See [PROJ-XXXXXX](https://tools.hmcts.net/jira/browse/PROJ-XXXXXX)

### Change description

<!--
Provide a description of what change you are proposing.
A short summary here and then you can add comments in your pull request explaining your change to others.
-->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


















## 🤖AEP PR SUMMARY🤖


### apps/pip/account-management/test.yaml
- Added configuration for `cpu` and `memory` with both enabled and an averageUtilization of 40.

### apps/pip/data-management/test.yaml
- Added configuration for `cpu` and `memory` with both enabled and an averageUtilization of 40.

### apps/pip/frontend/test.yaml
- Added configuration for `cpu` and `memory` with both enabled and an averageUtilization of 40.

### apps/pip/publication-services/test.yaml
- Added configuration for `cpu` and `memory` with both enabled and an averageUtilization of 40.

### apps/pip/subscription-management/test.yaml
- Added configuration for `cpu` and `memory` with both enabled and an averageUtilization of 40.