### PR TITLE
Revert PRE prod to AMS again

### DIFF
--- a/apps/pre/pre-api/prod.yaml
+++ b/apps/pre/pre-api/prod.yaml
@@ -14,4 +14,3 @@ spec:
         AZURE_RESOURCE_GROUP: pre-prod
         AZURE_SUBSCRIPTION_ID: 5ca62022-6aa2-4cee-aaa7-e7536c8d566c
         PLATFORM_ENV_TAG: Production
-        MEDIA_SERVICE: MediaKind

--- a/apps/pre/pre-portal/prod.yaml
+++ b/apps/pre/pre-portal/prod.yaml
@@ -15,4 +15,3 @@ spec:
         B2C_APP_CLIENT_ID: 95370927-9b25-4530-88e8-a1af7a9f0a48
         AMS_AZURE_MEDIA_SERVICES: https://preamsprod-ukso1.streaming.media.azure.net
         AMS_AZURE_MEDIA_SERVICES_KEY_DELIVERY: https://preamsprod.keydelivery.uksouth.media.azure.net
-        USE_MK_ON_WATCH_PAGE: true

--- a/apps/pre/prod/base/kustomization.yaml
+++ b/apps/pre/prod/base/kustomization.yaml
@@ -2,14 +2,10 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
-  - ../../pre-api-cron-cleanup-live-events/pre-api-cron-cleanup-live-events.yaml
-  - ../../pre-api-cron-cleanup-streaming-locators/pre-api-cron-cleanup-streaming-locators.yaml
   - ../../../base/slack-provider/prod
 namespace: pre
 patches:
   - path: ../../identity/prod.yaml
   - path: ../../pre-portal/prod.yaml
   - path: ../../pre-api/prod.yaml
-  - path: ../../pre-api-cron-cleanup-streaming-locators/prod.yaml
-  - path: ../../pre-api-cron-cleanup-live-events/prod.yaml
   - path: ../../serviceaccount/prod.yaml


### PR DESCRIPTION




## 🤖AEP PR SUMMARY🤖


### apps/pre/pre-api/prod.yaml
- Removed the `MEDIA_SERVICE` configuration
- Updated `PLATFORM_ENV_TAG` to \"Production\"

### apps/pre/pre-portal/prod.yaml
- Removed the `USE_MK_ON_WATCH_PAGE` configuration

### apps/pre/prod/base/kustomization.yaml
- Removed references to `pre-api-cron-cleanup-live-events` and `pre-api-cron-cleanup-streaming-locators` resource files