### PR TITLE
adding auto cluster system identity to flux config

### DIFF
--- a/apps/admin/aad-pod-identity/sbox/azure-identity-auto-cluster-01.yaml
+++ b/apps/admin/aad-pod-identity/sbox/azure-identity-auto-cluster-01.yaml
@@ -1,0 +1,6 @@
+- op: replace
+  path: /spec/resourceID
+  value: /subscriptions/a8140a9e-f1b0-481f-a4de-09e2ee23f7ab/resourcegroups/ss-sbox-01-rg/providers/Microsoft.ContainerService/managedClusters/ss-sbox-01-aks
+- op: replace
+  path: /spec/clientID
+  value: 8c44a4cc-f514-43fc-bc82-da3bdd3dfacc

--- a/apps/admin/sbox/01/kustomization.yaml
+++ b/apps/admin/sbox/01/kustomization.yaml
@@ -5,3 +5,9 @@ resources:
 
 patches:
 - path: ../../traefik2/sbox/01-traefik2.yaml
+- path: ../../aad-pod-identity/sbox/azure-identity-auto-cluster-01.yaml
+  target:
+    group: aadpodidentity.k8s.io
+    kind: AzureIdentity
+    name: aks-pod-identity-mi
+    version: v1

--- a/apps/flux-system/sbox/01/kustomize.yaml
+++ b/apps/flux-system/sbox/01/kustomize.yaml
@@ -10,6 +10,6 @@ spec:
       ENVIRONMENT: "sbox"
       WI_ENVIRONMENT: "sbox"
       CLUSTER: "01"
-      ISSUER_URL: "https://uksouth.oic.prod-aks.azure.com/531ff96d-0ae9-462a-8d2d-bec7c0b42082/3ddeb201-a606-40e0-a3f1-a1fe3c7944c9/"
+      ISSUER_URL: "https://uksouth.oic.prod-aks.azure.com/a8140a9e-f1b0-481f-a4de-09e2ee23f7ab/8c44a4cc-f514-43fc-bc82-da3bdd3dfacc"
       ENV_MONITOR_CHANNEL: "aks-monitor-sbox"
       KEYVAULT_ENVIRONMENT: "sbox"


### PR DESCRIPTION
### Jira link

[DTSPO-19027](https://tools.hmcts.net/jira/browse/DTSPO-19027)

### Change description

I am unable to setup auto cluster (ss-sbox-01-aks) with user assigned identity, so need to add the system assigned identity to allow the auto cluster access to the sop key for flux



## 🤖AEP PR SUMMARY🤖


### apps/admin/aad-pod-identity/sbox/azure-identity-auto-cluster-01.yaml
- 📄 Created a new file named azure-identity-auto-cluster-01.yaml.
- Replaced the /spec/resourceID and /spec/clientID values.

### apps/admin/sbox/01/kustomization.yaml
- Updated the kustomization.yaml file to include the azure-identity-auto-cluster-01.yaml as a resource and added target information.

### apps/flux-system/sbox/01/kustomize.yaml
- Updated the ISSUER_URL value in the kustomize.yaml file.