### PR TITLE
Image policy update

### DIFF
--- a/apps/darts-modernisation/darts-api/image-policy-pr.yaml
+++ b/apps/darts-modernisation/darts-api/image-policy-pr.yaml
@@ -1,0 +1,15 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImagePolicy
+metadata:
+  name: darts-api-pr
+  annotations:
+    hmcts.github.com/prod-automated: disabled
+spec:
+  imageRepositoryRef:
+    name: darts-api
+  filterTags:
+    extract: $ts
+    pattern: '^pr-2568-[a-f0-9]+-(?P<ts>[0-9]+)'
+  policy:
+    alphabetical:
+      order: asc

--- a/apps/darts-modernisation/darts-api/test.yaml
+++ b/apps/darts-modernisation/darts-api/test.yaml
@@ -7,6 +7,7 @@ spec:
   releaseName: darts-api
   values:
     java:
+      image: sdshmctspublic.azurecr.io/darts/api:pr-2568-ef9148d-20250210170553 # {"$imagepolicy": "flux-system:darts-api-pr"}
       ingressHost: darts-api.test.platform.hmcts.net
       environment:
         DARTS_GATEWAY_URL: http://darts-gateway.test.platform.hmcts.net


### PR DESCRIPTION
Image policy update



## 🤖AEP PR SUMMARY🤖


### New File - image-policy-pr.yaml
- Added a new file `image-policy-pr.yaml` with an `ImagePolicy` resource to specify image filtering and ordering for the `darts-api` application.

### Updated test.yaml
- Updated the `test.yaml` file to include a new image reference for the `darts-api` application pointing to `sdshmctspublic.azurecr.io/darts/api:pr-2568-ef9148d-20250210170553`.