### PR TITLE
Revert "Set to Paris time as a test"

### DIFF
--- a/apps/toffee/frontend/sbox.yaml
+++ b/apps/toffee/frontend/sbox.yaml
@@ -10,7 +10,6 @@ spec:
       ingressHost: toffee.sandbox.platform.hmcts.net
       environment:
         RECIPE_BACKEND_URL: http://toffee-recipe-backend.sandbox.platform.hmcts.net
-        TZ: CET-1CEST,M3.5.0,M10.5.0/3
       useWorkloadIdentity: true
       workloadClientID: ${WORKLOAD_IDENTITY_ID}
     global:


### PR DESCRIPTION
Reverts hmcts/sds-flux-config#5949

PR works fine, back to normal

## 🤖AEP PR SUMMARY🤖


### apps/toffee/frontend/sbox.yaml
- Removed `TZ: CET-1CEST,M3.5.0,M10.5.0/3` from the file.