### PR TITLE
DTSPO 23720 - Patching Traefik to v34.2.0 on non-prod

### DIFF
--- a/apps/admin/traefik2/demo/00-traefik2.yaml
+++ b/apps/admin/traefik2/demo/00-traefik2.yaml
@@ -4,6 +4,15 @@ metadata:
   name: traefik2
   namespace: admin
 spec:
+  chart:
+    spec:
+      chart: traefik
+      # update the crd version in traefik-crds when updating this
+      version: 34.2.0
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: admin
   values:
     ports:
       traefik:

--- a/apps/admin/traefik2/demo/01-traefik2.yaml
+++ b/apps/admin/traefik2/demo/01-traefik2.yaml
@@ -4,6 +4,15 @@ metadata:
   name: traefik2
   namespace: admin
 spec:
+  chart:
+    spec:
+      chart: traefik
+      # update the crd version in traefik-crds when updating this
+      version: 34.2.0
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: admin
   values:
     ports:
       traefik:

--- a/apps/admin/traefik2/dev/00-traefik2.yaml
+++ b/apps/admin/traefik2/dev/00-traefik2.yaml
@@ -4,6 +4,15 @@ metadata:
   name: traefik2
   namespace: admin
 spec:
+  chart:
+    spec:
+      chart: traefik
+      # update the crd version in traefik-crds when updating this
+      version: 34.2.0
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: admin
   values:
     service:
       spec:

--- a/apps/admin/traefik2/dev/01-traefik2.yaml
+++ b/apps/admin/traefik2/dev/01-traefik2.yaml
@@ -4,6 +4,15 @@ metadata:
   name: traefik2
   namespace: admin
 spec:
+  chart:
+    spec:
+      chart: traefik
+      # update the crd version in traefik-crds when updating this
+      version: 34.2.0
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: admin
   values:
     service:
       spec:

--- a/apps/admin/traefik2/ithc/00-traefik2.yaml
+++ b/apps/admin/traefik2/ithc/00-traefik2.yaml
@@ -4,6 +4,15 @@ metadata:
   name: traefik2
   namespace: admin
 spec:
+  chart:
+    spec:
+      chart: traefik
+      # update the crd version in traefik-crds when updating this
+      version: 34.2.0
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: admin
   values:
     service:
       spec:

--- a/apps/admin/traefik2/ithc/01-traefik2.yaml
+++ b/apps/admin/traefik2/ithc/01-traefik2.yaml
@@ -4,6 +4,15 @@ metadata:
   name: traefik2
   namespace: admin
 spec:
+  chart:
+    spec:
+      chart: traefik
+      # update the crd version in traefik-crds when updating this
+      version: 34.2.0
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: admin
   values:
     service:
       spec:

--- a/apps/admin/traefik2/stg/00-traefik2.yaml
+++ b/apps/admin/traefik2/stg/00-traefik2.yaml
@@ -4,6 +4,15 @@ metadata:
   name: traefik2
   namespace: admin
 spec:
+  chart:
+    spec:
+      chart: traefik
+      # update the crd version in traefik-crds when updating this
+      version: 34.2.0
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: admin
   values:
     service:
       spec:

--- a/apps/admin/traefik2/stg/01-traefik2.yaml
+++ b/apps/admin/traefik2/stg/01-traefik2.yaml
@@ -4,6 +4,15 @@ metadata:
   name: traefik2
   namespace: admin
 spec:
+  chart:
+    spec:
+      chart: traefik
+      # update the crd version in traefik-crds when updating this
+      version: 34.2.0
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: admin
   values:
     service:
       spec:

--- a/apps/admin/traefik2/test/00-traefik2.yaml
+++ b/apps/admin/traefik2/test/00-traefik2.yaml
@@ -4,6 +4,15 @@ metadata:
   name: traefik2
   namespace: admin
 spec:
+  chart:
+    spec:
+      chart: traefik
+      # update the crd version in traefik-crds when updating this
+      version: 34.2.0
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: admin
   values:
     service:
       spec:

--- a/apps/admin/traefik2/test/01-traefik2.yaml
+++ b/apps/admin/traefik2/test/01-traefik2.yaml
@@ -4,6 +4,15 @@ metadata:
   name: traefik2
   namespace: admin
 spec:
+  chart:
+    spec:
+      chart: traefik
+      # update the crd version in traefik-crds when updating this
+      version: 34.2.0
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: admin
   values:
     service:
       spec:

--- a/clusters/demo/base/kustomization.yaml
+++ b/clusters/demo/base/kustomization.yaml
@@ -22,3 +22,4 @@ patches:
       annotationSelector: hmcts.github.com/kustomize-defaults != disabled
   - path: ../../../apps/toffee/demo/base/kustomize.yaml
   - path: ../../../apps/admin/demo/base/kustomize.yaml
+  - path: ../../../apps/admin/traefik-crds-upgrade-v34/kustomize.yaml

--- a/clusters/dev/base/kustomization.yaml
+++ b/clusters/dev/base/kustomization.yaml
@@ -31,3 +31,4 @@ patches:
       annotationSelector: hmcts.github.com/kustomize-defaults != disabled
   - path: ../../../apps/toffee/dev/base/kustomize.yaml
   - path: ../../../apps/admin/dev/base/kustomize.yaml
+  - path: ../../../apps/admin/traefik-crds-upgrade-v34/kustomize.yaml

--- a/clusters/ithc/base/kustomization.yaml
+++ b/clusters/ithc/base/kustomization.yaml
@@ -25,3 +25,4 @@ patches:
   - path: ../../../apps/toffee/ithc/base/kustomize.yaml
   - path: ../../../apps/admin/ithc/base/kustomize.yaml
   - path: ../../../apps/neuvector/crds/kustomize.yaml
+  - path: ../../../apps/admin/traefik-crds-upgrade-v34/kustomize.yaml

--- a/clusters/stg/base/kustomization.yaml
+++ b/clusters/stg/base/kustomization.yaml
@@ -30,3 +30,4 @@ patches:
   - path: ../../../apps/toffee/stg/base/kustomize.yaml
   - path: ../../../apps/admin/stg/base/kustomize.yaml
   - path: ../../../apps/neuvector/crds/kustomize.yaml
+  - path: ../../../apps/admin/traefik-crds-upgrade-v34/kustomize.yaml

--- a/clusters/test/base/kustomization.yaml
+++ b/clusters/test/base/kustomization.yaml
@@ -28,3 +28,4 @@ patches:
   - path: ../../../apps/toffee/test/base/kustomize.yaml
   - path: ../../../apps/admin/test/base/kustomize.yaml
   - path: ../../../apps/neuvector/crds/kustomize.yaml
+  - path: ../../../apps/admin/traefik-crds-upgrade-v34/kustomize.yaml


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-23720

### Change description

- Patching Traefik to v34.2.0 on non-prod

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


- Updated traefik chart to version 34.2.0 in various environment specific YAML files (`00-traefik2.yaml` and `01-traefik2.yaml`)
- Updated kustomization.yaml files in different environment folders to include `traefik-crds-upgrade-v34/kustomize.yaml` file for traefik-crds upgrade.