### PR TITLE
DTSPO-19027 adding auto cluster system identity to flux config

### DIFF
--- a/apps/admin/aad-pod-identity/sbox/azure-identity-auto-cluster-01.yaml
+++ b/apps/admin/aad-pod-identity/sbox/azure-identity-auto-cluster-01.yaml
@@ -1,0 +1,6 @@
+- op: replace
+  path: /spec/resourceID
+  value: /subscriptions/a8140a9e-f1b0-481f-a4de-09e2ee23f7ab/resourcegroups/ss-sbox-01-rg/providers/Microsoft.ContainerService/managedClusters/ss-sbox-01-aks
+- op: replace
+  path: /spec/clientID
+  value: 8c44a4cc-f514-43fc-bc82-da3bdd3dfacc

--- a/apps/admin/sbox/01/kustomization.yaml
+++ b/apps/admin/sbox/01/kustomization.yaml
@@ -5,3 +5,9 @@ resources:
 
 patches:
 - path: ../../traefik2/sbox/01-traefik2.yaml
+- path: ../../aad-pod-identity/sbox/azure-identity-auto-cluster-01.yaml
+  target:
+    group: aadpodidentity.k8s.io
+    kind: AzureIdentity
+    name: aks-pod-identity-mi
+    version: v1


### PR DESCRIPTION
### Jira link
[DTSPO-19027](https://tools.hmcts.net/jira/browse/DTSPO-19027)

### Change description

I am unable to setup auto cluster (ss-sbox-01-aks) with user assigned identity, so need to add the system assigned identity to allow the auto cluster access to the sop key for flux






## 🤖AEP PR SUMMARY🤖


- Created new file `azure-identity-auto-cluster-01.yaml` under `apps/admin/aad-pod-identity/sbox` with operations to replace `resourceID` and `clientID` values.
- Updated `kustomization.yaml` in `apps/admin/sbox/01` to include a new patch for `azure-identity-auto-cluster-01.yaml` targeting `group: aadpodidentity.k8s.io`, `kind: AzureIdentity`, `name: aks-pod-identity-mi`, `version: v1`.