### PR TITLE
Updated ARM_RPO_HOURS to be ARM_RPO_DURATION to better reflect object

### DIFF
--- a/apps/darts-modernisation/darts-api/demo.yaml
+++ b/apps/darts-modernisation/darts-api/demo.yaml
@@ -19,7 +19,7 @@ spec:
         CASE_EXPIRY_DELETION_ENABLED: false
         MANUAL_DELETION_ENABLED: false
         PROCESS_E2E_ARM_RPO: false
-        ARM_RPO_HOURS: 24h
+        ARM_RPO_DURATION: 24h
     function:
       image: sdshmctspublic.azurecr.io/darts/api:prod-9c7e1c3-20241018161032 # {"$imagepolicy": "flux-system:darts-api"}
       environment:

--- a/apps/darts-modernisation/darts-api/prod.yaml
+++ b/apps/darts-modernisation/darts-api/prod.yaml
@@ -22,7 +22,7 @@ spec:
         MANUAL_DELETION_ENABLED: false
         DARTS_API_DB_POOL_SIZE: 200
         PROCESS_E2E_ARM_RPO: false
-        ARM_RPO_HOURS: 24h
+        ARM_RPO_DURATION: 24h
       pdb:
         enabled: false
     function:

--- a/apps/darts-modernisation/darts-automated-tasks/demo.yaml
+++ b/apps/darts-modernisation/darts-automated-tasks/demo.yaml
@@ -14,4 +14,4 @@ spec:
         ARM_URL: https://www.test.court-tribunal-records-archive.service.justice.gov.uk
         FEIGN_LOG_LEVEL: full
         PROCESS_E2E_ARM_RPO: false
-        ARM_RPO_HOURS: 24h
+        ARM_RPO_DURATION: 24h

--- a/apps/darts-modernisation/darts-automated-tasks/prod.yaml
+++ b/apps/darts-modernisation/darts-automated-tasks/prod.yaml
@@ -13,6 +13,6 @@ spec:
         DARTS_LOG_LEVEL: DEBUG
         ARM_URL: https://www.court-tribunal-records-archive.service.justice.gov.uk
         PROCESS_E2E_ARM_RPO: false
-        ARM_RPO_HOURS: 24h
+        ARM_RPO_DURATION: 24h
       pdb:
         enabled: false


### PR DESCRIPTION
Updated ARM_RPO_HOURS to be ARM_RPO_DURATION to better reflect object





## 🤖AEP PR SUMMARY🤖


- `demo.yaml`:
  - Updated the `ARM_RPO_HOURS` field to `ARM_RPO_DURATION` with a value of `24h`.
  
- `prod.yaml`:
  - Updated the `ARM_RPO_HOURS` field to `ARM_RPO_DURATION` with a value of `24h`.

- `darts-automated-tasks/demo.yaml`:
  - Updated the `ARM_RPO_HOURS` field to `ARM_RPO_DURATION` with a value of `24h`.

- `darts-automated-tasks/prod.yaml`:
  - Updated the `ARM_RPO_HOURS` field to `ARM_RPO_DURATION` with a value of `24h`.