### PR TITLE
Allow dynatrace csidriver onto cronjob nodes

### DIFF
--- a/apps/dynatrace/dynatrace-operator.yaml
+++ b/apps/dynatrace/dynatrace-operator.yaml
@@ -27,6 +27,10 @@ spec:
           key: kubernetes.io/os
           operator: Equal
           value: "windows"
+        - effect: NoSchedule
+          key: dedicated
+          operator: Equal
+          value: "jobs"
       nodeSelector:
         kubernetes.io/os: linux
     operator:

--- a/apps/monitoring/vm-hourlyusage/fiveminuteusage.yaml
+++ b/apps/monitoring/vm-hourlyusage/fiveminuteusage.yaml
@@ -55,7 +55,7 @@ spec:
         secretRef: vm-hourlyusage
         key: access_key
     nodeSelector:
-      agentpool: cronjob
+      kubernetes.io/os: linux
     tolerations:
       - key: dedicated
         effect: NoSchedule


### PR DESCRIPTION

Trying to fix this errors on SDS.  This may allow csi pods to to schedule on the cronjobs nodes

`MountVolume.SetUp failed for volume "oneagent-bin" : kubernetes.io/csi: mounter.SetUpAt failed to get CSI client: driver name csi.oneagent.dynatrace.com not found in the list of registered CSI drivers`







## 🤖AEP PR SUMMARY🤖


- `apps/dynatrace/dynatrace-operator.yaml` 🛠️
  - Added a new nodeSelector rule for the key `dedicated` with the operator `Equal` and value `jobs`.
- `apps/monitoring/vm-hourlyusage/fiveminuteusage.yaml` 🛠️
  - Updated the nodeSelector rule from `agentpool: cronjob` to `kubernetes.io/os: linux`.
  - Tolerations now include a rule with the key `dedicated` and effect `NoSchedule`.