### PR TITLE
Revert "DTSPO-19027 adding auto cluster system identity to flux config"

### DIFF
--- a/apps/admin/aad-pod-identity/sbox/azure-identity-auto-cluster-01.yaml
+++ b/apps/admin/aad-pod-identity/sbox/azure-identity-auto-cluster-01.yaml
@@ -1,6 +1,0 @@
-- op: replace
-  path: /spec/resourceID
-  value: /subscriptions/a8140a9e-f1b0-481f-a4de-09e2ee23f7ab/resourcegroups/ss-sbox-01-rg/providers/Microsoft.ContainerService/managedClusters/ss-sbox-01-aks
-- op: replace
-  path: /spec/clientID
-  value: 8c44a4cc-f514-43fc-bc82-da3bdd3dfacc

--- a/apps/admin/sbox/01/kustomization.yaml
+++ b/apps/admin/sbox/01/kustomization.yaml
@@ -5,9 +5,3 @@ resources:
 
 patches:
 - path: ../../traefik2/sbox/01-traefik2.yaml
-- path: ../../aad-pod-identity/sbox/azure-identity-auto-cluster-01.yaml
-  target:
-    group: aadpodidentity.k8s.io
-    kind: AzureIdentity
-    name: aks-pod-identity-mi
-    version: v1


### PR DESCRIPTION
Reverts hmcts/sds-flux-config#5690

## 🤖AEP PR SUMMARY🤖


- The file `azure-identity-auto-cluster-01.yaml` has been deleted.
- In the `kustomization.yaml` file, the reference to the deleted `azure-identity-auto-cluster-01.yaml` file has been removed.