### PR TITLE
DTSPO-19360 - Increase max limit on ptl agents

### DIFF
--- a/apps/jenkins/jenkins/ptl/jenkins-azure-vm-agent.yaml
+++ b/apps/jenkins/jenkins/ptl/jenkins-azure-vm-agent.yaml
@@ -93,7 +93,7 @@ spec:
                       retentionStrategy:
                         azureVMCloudRetentionStrategy:
                           idleTerminationMinutes: 5
-                      maxVirtualMachinesLimit: 10
+                      maxVirtualMachinesLimit: 20
                       usageMode: "NORMAL"
                       virtualMachineSize: "Standard_D4ds_v5"
                       imageReference:


### PR DESCRIPTION
### Jira link

See [DTSPO-19360](https://tools.hmcts.net/jira/browse/DTSPO-19360)

### Change description

Jenkins agents on SDS are limited to 10 which has been a bottleneck this past few days.
I've noticed it in some testing but it's now being reported by users.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change




## 🤖AEP PR SUMMARY🤖


- File: `apps/jenkins/jenkins/ptl/jenkins-azure-vm-agent.yaml`
- Changed `maxVirtualMachinesLimit` from 10 to 20.