### PR TITLE
Updating Keda dev deployment to use stg MI and not AAT MI (wrong platform)

### DIFF
--- a/apps/keda/dev/base/workload-identity.yaml
+++ b/apps/keda/dev/base/workload-identity.yaml
@@ -4,4 +4,4 @@ metadata:
   name: ${NAMESPACE}
   namespace: ${NAMESPACE}
   annotations:
-    azure.workload.identity/client-id: "d7a2a92e-63ba-4ee3-b8fb-9680afee622f"
+    azure.workload.identity/client-id: "8469c7cb-7be4-46c7-a76b-74674726520e"


### PR DESCRIPTION
### Change description
Updating Keda dev deployment to use stg MI and not AAT MI (wrong platform)


## 🤖AEP PR SUMMARY🤖


### apps/keda/dev/base/workload-identity.yaml
- Updated the `client-id` annotation for azure workload identity from \"d7a2a92e-63ba-4ee3-b8fb-9680afee622f\" to \"8469c7cb-7be4-46c7-a76b-74674726520e\".