### PR TITLE
Setting up job to run on cluster for cveinfo

### DIFF
--- a/apps/monitoring/automation/kustomization.yaml
+++ b/apps/monitoring/automation/kustomization.yaml
@@ -13,3 +13,5 @@ resources:
   - ../version-reporter/docsoutdated/image-policy.yaml
   - ../vm-hourlyusage/image-policy.yaml
   - ../vm-hourlyusage/image-repo.yaml
+  - ../cveinfo/image-policy.yaml
+  - ../cveinfo/image-repo.yaml

--- a/apps/monitoring/cveinfo/cveinfo.yaml
+++ b/apps/monitoring/cveinfo/cveinfo.yaml
@@ -1,0 +1,59 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: cveinfo
+  namespace: monitoring
+  labels:
+    app: cveinfo
+    ignored-by-dynatrace: "true"
+spec:
+  releaseName: cveinfo
+  chart:
+    spec:
+      chart: job
+      sourceRef:
+        kind: GitRepository
+        name: chart-job
+        namespace: flux-system
+      interval: 1m
+  interval: 5m
+  values:
+    global:
+      tenantId: "531ff96d-0ae9-462a-8d2d-bec7c0b42082"
+    schedule: "0 */4 * * 1-5" # Every 4 hours, week days
+    concurrencyPolicy: "Forbid"
+    failedJobsHistoryLimit: 5
+    startingDeadlineSeconds: 300
+    successfulJobsHistoryLimit: 5
+    backoffLimit: 3
+    restartPolicy: Never
+    serviceAccountName: version-reporter-service-sa
+    kind: CronJob
+    image: hmctspublic.azurecr.io/version-reporter-service/cveinfo:prod-e92ce54-20241106104306 #{"$imagepolicy": "flux-system:cveinfo"}
+    imagePullPolicy: Always
+    environment:
+      CLUSTER_NAME: ss-prod-00-aks
+      MAX_BATCH_SIZE: 1000
+      COSMOS_DB_URI: https://version-reporter-ptl-cosmos.documents.azure.com:443/
+      COSMOS_DB_NAME: reports
+      COSMOS_DB_CONTAINER: cveinfo
+    secrets:
+      COSMOS_KEY:
+        secretRef: version-reporter
+        key: cosmos_key
+      AZURE_TENANT_ID:
+        secretRef: version-reporter
+        key: tenant_id
+      AZURE_CLIENT_ID:
+        secretRef: version-reporter
+        key: client_id
+      AZURE_CLIENT_SECRET:
+        secretRef: version-reporter
+        key: client_secret
+    nodeSelector:
+      agentpool: cronjob
+    tolerations:
+      - key: dedicated
+        effect: NoSchedule
+        operator: Equal
+        value: jobs

--- a/apps/monitoring/cveinfo/cveinfo.yaml
+++ b/apps/monitoring/cveinfo/cveinfo.yaml
@@ -32,7 +32,7 @@ spec:
     image: hmctspublic.azurecr.io/version-reporter-service/cveinfo:prod-e92ce54-20241106104306 #{"$imagepolicy": "flux-system:cveinfo"}
     imagePullPolicy: Always
     environment:
-      CLUSTER_NAME: ss-prod-00-aks
+      CLUSTER_NAME: ss-ptl-00-aks
       MAX_BATCH_SIZE: 1000
       COSMOS_DB_URI: https://version-reporter-ptl-cosmos.documents.azure.com:443/
       COSMOS_DB_NAME: reports

--- a/apps/monitoring/cveinfo/image-policy.yaml
+++ b/apps/monitoring/cveinfo/image-policy.yaml
@@ -1,0 +1,7 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta1
+kind: ImagePolicy
+metadata:
+  name: cveinfo
+spec:
+  imageRepositoryRef:
+    name: cveinfo

--- a/apps/monitoring/cveinfo/image-repo.yaml
+++ b/apps/monitoring/cveinfo/image-repo.yaml
@@ -1,0 +1,6 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImageRepository
+metadata:
+  name: cveinfo
+spec:
+  image: hmctspublic.azurecr.io/version-reporter-service/cveinfo

--- a/apps/monitoring/cveinfo/kustomization.yaml
+++ b/apps/monitoring/cveinfo/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - cveinfo.yaml
+  - rbac.yaml

--- a/apps/monitoring/cveinfo/rbac.yaml
+++ b/apps/monitoring/cveinfo/rbac.yaml
@@ -1,0 +1,38 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cveinfo-clusterrolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cveinfo-clusterrole
+subjects:
+  - kind: ServiceAccount
+    name: cveinfo-sa
+    namespace: monitoring
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cveinfo-clusterrole
+rules:
+  - apiGroups: ['']
+    resources: ['namespaces']
+    verbs: ['list', 'get']
+  - apiGroups: ['source.toolkit.fluxcd.io']
+    resources: ['helmcharts']
+    verbs: ['list', 'get']
+  - apiGroups: ['source.toolkit.fluxcd.io']
+    resources: ['helmrepositories']
+    verbs: ['list', 'get']
+  - apiGroups: ['']
+    resources: ['secrets']
+    verbs: ['list', 'get']
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cveinfo-sa
+  namespace: monitoring

--- a/apps/monitoring/ptl/base/kustomization.yaml
+++ b/apps/monitoring/ptl/base/kustomization.yaml
@@ -7,5 +7,6 @@ resources:
 - ../../version-reporter
 - ../../version-reporter/ptl/version-reporter.enc.yaml
 - ../../version-reporter/ptl/github-token.enc.yaml
+- ../../cveinfo
 patches:
 - path: ../../version-reporter/ptl/ptl.yaml


### PR DESCRIPTION
### Change description

Off the back of the vulnerability calls, the idea of this repo is to run a cron job that will pull in cveinfo from the [cveproject](https://github.com/CVEProject) repository, summarised and store in the cosmosdb for reports.

This can them be used in many ways to enhance reports or easy access to current cves. Ideas around enhancing the vulnerably reports and using the info to facilitate conversation are hoped to be end results of how the data is consumed.

The data is free for public use, no licence required.

The job will run every 4 hours in the weekday to keep data up-to-date. image build in the [version reporter service](https://github.com/hmcts/version-reporter-services) repo 



## 🤖AEP PR SUMMARY🤖


- In `apps/monitoring/automation/kustomization.yaml`, a new resource `./cveinfo/image-policy.yaml` was added.
- The new file `apps/monitoring/cveinfo/cveinfo.yaml` is a HelmRelease resource defining configuration for the `cveinfo` application.
- `apps/monitoring/cveinfo/image-policy.yaml` is a new file that defines an ImagePolicy for the `cveinfo` application.
- A new file `apps/monitoring/cveinfo/image-repo.yaml` was added, which specifies the ImageRepository for `cveinfo`.
- Added `apps/monitoring/cveinfo/kustomization.yaml`, containing resources `cveinfo.yaml` and `rbac.yaml` for the `cveinfo` application.
- Added `apps/monitoring/cveinfo/rbac.yaml` and it includes ClusterRoleBinding, ClusterRole, and ServiceAccount for the `cveinfo` application.
- In `apps/monitoring/ptl/base/kustomization.yaml`, a new resource `././cveinfo` and a patch for `././version-reporter/ptl/ptl.yaml` were added.