### PR TITLE
PRE STG default to mk

### DIFF
--- a/apps/pre/pre-portal/stg.yaml
+++ b/apps/pre/pre-portal/stg.yaml
@@ -12,6 +12,6 @@ spec:
         PRE_API_URL: https://sds-api-mgmt.staging.platform.hmcts.net/pre-api
         PORTAL_URL: https://pre-portal.staging.platform.hmcts.net
         B2C_APP_CLIENT_ID: d20a7462-f222-46b8-a363-d2e30eb274eb
-        ENABLE_MK_WATCH_PAGE: true
+        USE_MK_ON_WATCH_PAGE: true
         DYNATRACE_JSTAG: https://js-cdn.dynatrace.com/jstag/17177a07246/bf24054dsx/bb016222bfe9b010_complete.js
         TRIGGER: init-1


### PR DESCRIPTION


## 🤖AEP PR SUMMARY🤖


- `stg.yaml` 🔄
  - Changed `ENABLE_MK_WATCH_PAGE` to `USE_MK_ON_WATCH_PAGE`
  - Updated the `PRE_API_URL` and `PORTAL_URL` to staging URLs.
  - Updated the `B2C_APP_CLIENT_ID`.
  - Updated the `DYNATRACE_JSTAG`.
  - `TRIGGER` was changed to `init-1`.