### PR TITLE
PUB-2364 Update SSO test image to use GET for SSO return

### DIFF
--- a/apps/pip/frontend/test.yaml
+++ b/apps/pip/frontend/test.yaml
@@ -8,7 +8,7 @@ spec:
     nodejs:
       replicas: 2
       ingressHost: pip-frontend.test.platform.hmcts.net
-      image: sdshmctspublic.azurecr.io/pip/frontend:pr-1380-6990680-20241106114320
+      image: sdshmctspublic.azurecr.io/pip/frontend:pr-1381-453e939-20241106143948
       keyVaults:
         pip-ss-kv:
           resourceGroup: pip-ss-test-rg
@@ -77,5 +77,5 @@ spec:
         MEDIA_VERIFICATION_CONFIG_ENDPOINT: https://sign-in.pip-frontend.test.platform.hmcts.net/pip-frontend.test.platform.hmcts.net/B2C_1_SignInMediaVerification/v2.0/.well-known/openid-configuration
         B2C_URL: https://sign-in.pip-frontend.test.platform.hmcts.net/pip-frontend.test.platform.hmcts.net
         B2C_ADMIN_URL: https://staff.pip-frontend.test.platform.hmcts.net/pip-frontend.test.platform.hmcts.net
-        SESSION_COOKIE_SAME_SITE: ''
+        SESSION_COOKIE_SAME_SITE: lax
         CRIME_IDAM_URL: https://login.sit.cjscp.org.uk


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/PUB-2364

### Change description

Update SSO test image to use GET for SSO return

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


- `test.yaml` 🔄
  - Changed the image version from `pr-1380-6990680-20241106114320` to `pr-1381-453e939-20241106143948`
  - Updated `SESSION_COOKIE_SAME_SITE` to `lax`