### PR TITLE
DTSPO-23725 - Patching ptl traefik to 34.2.0

### DIFF
--- a/apps/admin/traefik2/ptl/00-traefik.yaml
+++ b/apps/admin/traefik2/ptl/00-traefik.yaml
@@ -4,6 +4,15 @@ metadata:
   name: traefik2
   namespace: admin
 spec:
+  chart:
+    spec:
+      chart: traefik
+      # update the crd version in traefik-crds when updating this
+      version: 34.2.0
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: admin
   values:
     service:
       spec:

--- a/clusters/ptl/base/kustomization.yaml
+++ b/clusters/ptl/base/kustomization.yaml
@@ -16,3 +16,4 @@ patches:
       kind: Kustomization
       annotationSelector: hmcts.github.com/kustomize-defaults != disabled
   - path: ../../../apps/admin/ptl/base/kustomize.yaml
+  - path: ../../../apps/admin/traefik-crds-upgrade-v34/kustomize.yaml


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-23725

### Change description

Patching Traefik to v34.2.0 on ptl

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


- Updated 00-traefik.yaml``` in ```apps/admin/traefik2/ptl```:
  - Added a new version of the Traefik chart (34.2.0) sourced from the Helm repository.

- Updated ```kustomization.yaml``` in ```clusters/ptl/base```:
  - Added a new path for ```./././apps/admin/traefik-crds-upgrade-v34/kustomize.yaml``` 