### PR TITLE
Updating image location as its updated upstream

### DIFF
--- a/apps/monitoring/vm-hourlyusage/fiveminuteusage.yaml
+++ b/apps/monitoring/vm-hourlyusage/fiveminuteusage.yaml
@@ -29,7 +29,7 @@ spec:
     restartPolicy: Never
     serviceAccountName: version-reporter-service-sa
     kind: CronJob
-    image: sdshmctspublic.azurecr.io/version-reporter-service/hourlyusage:prod-1902c02-20240516160840 #{"$imagepolicy": "flux-system:vm-hourlyusage"}
+    image: hmctspublic.azurecr.io/version-reporter-service/hourlyusage:prod-1902c02-20240516160840 #{"$imagepolicy": "flux-system:vm-hourlyusage"}
     imagePullPolicy: Always
     environment:
       CLUSTER_NAME: ss-prod-00-aks

--- a/apps/monitoring/vm-hourlyusage/hourlyusage.yaml
+++ b/apps/monitoring/vm-hourlyusage/hourlyusage.yaml
@@ -29,7 +29,7 @@ spec:
     restartPolicy: Never
     serviceAccountName: version-reporter-service-sa
     kind: CronJob
-    image: sdshmctspublic.azurecr.io/version-reporter-service/hourlyusage:prod-1902c02-20240516160840 #{"$imagepolicy": "flux-system:vm-hourlyusage"}
+    image: hmctspublic.azurecr.io/version-reporter-service/hourlyusage:prod-1902c02-20240516160840 #{"$imagepolicy": "flux-system:vm-hourlyusage"}
     imagePullPolicy: Always
     environment:
       CLUSTER_NAME: ss-prod-00-aks

--- a/apps/monitoring/vm-hourlyusage/image-repo.yaml
+++ b/apps/monitoring/vm-hourlyusage/image-repo.yaml
@@ -3,4 +3,4 @@ kind: ImageRepository
 metadata:
   name: vm-hourlyusage
 spec:
-  image: sdshmctspublic.azurecr.io/version-reporter-service/hourlyusage
+  image: hmctspublic.azurecr.io/version-reporter-service/hourlyusage


### PR DESCRIPTION
Updating image location as it has been updated here - 
https://github.com/hmcts/version-reporter-services/pull/146/files#diff-9eedc1d7d657ddb36b1105a0fffb4852f6d34e26454371f27b6e0ad1391f290eR31 





## 🤖AEP PR SUMMARY🤖


- `fiveminuteusage.yaml` 🛠️: Updated the image repository for the cron job to use the new image from `hmctspublic.azurecr.io`.
- `hourlyusage.yaml` 🛠️: Updated the image repository for the cron job to use the new image from `hmctspublic.azurecr.io`.
- `image-repo.yaml` 🛠️: Updated the image repository to use the new image from `hmctspublic.azurecr.io`.