### PR TITLE
DTSPO-22647 - Add oci repo

### DIFF
--- a/apps/flux-system/base/hmctspublic-ocirepo.yaml
+++ b/apps/flux-system/base/hmctspublic-ocirepo.yaml
@@ -1,0 +1,9 @@
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: hmctspublic-oci
+  namespace: flux-system
+spec:
+  url: oci://hmctspublic.azurecr.io/helm
+  interval: 10m
+  type: oci

--- a/apps/flux-system/base/kustomization.yaml
+++ b/apps/flux-system/base/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
 - hmcts-charts-gitrepo.yaml
 - sds-helm-charts-gitrepo.yaml
 - hmctspublic-helmrepo.yaml
+- hmctspublic-ocirepo.yaml
 - hmcts-stable-charts-gitrepo.yaml
 - admin-web-gitrepo.yaml
 - booking-queue-subscriber-gitrepo.yaml


### PR DESCRIPTION
### Jira link

See [DTSPO-22647](https://tools.hmcts.net/jira/browse/DTSPO-22647)

### Change description

Adding oci repo for future use

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change








## 🤖AEP PR SUMMARY🤖


md
- Added new file apps/flux-system/base/hmctspublic-ocirepo.yaml
  - Defines a Helm repository for hmctspublic-oci with a specified URL and interval
- Modified apps/flux-system/base/kustomization.yaml
  - Added hmctspublic-ocirepo.yaml to the list of resources
```