### PR TITLE
DTSPO-18332 - Simplify onboarding to persistent preview databases

### DIFF
--- a/bin/v2/postgres-setup.sh
+++ b/bin/v2/postgres-setup.sh
@@ -75,7 +75,7 @@ metadata:
     namespace: $NAMESPACE_NAME
 type: Opaque
 EOF
-) >"apps/$NAMESPACE_NAME/dev/sops-secrets/$APP_NAME-values.enc.yaml"
+) >"apps/$NAMESPACE_NAME/dev/sops-secrets/$APP_NAME-values.enc_temp.yaml"
 
 if ! [ -f /usr/local/bin/sops ]; then
   echo "Sops is not installed... installing..."
@@ -84,7 +84,13 @@ if ! [ -f /usr/local/bin/sops ]; then
   chmod +x /usr/local/bin/sops
 fi
 
-sops --encrypt --azure-kv https://dtssharedservicesdevkv.vault.azure.net/keys/sops-key/2beba064ddfe454482ad0133af2cf0fd --encrypted-regex "^(data|stringData)$" --in-place apps/$NAMESPACE_NAME/dev/sops-secrets/$APP_NAME-values.enc.yaml
+sops --encrypt --azure-kv https://dtssharedservicesdevkv.vault.azure.net/keys/sops-key/2beba064ddfe454482ad0133af2cf0fd --encrypted-regex "^(data|stringData)$" --in-place apps/$NAMESPACE_NAME/dev/sops-secrets/$APP_NAME-values.enc_temp.yaml
+
+# making sure the indentation is with 2 spaces
+yq eval --indent 2 -P "apps/$NAMESPACE_NAME/dev/sops-secrets/$APP_NAME-values.enc_temp.yaml" > "apps/$NAMESPACE_NAME/dev/sops-secrets/$APP_NAME-values.enc.yaml"
+
+# deleting the temp file
+rm "./apps/$NAMESPACE_NAME/dev/sops-secrets/$APP_NAME-values.enc_temp.yaml"
 
 (
   cat <<EOF

--- a/bin/v2/postgres-setup.sh
+++ b/bin/v2/postgres-setup.sh
@@ -67,7 +67,7 @@ fi
   cat <<EOF
 apiVersion: v1
 data:
-    PASSWORD: $PASSWORD
+  PASSWORD: $PASSWORD
 kind: Secret
 metadata:
     creationTimestamp: null
@@ -91,6 +91,9 @@ sops --encrypt --azure-kv https://dtssharedservicesdevkv.vault.azure.net/keys/so
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ../../../azureserviceoperator-system/resources/resource-group.yaml
+  - ../../../azureserviceoperator-system/resources/flexibleserver-postgres.yaml
+  - ../../../azureserviceoperator-system/resources/flexibleserver-postgres-config.yaml
   - $APP_NAME-postgres.enc.yaml
 namespace: $NAMESPACE_NAME
 EOF

--- a/bin/v2/postgres-setup.sh
+++ b/bin/v2/postgres-setup.sh
@@ -19,11 +19,11 @@ if [ -z "${NAMESPACE_NAME}" ] || [ -z "${APP_NAME}" ]; then
   exit 1
 fi
 
-if [ ! -f "apps/$NAMESPACE_NAME/preview/aso" ]; then
+if [ ! -f "apps/$NAMESPACE_NAME/dev/aso" ]; then
   echo "Creating aso"
   mkdir -p apps/$NAMESPACE_NAME
-  mkdir -p apps/$NAMESPACE_NAME/preview
-  mkdir -p apps/$NAMESPACE_NAME/preview/aso
+  mkdir -p apps/$NAMESPACE_NAME/dev
+  mkdir -p apps/$NAMESPACE_NAME/dev/aso
 
   (
     cat <<EOF
@@ -41,7 +41,7 @@ spec:
   source: user-override
   value: "btree_gin"
 EOF
-  ) >"apps/$NAMESPACE_NAME/preview/aso/$NAMESPACE_NAME-postgres-config.yaml"
+  ) >"apps/$NAMESPACE_NAME/dev/aso/$NAMESPACE_NAME-postgres-config.yaml"
 
   (
     cat <<EOF
@@ -51,21 +51,16 @@ metadata:
   name: ${NAMESPACE}-${ENVIRONMENT}
   namespace: ${NAMESPACE}
 spec:
-  version: "14"
-  network:
-    delegatedSubnetResourceReference:
-      armId: /subscriptions/8b6ea922-0862-443e-af15-6056e1c9b9a4/resourceGroups/cft-preview-network-rg/providers/Microsoft.Network/virtualNetworks/cft-preview-vnet/subnets/postgresql
-    privateDnsZoneArmResourceReference:
-      armId: /subscriptions/1baf5470-1c3e-40d3-a6f7-74bfbce4b348/resourceGroups/core-infra-intsvc-rg/providers/Microsoft.Network/privateDnsZones/privatelink.postgres.database.azure.com
+  version: "16"
 EOF
-  ) >"apps/$NAMESPACE_NAME/preview/aso/$NAMESPACE_NAME-postgres.yaml"
+  ) >"apps/$NAMESPACE_NAME/dev/aso/$NAMESPACE_NAME-postgres.yaml"
 fi
 
-if [ ! -f "apps/$NAMESPACE_NAME/preview/sops-secrets" ]; then
+if [ ! -f "apps/$NAMESPACE_NAME/dev/sops-secrets" ]; then
   echo "Creating sops-secrets"
   mkdir -p apps/$NAMESPACE_NAME
-  mkdir -p apps/$NAMESPACE_NAME/preview
-  mkdir -p apps/$NAMESPACE_NAME/preview/sops-secrets
+  mkdir -p apps/$NAMESPACE_NAME/dev
+  mkdir -p apps/$NAMESPACE_NAME/dev/sops-secrets
 fi
 
 (
@@ -80,7 +75,7 @@ metadata:
     namespace: $NAMESPACE_NAME
 type: Opaque
 EOF
-) >"apps/$NAMESPACE_NAME/preview/sops-secrets/$APP_NAME-values.enc.yaml"
+) >"apps/$NAMESPACE_NAME/dev/sops-secrets/$APP_NAME-values.enc.yaml"
 
 if ! [ -f /usr/local/bin/sops ]; then
   echo "Sops is not installed... installing..."
@@ -89,7 +84,7 @@ if ! [ -f /usr/local/bin/sops ]; then
   chmod +x /usr/local/bin/sops
 fi
 
-sops --encrypt --azure-kv https://dcdcftappsdevkv.vault.azure.net/keys/sops-key/aedb9ea38954430ca1d0a46ed589c049 --encrypted-regex "^(data|stringData)$" --in-place apps/$NAMESPACE_NAME/preview/sops-secrets/$APP_NAME-values.enc.yaml
+sops --encrypt --azure-kv https://dtssharedservicesdevkv.vault.azure.net/keys/sops-key/2beba064ddfe454482ad0133af2cf0fd --encrypted-regex "^(data|stringData)$" --in-place apps/$NAMESPACE_NAME/dev/sops-secrets/$APP_NAME-values.enc.yaml
 
 (
   cat <<EOF
@@ -99,4 +94,4 @@ resources:
   - $APP_NAME-postgres.enc.yaml
 namespace: $NAMESPACE_NAME
 EOF
-) >"apps/$NAMESPACE_NAME/preview/sops-secrets/kustomization.yaml"
+) >"apps/$NAMESPACE_NAME/dev/sops-secrets/kustomization.yaml"

--- a/bin/v2/postgres-setup.sh
+++ b/bin/v2/postgres-setup.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# set -ex
+
+NAMESPACE='${NAMESPACE}'
+ENVIRONMENT='${ENVIRONMENT}'
+NAMESPACE_NAME="$1"
+APP_NAME="$2"
+APPS_DIR="../../apps/"
+CLUSTERS_DIR="../../clusters"
+
+PASSWORD=$(openssl rand -base64 15)
+
+function usage() {
+  echo 'usage: ./postgres-setup.sh <namespace> <app_name>'
+}
+
+if [ -z "${NAMESPACE_NAME}" ] || [ -z "${APP_NAME}" ]; then
+  usage
+  exit 1
+fi
+
+if [ ! -f "apps/$NAMESPACE_NAME/preview/aso" ]; then
+  echo "Creating aso"
+  mkdir -p apps/$NAMESPACE_NAME
+  mkdir -p apps/$NAMESPACE_NAME/preview
+  mkdir -p apps/$NAMESPACE_NAME/preview/aso
+
+  (
+    cat <<EOF
+apiVersion: dbforpostgresql.azure.com/v1api20210601
+kind: FlexibleServersConfiguration
+metadata:
+  name: extensions
+  namespace: ${NAMESPACE}
+  annotations:
+    serviceoperator.azure.com/reconcile-policy: detach-on-delete
+spec:
+  owner:
+    name: ${NAMESPACE}-${ENVIRONMENT}
+  azureName: azure.extensions
+  source: user-override
+  value: "btree_gin"
+EOF
+  ) >"apps/$NAMESPACE_NAME/preview/aso/$NAMESPACE_NAME-postgres-config.yaml"
+
+  (
+    cat <<EOF
+apiVersion: dbforpostgresql.azure.com/v1api20210601
+kind: FlexibleServer
+metadata:
+  name: ${NAMESPACE}-${ENVIRONMENT}
+  namespace: ${NAMESPACE}
+spec:
+  version: "14"
+  network:
+    delegatedSubnetResourceReference:
+      armId: /subscriptions/8b6ea922-0862-443e-af15-6056e1c9b9a4/resourceGroups/cft-preview-network-rg/providers/Microsoft.Network/virtualNetworks/cft-preview-vnet/subnets/postgresql
+    privateDnsZoneArmResourceReference:
+      armId: /subscriptions/1baf5470-1c3e-40d3-a6f7-74bfbce4b348/resourceGroups/core-infra-intsvc-rg/providers/Microsoft.Network/privateDnsZones/privatelink.postgres.database.azure.com
+EOF
+  ) >"apps/$NAMESPACE_NAME/preview/aso/$NAMESPACE_NAME-postgres.yaml"
+fi
+
+if [ ! -f "apps/$NAMESPACE_NAME/preview/sops-secrets" ]; then
+  echo "Creating sops-secrets"
+  mkdir -p apps/$NAMESPACE_NAME
+  mkdir -p apps/$NAMESPACE_NAME/preview
+  mkdir -p apps/$NAMESPACE_NAME/preview/sops-secrets
+fi
+
+(
+  cat <<EOF
+apiVersion: v1
+data:
+    PASSWORD: $PASSWORD
+kind: Secret
+metadata:
+    creationTimestamp: null
+    name: postgres
+    namespace: $NAMESPACE_NAME
+type: Opaque
+EOF
+) >"apps/$NAMESPACE_NAME/preview/sops-secrets/$APP_NAME-values.enc.yaml"
+
+if ! [ -f /usr/local/bin/sops ]; then
+  echo "Sops is not installed... installing..."
+  curl -LO https://github.com/getsops/sops/releases/download/v3.9.1/sops-v3.9.1.darwin.amd64
+  mv sops-v3.9.1.darwin.amd64 /usr/local/bin/sops
+  chmod +x /usr/local/bin/sops
+fi
+
+sops --encrypt --azure-kv https://dcdcftappsdevkv.vault.azure.net/keys/sops-key/aedb9ea38954430ca1d0a46ed589c049 --encrypted-regex "^(data|stringData)$" --in-place apps/$NAMESPACE_NAME/preview/sops-secrets/$APP_NAME-values.enc.yaml
+
+(
+  cat <<EOF
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - $APP_NAME-postgres.enc.yaml
+namespace: $NAMESPACE_NAME
+EOF
+) >"apps/$NAMESPACE_NAME/preview/sops-secrets/kustomization.yaml"

--- a/bin/v2/postgres-setup.sh
+++ b/bin/v2/postgres-setup.sh
@@ -8,7 +8,8 @@ APP_NAME="$2"
 APPS_DIR="../../apps/"
 CLUSTERS_DIR="../../clusters"
 
-PASSWORD=$(openssl rand -base64 15)
+PASSWORD=$(LC_ALL=C tr -dc 'A-Za-z0-9' </dev/urandom | head -c 16 ; echo)
+PASSWORD=$(echo -n $PASSWORD | base64 )
 
 function usage() {
   echo 'usage: ./postgres-setup.sh <namespace> <app_name>'
@@ -27,31 +28,16 @@ if [ ! -f "apps/$NAMESPACE_NAME/dev/aso" ]; then
 
   (
     cat <<EOF
-apiVersion: dbforpostgresql.azure.com/v1api20210601
-kind: FlexibleServersConfiguration
-metadata:
-  name: extensions
-  namespace: ${NAMESPACE}
-  annotations:
-    serviceoperator.azure.com/reconcile-policy: detach-on-delete
-spec:
-  owner:
-    name: ${NAMESPACE}-${ENVIRONMENT}
-  azureName: azure.extensions
-  source: user-override
-  value: "btree_gin"
-EOF
-  ) >"apps/$NAMESPACE_NAME/dev/aso/$NAMESPACE_NAME-postgres-config.yaml"
-
-  (
-    cat <<EOF
-apiVersion: dbforpostgresql.azure.com/v1api20210601
+apiVersion: dbforpostgresql.azure.com/v1api20230601preview
 kind: FlexibleServer
 metadata:
   name: ${NAMESPACE}-${ENVIRONMENT}
   namespace: ${NAMESPACE}
 spec:
   version: "16"
+  sku:
+    name: Standard_D2ds_v5
+    tier: GeneralPurpose
 EOF
   ) >"apps/$NAMESPACE_NAME/dev/aso/$NAMESPACE_NAME-postgres.yaml"
 fi
@@ -97,10 +83,79 @@ rm "./apps/$NAMESPACE_NAME/dev/sops-secrets/$APP_NAME-values.enc_temp.yaml"
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ../../../azureserviceoperator-system/resources/resource-group.yaml
-  - ../../../azureserviceoperator-system/resources/flexibleserver-postgres.yaml
-  - ../../../azureserviceoperator-system/resources/flexibleserver-postgres-config.yaml
-  - $APP_NAME-postgres.enc.yaml
+  - $APP_NAME-values.enc.yaml
 namespace: $NAMESPACE_NAME
 EOF
 ) >"apps/$NAMESPACE_NAME/dev/sops-secrets/kustomization.yaml"
+
+if [ ! -f "apps/$NAMESPACE_NAME/dev/base/kustomization.yaml" ]; then
+  echo "Creating kustomization in dev/base"
+  mkdir -p apps/$NAMESPACE_NAME
+  mkdir -p apps/$NAMESPACE_NAME/dev
+  mkdir -p apps/$NAMESPACE_NAME/dev/base
+
+  (
+    cat <<EOF
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../../base
+  - ../../../azureserviceoperator-system/resources/resource-group.yaml
+  - ../../../azureserviceoperator-system/resources/flexibleserver-postgres.yaml
+  - ../sops-secrets
+namespace: $NAMESPACE_NAME
+patches:
+  - path: ../aso/$NAMESPACE_NAME-postgres.yaml
+EOF
+  ) >"apps/$NAMESPACE_NAME/dev/base/kustomization.yaml"
+else
+(
+    cat <<EOF
+  - ../../../azureserviceoperator-system/resources/resource-group.yaml\\
+  - ../../../azureserviceoperator-system/resources/flexibleserver-postgres.yaml\\
+  - ../../../azureserviceoperator-system/resources/flexibleserver-postgres-config.yaml\\
+  - ../sops-secrets
+EOF
+  ) >"apps/$NAMESPACE_NAME/dev/base/kustomization_resources_temp.yaml"
+(
+    cat <<EOF
+  - path: ../aso/$NAMESPACE_NAME-postgres.yaml
+EOF
+  ) >"apps/$NAMESPACE_NAME/dev/base/kustomization_patches_temp.yaml"
+
+# Path to the kustomization.yaml file
+KUSTOMIZATION_FILE="apps/$NAMESPACE_NAME/dev/base/kustomization.yaml"
+
+# Path to the file to be included
+FILE_RESOURCES_TO_INCLUDE="apps/$NAMESPACE_NAME/dev/base/kustomization_resources_temp.yaml"
+
+# Read the contents of the file to be included
+FILE_RESOURCES_CONTENTS=$(cat "$FILE_RESOURCES_TO_INCLUDE")
+
+# Path to the file to be included
+FILE_PATCHES_TO_INCLUDE="apps/$NAMESPACE_NAME/dev/base/kustomization_patches_temp.yaml"
+
+# Read the contents of the file to be included
+FILE_PATCHES_CONTENTS=$(cat "$FILE_PATCHES_TO_INCLUDE")
+
+echo $FILE_RESOURCES_CONTENTS
+echo $FILE_PATCHES_CONTENTS
+
+# Update the kustomization.yaml file
+sed -i.bak "/namespace:/i\\
+$FILE_RESOURCES_CONTENTS
+" "$KUSTOMIZATION_FILE"
+
+echo "Updated $KUSTOMIZATION_FILE with contents of $FILE_TO_RESOURCES_INCLUDE"
+
+# Update the kustomization.yaml file
+sed -i.bak "/patches:/a\\
+$FILE_PATCHES_CONTENTS
+" "$KUSTOMIZATION_FILE"
+
+echo "Updated $KUSTOMIZATION_FILE with contents of $FILE_TO_PATCHES_INCLUDE"
+
+# deleting the temp file
+rm "./apps/$NAMESPACE_NAME/dev/base/kustomization_resources_temp.yaml"
+rm "./apps/$NAMESPACE_NAME/dev/base/kustomization_patches_temp.yaml"
+fi

--- a/bin/v2/postgres-setup.sh
+++ b/bin/v2/postgres-setup.sh
@@ -109,6 +109,7 @@ patches:
 EOF
   ) >"apps/$NAMESPACE_NAME/dev/base/kustomization.yaml"
 else
+echo "Updating kustomization in dev/base"
 (
     cat <<EOF
   - ../../../azureserviceoperator-system/resources/resource-group.yaml\\
@@ -158,4 +159,5 @@ echo "Updated $KUSTOMIZATION_FILE with contents of $FILE_TO_PATCHES_INCLUDE"
 # deleting the temp file
 rm "./apps/$NAMESPACE_NAME/dev/base/kustomization_resources_temp.yaml"
 rm "./apps/$NAMESPACE_NAME/dev/base/kustomization_patches_temp.yaml"
+rm "./apps/$NAMESPACE_NAME/dev/base/kustomization.yaml.bak"
 fi


### PR DESCRIPTION
### Jira link
DTSPO-18332

### Change description
Create a script to automate and simplify onboarding to persistent preview databases

### Testing done
Tested when merged [PR-5953](https://github.com/hmcts/sds-flux-config/pull/5953)
Created flexible server and resource group containing it: [toffee-dev flexible server](https://portal.azure.com/#@HMCTS.NET/resource/subscriptions/74dacd4f-a248-45bb-a2f0-af700dc4cf68/resourceGroups/toffee-aso-dev-rg/providers/Microsoft.DBforPostgreSQL/flexibleServers/toffee-dev/overview)

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [X] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change




















## 🤖AEP PR SUMMARY🤖


- Added a new script `postgres-setup.sh` in the `bin/v2` directory to set up a PostgreSQL instance for a given namespace and app.
- The script creates configuration files for the PostgreSQL instance and encrypts sensitive values using `sops`.
- It also updates the kustomization in `dev/base` with new resources and patches if necessary.