### PR TITLE
VIH-10931 override the format for the callbackuri environment variable for Vodafone to match Kinly

### DIFF
--- a/apps/vh/video-api/prod.yaml
+++ b/apps/vh/video-api/prod.yaml
@@ -11,6 +11,7 @@ spec:
       environment:
         KINLYCONFIGURATION__CALLBACKURI: https://video.hearings.reform.hmcts.net/callback
         SERVICES__CALLBACKURI: https://video.hearings.reform.hmcts.net/callback
+        VODAFONECONFIGURATION__CALLBACKURI: https://video.hearings.reform.hmcts.net/callback
       image: sdshmctspublic.azurecr.io/vh/video-api:prod-ff4cf73-202409041311 #{"$imagepolicy": "flux-system:vh-video-api"}
   chart:
     spec:

--- a/apps/vh/video-api/stg.yaml
+++ b/apps/vh/video-api/stg.yaml
@@ -11,6 +11,7 @@ spec:
       image: sdshmctspublic.azurecr.io/vh/video-api:staging-b412f1e-202410211004 #{"$imagepolicy": "flux-system:vh-video-api-staging"}
       environment:
         KINLYCONFIGURATION__CALLBACKURI: https://video.staging.hearings.reform.hmcts.net/callback
+        VODAFONECONFIGURATION__CALLBACKURI: https://video.staging.hearings.reform.hmcts.net/callback
         SERVICES__CALLBACKURI: https://video.staging.hearings.reform.hmcts.net/callback
   chart:
     spec:


### PR DESCRIPTION
### Jira link

VIH-10931

### Change description

Override the format for the callbackuri environment variable for Vodafone to match Kinly:

Environment configuration updates:

* [`apps/vh/video-api/prod.yaml`](diffhunk://#diff-a9c387e26e5cdb7afee0202a7c64118a1e323c0ea3e67dea0987743d359ae42dR14): Added `VODAFONECONFIGURATION__CALLBACKURI` with the value `https://video.hearings.reform.hmcts.net/callback`.
* [`apps/vh/video-api/stg.yaml`](diffhunk://#diff-a8a073ea69efce17136197c7a278350c66caf54d961799438c7c6be459d9a5dcR14): Added `VODAFONECONFIGURATION__CALLBACKURI` with the value `https://video.staging.hearings.reform.hmcts.net/callback`.





## 🤖AEP PR SUMMARY🤖


### Changes in prod.yaml
- Added VODAFONECONFIGURATION__CALLBACKURI with URL for production environment.ℹ️

### Changes in stg.yaml
- Added VODAFONECONFIGURATION__CALLBACKURI with URL for staging environment.ℹ️