### PR TITLE
Turning on the test harness

### DIFF
--- a/apps/darts-modernisation/darts-ucf-test-harness/test.yaml
+++ b/apps/darts-modernisation/darts-ucf-test-harness/test.yaml
@@ -7,7 +7,7 @@ spec:
   releaseName: darts-ucf-test-harness
   values:
     java:
-      replicas: 0
+      replicas: 10
       ingressHost: darts-ucf-test-harness.test.platform.hmcts.net
       environment:
         DARTS_LOG_LEVEL: DEBUG


### PR DESCRIPTION
Turning on the test harness by adding 10 replicas

## 🤖AEP PR SUMMARY🤖


### apps/darts-modernisation/darts-ucf-test-harness/test.yaml
- Increased the number of replicas for the `java` service from 0 to 10.
- Updated the `ingressHost` to `darts-ucf-test-harness.test.platform.hmcts.net`.
- Set the `DARTS_LOG_LEVEL` environment variable to `DEBUG`.