### PR TITLE
DTSPO-23036: rollback controller version in ptlsbox to gather errors

### DIFF
--- a/apps/jenkins/jenkins/ptlsbox/jenkins-controller-version.yaml
+++ b/apps/jenkins/jenkins/ptlsbox/jenkins-controller-version.yaml
@@ -7,4 +7,4 @@ metadata:
 spec:
   values:
     controller:
-      tag: 2.491-829
+      tag: 2.491-828


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-23036


### Change description

- temp rollback to previous image with upgrade to azure-vm-agents plugin to gather errors


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change



## 🤖AEP PR SUMMARY🤖


md
- Updated apps/jenkins/jenkins/ptlsbox/jenkins-controller-version.yaml
- The tag for the Jenkins controller image was downgraded from 2.491-829 to 2.491-828.
```