### PR TITLE
PUB-2618 - Removed test image

### DIFF
--- a/apps/pip/frontend/test.yaml
+++ b/apps/pip/frontend/test.yaml
@@ -6,7 +6,6 @@ spec:
   releaseName: pip-frontend
   values:
     nodejs:
-      image: sdshmctspublic.azurecr.io/pip/frontend:pr-1363-9aebad8-20241010110422
       replicas: 2
       ingressHost: pip-frontend.test.platform.hmcts.net
       environment:


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/PUB-2618

### Change description

Removed test image following testing


## 🤖AEP PR SUMMARY🤖


### apps/pip/frontend/test.yaml
- Removed a line that specified the number of replicas for the frontend service.
- Updated the image for the frontend service to `sdshmctspublic.azurecr.io/pip/frontend:pr-1363-9aebad8-20241010110422`.
- Updated the ingress host to `pip-frontend.test.platform.hmcts.net`.