### PR TITLE
Set to Paris time as a test

### DIFF
--- a/apps/toffee/frontend/sbox.yaml
+++ b/apps/toffee/frontend/sbox.yaml
@@ -10,6 +10,7 @@ spec:
       ingressHost: toffee.sandbox.platform.hmcts.net
       environment:
         RECIPE_BACKEND_URL: http://toffee-recipe-backend.sandbox.platform.hmcts.net
+        TZ: CET-1CEST,M3.5.0,M10.5.0/3
       useWorkloadIdentity: true
       workloadClientID: ${WORKLOAD_IDENTITY_ID}
     global:


### PR DESCRIPTION
### Change description
Set to Paris time as a test
- Tested locally on toffee container, only POSIX format works. Did try `Europe/Paris` with no success

TLDR: This is for a quick fix for a pod to be GMT / UK time. I dont want to spend much time on updating a base image or such. 

## 🤖AEP PR SUMMARY🤖


### apps/toffee/frontend/sbox.yaml
- Added a new environment variable \"TZ\" with value \"CET-1CEST,M3.5.0,M10.5.0/3\"