### PR TITLE
Revert "PUB-2682 deploy list type subscription"

### DIFF
--- a/apps/pip/frontend/test.yaml
+++ b/apps/pip/frontend/test.yaml
@@ -8,7 +8,6 @@ spec:
     nodejs:
       replicas: 2
       ingressHost: pip-frontend.test.platform.hmcts.net
-      image: sdshmctspublic.azurecr.io/pip/frontend:pr-1383-bff7961-20241205130515
       environment:
         DATA_MANAGEMENT_URL: https://pip-data-management.test.platform.hmcts.net
         ACCOUNT_MANAGEMENT_URL: https://pip-account-management.test.platform.hmcts.net

--- a/apps/pip/subscription-management/test.yaml
+++ b/apps/pip/subscription-management/test.yaml
@@ -9,7 +9,6 @@ spec:
     java:
       replicas: 2
       ingressHost: pip-subscription-management.test.platform.hmcts.net
-      image: sdshmctspublic.azurecr.io/pip/subscription-management:pr-367-9a175c0-20241205133941
       environment:
         DATA_MANAGEMENT_URL: https://pip-data-management.test.platform.hmcts.net
         ACCOUNT_MANAGEMENT_URL: https://pip-account-management.test.platform.hmcts.net


### PR DESCRIPTION
Reverts hmcts/sds-flux-config#5841

## 🤖AEP PR SUMMARY🤖


- `test.yaml`:
  - Removed the `image` field from `pip-frontend` and `pip-subscription-management` services.