### PR TITLE
Removed replacers on UCF test harness for darts

### DIFF
--- a/apps/darts-modernisation/darts-ucf-test-harness/test.yaml
+++ b/apps/darts-modernisation/darts-ucf-test-harness/test.yaml
@@ -7,7 +7,7 @@ spec:
   releaseName: darts-ucf-test-harness
   values:
     java:
-      replicas: 25
+      replicas: 0
       ingressHost: darts-ucf-test-harness.test.platform.hmcts.net
       environment:
         DARTS_LOG_LEVEL: DEBUG


### PR DESCRIPTION
Removed replacers on UCF test harness for darts

## 🤖AEP PR SUMMARY🤖


### apps/darts-modernisation/darts-ucf-test-harness/test.yaml
- Changed the number of replicas from 25 to 0 for the Java service.
- Updated the ingress host to darts-ucf-test-harness.test.platform.hmcts.net.
- Modified the environment variable DARTS_LOG_LEVEL to DEBUG.