### PR TITLE
juror: Revert "break bais connection (#5541)"

### DIFF
--- a/apps/juror/juror-scheduler-execution/ithc.yaml
+++ b/apps/juror/juror-scheduler-execution/ithc.yaml
@@ -10,5 +10,3 @@ spec:
       # Uncomment and edit the line below to fix the environment at a specific image
       image: sdshmctspublic.azurecr.io/juror/scheduler-execution:pr-225-1695f06-20241009093321
       ingressHost: juror-scheduler-execution.ithc.platform.hmcts.net
-      environment:
-        BAIS_PORT: 222


### PR DESCRIPTION
This reverts commit dc2f96fa199db9ea4c786030e6d6801b025bf42a.





## 🤖AEP PR SUMMARY🤖


md
- The file `apps/juror/juror-scheduler-execution/ithc.yaml` has had the environment section removed from the spec.
```