### PR TITLE
Upgrade all nonprod traefik

### DIFF
--- a/apps/admin/traefik2/demo/00-traefik2.yaml
+++ b/apps/admin/traefik2/demo/00-traefik2.yaml
@@ -4,6 +4,14 @@ metadata:
   name: traefik2
   namespace: admin
 spec:
+  chart:
+    spec:
+      chart: traefik
+      version: 33.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: admin
   values:
     ports:
       traefik:

--- a/apps/admin/traefik2/demo/01-traefik2.yaml
+++ b/apps/admin/traefik2/demo/01-traefik2.yaml
@@ -4,6 +4,14 @@ metadata:
   name: traefik2
   namespace: admin
 spec:
+  chart:
+    spec:
+      chart: traefik
+      version: 33.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: admin
   values:
     ports:
       traefik:

--- a/apps/admin/traefik2/dev/00-traefik2.yaml
+++ b/apps/admin/traefik2/dev/00-traefik2.yaml
@@ -4,6 +4,14 @@ metadata:
   name: traefik2
   namespace: admin
 spec:
+  chart:
+    spec:
+      chart: traefik
+      version: 33.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: admin
   values:
     service:
       spec:

--- a/apps/admin/traefik2/dev/01-traefik2.yaml
+++ b/apps/admin/traefik2/dev/01-traefik2.yaml
@@ -4,6 +4,14 @@ metadata:
   name: traefik2
   namespace: admin
 spec:
+  chart:
+    spec:
+      chart: traefik
+      version: 33.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: admin
   values:
     service:
       spec:

--- a/apps/admin/traefik2/ithc/00-traefik2.yaml
+++ b/apps/admin/traefik2/ithc/00-traefik2.yaml
@@ -4,6 +4,14 @@ metadata:
   name: traefik2
   namespace: admin
 spec:
+  chart:
+    spec:
+      chart: traefik
+      version: 33.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: admin
   values:
     service:
       spec:

--- a/apps/admin/traefik2/ithc/01-traefik2.yaml
+++ b/apps/admin/traefik2/ithc/01-traefik2.yaml
@@ -4,6 +4,14 @@ metadata:
   name: traefik2
   namespace: admin
 spec:
+  chart:
+    spec:
+      chart: traefik
+      version: 33.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: admin
   values:
     service:
       spec:

--- a/apps/admin/traefik2/ptlsbox/00-traefik.yaml
+++ b/apps/admin/traefik2/ptlsbox/00-traefik.yaml
@@ -4,6 +4,14 @@ metadata:
   name: traefik2
   namespace: admin
 spec:
+  chart:
+    spec:
+      chart: traefik
+      version: 33.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: admin
   values:
     entryPoints:
       websecure:

--- a/apps/admin/traefik2/stg/00-traefik2.yaml
+++ b/apps/admin/traefik2/stg/00-traefik2.yaml
@@ -4,6 +4,14 @@ metadata:
   name: traefik2
   namespace: admin
 spec:
+  chart:
+    spec:
+      chart: traefik
+      version: 33.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: admin
   values:
     service:
       spec:

--- a/apps/admin/traefik2/stg/01-traefik2.yaml
+++ b/apps/admin/traefik2/stg/01-traefik2.yaml
@@ -4,6 +4,14 @@ metadata:
   name: traefik2
   namespace: admin
 spec:
+  chart:
+    spec:
+      chart: traefik
+      version: 33.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: admin
   values:
     service:
       spec:

--- a/apps/admin/traefik2/test/00-traefik2.yaml
+++ b/apps/admin/traefik2/test/00-traefik2.yaml
@@ -4,6 +4,14 @@ metadata:
   name: traefik2
   namespace: admin
 spec:
+  chart:
+    spec:
+      chart: traefik
+      version: 33.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: admin
   values:
     service:
       spec:

--- a/apps/admin/traefik2/test/01-traefik2.yaml
+++ b/apps/admin/traefik2/test/01-traefik2.yaml
@@ -4,6 +4,14 @@ metadata:
   name: traefik2
   namespace: admin
 spec:
+  chart:
+    spec:
+      chart: traefik
+      version: 33.0.0
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: admin
   values:
     service:
       spec:

--- a/clusters/demo/base/kustomization.yaml
+++ b/clusters/demo/base/kustomization.yaml
@@ -22,3 +22,4 @@ patches:
       annotationSelector: hmcts.github.com/kustomize-defaults != disabled
   - path: ../../../apps/toffee/demo/base/kustomize.yaml
   - path: ../../../apps/admin/demo/base/kustomize.yaml
+  - path: ../../../apps/admin/traefik-v33-crds/kustomize.yaml

--- a/clusters/dev/base/kustomization.yaml
+++ b/clusters/dev/base/kustomization.yaml
@@ -31,3 +31,4 @@ patches:
       annotationSelector: hmcts.github.com/kustomize-defaults != disabled
   - path: ../../../apps/toffee/dev/base/kustomize.yaml
   - path: ../../../apps/admin/dev/base/kustomize.yaml
+  - path: ../../../apps/admin/traefik-v33-crds/kustomize.yaml

--- a/clusters/ithc/base/kustomization.yaml
+++ b/clusters/ithc/base/kustomization.yaml
@@ -24,3 +24,4 @@ patches:
       annotationSelector: hmcts.github.com/kustomize-defaults != disabled
   - path: ../../../apps/toffee/ithc/base/kustomize.yaml
   - path: ../../../apps/admin/ithc/base/kustomize.yaml
+  - path: ../../../apps/admin/traefik-v33-crds/kustomize.yaml

--- a/clusters/ptlsbox/base/kustomization.yaml
+++ b/clusters/ptlsbox/base/kustomization.yaml
@@ -16,3 +16,4 @@ patches:
       kind: Kustomization
       annotationSelector: hmcts.github.com/kustomize-defaults != disabled
   - path: ../../../apps/admin/ptlsbox/base/kustomize.yaml
+  - path: ../../../apps/admin/traefik-v33-crds/kustomize.yaml

--- a/clusters/stg/base/kustomization.yaml
+++ b/clusters/stg/base/kustomization.yaml
@@ -29,3 +29,4 @@ patches:
       annotationSelector: hmcts.github.com/kustomize-defaults != disabled
   - path: ../../../apps/toffee/stg/base/kustomize.yaml
   - path: ../../../apps/admin/stg/base/kustomize.yaml
+  - path: ../../../apps/admin/traefik-v33-crds/kustomize.yaml

--- a/clusters/test/base/kustomization.yaml
+++ b/clusters/test/base/kustomization.yaml
@@ -26,4 +26,5 @@ patches:
       kind: Kustomization
       annotationSelector: hmcts.github.com/kustomize-defaults != disabled
   - path: ../../../apps/toffee/test/base/kustomize.yaml
+  - path: ../../../apps/admin/traefik-v33-crds/kustomize.yaml
   - path: ../../../apps/admin/test/base/kustomize.yaml


### PR DESCRIPTION
Successful upgrade in sbox
Moving onto all nonprod 



## 🤖AEP PR SUMMARY🤖


- Updated the Helm chart version to 33.0.0 and specified the Helm repository for the traefik2 application in multiple demo, dev, ithc, ptlsbox, stg, and test environments in the corresponding YAML files. 📦
- Added the path to the `traefik-v33-crds/kustomize.yaml` in the kustomization.yaml file for dev, ithc, ptlsbox, stg, and test environments. 🛠️