### PR TITLE
Change hourly report to run every 5 minutes

### DIFF
--- a/apps/monitoring/vm-hourlyusage/fiveminuteusage.yaml
+++ b/apps/monitoring/vm-hourlyusage/fiveminuteusage.yaml
@@ -1,13 +1,13 @@
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
-  name: vm-hourlyusage
+  name: vm-fiveminuteusage
   namespace: monitoring
   labels:
-    app: vm-hourlyusage
+    app: vm-fiveminuteusage
     ignored-by-dynatrace: "true"
 spec:
-  releaseName: vm-hourlyusage
+  releaseName: vm-fiveminuteusage
   chart:
     spec:
       chart: job
@@ -20,7 +20,7 @@ spec:
   values:
     global:
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
-    schedule: "5 * * * *" # 5min past every hour, every day
+    schedule: "*/5 * * * *" # Every 5 Mins, everyday
     concurrencyPolicy: "Forbid"
     failedJobsHistoryLimit: 5
     startingDeadlineSeconds: 300
@@ -33,7 +33,7 @@ spec:
     imagePullPolicy: Always
     environment:
       CLUSTER_NAME: ss-prod-00-aks
-      AZURE_STORAGE_CONTAINER: hmctshourlydatasource
+      AZURE_STORAGE_CONTAINER: hmctsfiveminutedatasource
       AZURE_STORAGE_URL: https://finopsdataptlsa.blob.core.windows.net
       COSMOS_DB_URI: https://sds-platform-version-reporter.documents.azure.com:443/
       COSMOS_DB_NAME: reports

--- a/apps/monitoring/vm-hourlyusage/hourlyusage.yaml
+++ b/apps/monitoring/vm-hourlyusage/hourlyusage.yaml
@@ -20,7 +20,7 @@ spec:
   values:
     global:
       tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
-    schedule: "5 * * * *" # 5min past every hour, every day
+    schedule: "*/5 * * * *" # Every 5 Mins, everyday
     concurrencyPolicy: "Forbid"
     failedJobsHistoryLimit: 5
     startingDeadlineSeconds: 300

--- a/apps/monitoring/vm-hourlyusage/kustomization.yaml
+++ b/apps/monitoring/vm-hourlyusage/kustomization.yaml
@@ -2,4 +2,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - hourlyusage.yaml
+  - fiveminuteusage.yaml
   - rbac.yaml


### PR DESCRIPTION
No Jira for this as Felix contacted directly on the Slack. 

David Fielding asked to change the frequency of this report from being hourly to run every 5 minutes.







## 🤖AEP PR SUMMARY🤖


- Created a new file `fiveminuteusage.yaml` in the `apps/monitoring/vm-hourlyusage` directory.
- Defined a HelmRelease resource for `vm-fiveminuteusage` with various specifications including chart, schedule, image, environment variables, and nodeSelector.
- Updated `kustomization.yaml` to include the newly created `fiveminuteusage.yaml` file.