### PR TITLE
Changing to replicas: 11

### DIFF
--- a/apps/darts-modernisation/darts-ucf-test-harness/test.yaml
+++ b/apps/darts-modernisation/darts-ucf-test-harness/test.yaml
@@ -7,7 +7,7 @@ spec:
   releaseName: darts-ucf-test-harness
   values:
     java:
-      replicas: 10
+      replicas: 11
       ingressHost: darts-ucf-test-harness.test.platform.hmcts.net
       environment:
         DARTS_LOG_LEVEL: DEBUG


### PR DESCRIPTION
Changing to replicas: 11

## 🤖AEP PR SUMMARY🤖


- Updated `test.yaml` in `apps/darts-modernisation/darts-ucf-test-harness`
- Changed the number of replicas from 10 to 11