### PR TITLE
Patch dynatrace operator

### DIFF
--- a/apps/dynatrace/dynatrace-crds/kustomization.yaml
+++ b/apps/dynatrace/dynatrace-crds/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/Dynatrace/dynatrace-operator/releases/download/v1.2.2/dynatrace-operator-crd.yaml
+  - https://github.com/Dynatrace/dynatrace-operator/releases/download/v1.3.2/dynatrace-operator-crd.yaml

--- a/apps/dynatrace/dynatrace-operator.yaml
+++ b/apps/dynatrace/dynatrace-operator.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       chart: dynatrace-operator
       # update the CRDs in dynatrace-crds when changing this value
-      version: 1.2.2
+      version: 1.3.2
       sourceRef:
         name: dynatrace-operator
         kind: HelmRepository


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-22277

### Change description

Patch dynatrace operator to 1.3.2



## 🤖AEP PR SUMMARY🤖


- Updated `kustomization.yaml`: Updated the URL for Dynatrace Operator CRD from v1.2.2 to v1.3.2.
- Updated `dynatrace-operator.yaml`: Updated the version of Dynatrace Operator from 1.2.2 to 1.3.2.