### PR TITLE
Adding dummy var to support ad-hoc restarts by developers

### DIFF
--- a/apps/met/batch-jobs/test.yaml
+++ b/apps/met/batch-jobs/test.yaml
@@ -25,6 +25,7 @@ spec:
           - dac-datasource-url
     environment:
       KV_NAME: libragob-test-kv
+      DUMMY_VAR_TO_RESTART: 0
   chart:
     spec:
       chart: job
@@ -70,6 +71,7 @@ spec:
           - confiscation-datasource-url
     environment:
       KV_NAME: libragob-test-kv
+      DUMMY_VAR_TO_RESTART: 0
   chart:
     spec:
       chart: job


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-19198

### Adding dummy var to support ad-hoc restarts by developers


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change










## 🤖AEP PR SUMMARY🤖


### apps/met/batch-jobs/test.yaml
- Added a new environment variable `DUMMY_VAR_TO_RESTART` with a value of `0` for both `dac-datasource-url` and `confiscation-datasource-url` configurations.