### PR TITLE
Changes to TEST_HARNESS_PROXY_URL from proxy to gateway and adding 1

### DIFF
--- a/apps/darts-modernisation/darts-ucf-test-harness/test.yaml
+++ b/apps/darts-modernisation/darts-ucf-test-harness/test.yaml
@@ -7,9 +7,9 @@ spec:
   releaseName: darts-ucf-test-harness
   values:
     java:
-      replicas: 0
+      replicas: 1
       ingressHost: darts-ucf-test-harness.test.platform.hmcts.net
       environment:
         DARTS_LOG_LEVEL: DEBUG
         TEST_HARNESS_AUTOMATION_ENABLED: true
-        TEST_HARNESS_PROXY_URL: http://darts-proxy.test.platform.hmcts.net/service
+        TEST_HARNESS_PROXY_URL: http://darts-gateway.test.platform.hmcts.net/service


### PR DESCRIPTION
Changes to TEST_HARNESS_PROXY_URL from proxy to gateway and adding 1 to replicas to start the test running



## 🤖AEP PR SUMMARY🤖


- Updated `test.yaml`
  - Changed the number of replicas from 0 to 1 for the `java` service
  - Updated `TEST_HARNESS_PROXY_URL` to use `darts-gateway` instead of `darts-proxy`