### PR TITLE
DTSPO-23036: fix jenkins controller image

### DIFF
--- a/apps/jenkins/jenkins/jenkins-controller-version.yaml
+++ b/apps/jenkins/jenkins/jenkins-controller-version.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   values:
     controller:
-      tag: 2.491-828
+      tag: 2.491-829

--- a/apps/jenkins/jenkins/ptlsbox/jenkins-controller-version.yaml
+++ b/apps/jenkins/jenkins/ptlsbox/jenkins-controller-version.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   values:
     controller:
-      tag: 2.491-828
+      tag: 2.491-829


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-23036


### Change description

- new image without upgrade to azure-vm-agents plugin to fix jenkins agent pools


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change

## 🤖AEP PR SUMMARY🤖


### apps/jenkins/jenkins/jenkins-controller-version.yaml
- Updated Jenkins controller version from 2.491-828 to 2.491-829.

### apps/jenkins/jenkins/ptlsbox/jenkins-controller-version.yaml
- Updated Jenkins controller version from 2.491-828 to 2.491-829.