### PR TITLE
break bais connection

### DIFF
--- a/apps/juror/juror-scheduler-execution/ithc.yaml
+++ b/apps/juror/juror-scheduler-execution/ithc.yaml
@@ -10,3 +10,5 @@ spec:
       # Uncomment and edit the line below to fix the environment at a specific image
       image: sdshmctspublic.azurecr.io/juror/scheduler-execution:pr-225-af2ae4e-20241003110808
       ingressHost: juror-scheduler-execution.ithc.platform.hmcts.net
+      environment:
+        BAIS_PORT: 222


### PR DESCRIPTION
break bais connection in ithc for testing


## 🤖AEP PR SUMMARY🤖


### apps/juror/juror-scheduler-execution/ithc.yaml
- Added environment variable `BAIS_PORT` with value `222`. 🚀