### PR TITLE
switch volumes to separate values

### DIFF
--- a/apps/met/themis-fe/test.yaml
+++ b/apps/met/themis-fe/test.yaml
@@ -6,6 +6,10 @@ metadata:
   namespace: met
 spec:
   values:
+    volumes:
+      - name: tz-config
+        hostPath:
+          path: /usr/share/zoneinfo/Europe/Paris
     nodejs:
       ingressHost: 'cloudgobgateway.test.platform.hmcts.net'
       image: 'sdshmctspublic.azurecr.io/themis/themis_sb_azure:1.19.0'
@@ -20,10 +24,6 @@ spec:
       volumeMounts:
         - name: tz-config
           mountPath: /etc/localtime
-      volumes:
-        - name: tz-config
-          hostPath:
-            path: /usr/share/zoneinfo/Europe/Paris
       keyVaults:
         libragob-test-kv:
           excludeEnvironmentSuffix: true


### PR DESCRIPTION
### Change description
switch volumes to separate values


## 🤖AEP PR SUMMARY🤖


- `test.yaml`: 
  - Added a new volume `tz-config` with a `hostPath` pointing to `/usr/share/zoneinfo/Europe/Paris`.
  - Removed the duplicate `volumes` section.
  - Updated the configuration for `nodejs` and `volumeMounts`.
  - Updated `keyVaults` configuration, removing the `volumes` section and adding `excludeEnvironmentSuffix` property.