### PR TITLE
Turning off the Test Harness

### DIFF
--- a/apps/darts-modernisation/darts-ucf-test-harness/test.yaml
+++ b/apps/darts-modernisation/darts-ucf-test-harness/test.yaml
@@ -7,7 +7,7 @@ spec:
   releaseName: darts-ucf-test-harness
   values:
     java:
-      replicas: 10
+      replicas: 0
       ingressHost: darts-ucf-test-harness.test.platform.hmcts.net
       environment:
         DARTS_LOG_LEVEL: DEBUG


### PR DESCRIPTION
Turning off the Test Harness

## 🤖AEP PR SUMMARY🤖


- Updated file: test.yaml
- Changed replicas from 10 to 0 for the Java service in the darts-ucf-test-harness deployment.