### PR TITLE
DTSPO 23720 - Patching Traefik to v34.2.0 on sbox and ptlsbox

### DIFF
--- a/apps/admin/traefik-crds-upgrade-v34/kustomization.yaml
+++ b/apps/admin/traefik-crds-upgrade-v34/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v34.2.0/traefik/crds/traefik.io_ingressroutetcps.yaml
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v34.2.0/traefik/crds/traefik.io_ingressroutes.yaml
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v34.2.0/traefik/crds/traefik.io_ingressrouteudps.yaml
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v34.2.0/traefik/crds/traefik.io_middlewares.yaml
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v34.2.0/traefik/crds/traefik.io_middlewaretcps.yaml
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v34.2.0/traefik/crds/traefik.io_serverstransports.yaml
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v34.2.0/traefik/crds/traefik.io_tlsoptions.yaml
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v34.2.0/traefik/crds/traefik.io_tlsstores.yaml
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v34.2.0/traefik/crds/traefik.io_traefikservices.yaml

--- a/apps/admin/traefik-crds-upgrade-v34/kustomize.yaml
+++ b/apps/admin/traefik-crds-upgrade-v34/kustomize.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: traefik-crd
+  namespace: flux-system
+spec:
+  path: ./apps/admin/traefik-crds-upgrade-v34

--- a/apps/admin/traefik2/ptlsbox/00-traefik.yaml
+++ b/apps/admin/traefik2/ptlsbox/00-traefik.yaml
@@ -4,6 +4,15 @@ metadata:
   name: traefik2
   namespace: admin
 spec:
+  chart:
+    spec:
+      chart: traefik
+      # update the crd version in traefik-crds when updating this
+      version: 34.2.0
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: admin
   values:
     entryPoints:
       websecure:

--- a/apps/admin/traefik2/sbox/00-traefik2.yaml
+++ b/apps/admin/traefik2/sbox/00-traefik2.yaml
@@ -4,6 +4,15 @@ metadata:
   name: traefik2
   namespace: admin
 spec:
+  chart:
+    spec:
+      chart: traefik
+      # update the crd version in traefik-crds when updating this
+      version: 34.2.0
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: admin
   values:
     ports:
       traefik:

--- a/apps/admin/traefik2/sbox/01-traefik2.yaml
+++ b/apps/admin/traefik2/sbox/01-traefik2.yaml
@@ -4,6 +4,15 @@ metadata:
   name: traefik2
   namespace: admin
 spec:
+  chart:
+    spec:
+      chart: traefik
+      # update the crd version in traefik-crds when updating this
+      version: 34.2.0
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: admin
   values:
     ports:
       traefik:

--- a/clusters/ptlsbox/base/kustomization.yaml
+++ b/clusters/ptlsbox/base/kustomization.yaml
@@ -16,3 +16,4 @@ patches:
       kind: Kustomization
       annotationSelector: hmcts.github.com/kustomize-defaults != disabled
   - path: ../../../apps/admin/ptlsbox/base/kustomize.yaml
+  - path: ../../../apps/admin/traefik-crds-upgrade-v34/kustomize.yaml

--- a/clusters/sbox/base/kustomization.yaml
+++ b/clusters/sbox/base/kustomization.yaml
@@ -23,3 +23,4 @@ patches:
       annotationSelector: hmcts.github.com/kustomize-defaults != disabled
   - path: ../../../apps/toffee/sbox/base/kustomize.yaml
   - path: ../../../apps/admin/sbox/base/kustomize.yaml
+  - path: ../../../apps/admin/traefik-crds-upgrade-v34/kustomize.yaml


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-23720

### Change description

- Patching Traefik to v34.2.0 on sbox and ptlsbox

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change






## 🤖AEP PR SUMMARY🤖


- Added a new file \"apps/admin/traefik-crds-upgrade-v34/kustomization.yaml\" which includes references to multiple CRDs related to Traefik.
- Added a new file \"apps/admin/traefik-crds-upgrade-v34/kustomize.yaml\" with specification for traefik-crd.
- Updated \"apps/admin/traefik2/ptlsbox/00-traefik.yaml\" to use chart version 34.2.0 from HelmRepository.
- Updated \"apps/admin/traefik2/sbox/00-traefik2.yaml\" to use chart version 34.2.0 from HelmRepository.
- Updated \"apps/admin/traefik2/sbox/01-traefik2.yaml\" to use chart version 34.2.0 from HelmRepository.
- Updated \"clusters/ptlsbox/base/kustomization.yaml\" to add path \"./././apps/admin/traefik-crds-upgrade-v34/kustomize.yaml\".
- Updated \"clusters/sbox/base/kustomization.yaml\" to add path \"./././apps/admin/traefik-crds-upgrade-v34/kustomize.yaml\".