### PR TITLE
testing with Paris timezone

### DIFF
--- a/apps/met/themis-fe/test.yaml
+++ b/apps/met/themis-fe/test.yaml
@@ -9,6 +9,7 @@ spec:
     nodejs:
       ingressHost: 'cloudgobgateway.test.platform.hmcts.net'
       image: 'sdshmctspublic.azurecr.io/themis/themis_sb_azure:1.19.0'
+      TZ: CET-1CEST,M3.5.0,M10.5.0/3
       replicas: 1
       autoscaling:
         enabled: false


### PR DESCRIPTION
### Change description
Set to Paris time as a test

Tested locally on toffee container, only POSIX format works. Did try Europe/Paris with no success
TLDR: This is for a quick fix for a pod to be GMT / UK time. I dont want to spend much time on updating a base image or such.

tested fine previous on test app - https://github.com/hmcts/sds-flux-config/pull/5949



## 🤖AEP PR SUMMARY🤖


### apps/met/themis-fe/test.yaml
- Added `TZ: CET-1CEST,M3.5.0,M10.5.0/3` to the environment variables for the Themis Frontend service. 🕒