### PR TITLE
PRE API Feature Toggle: Create Streaming Locator on Start 

### DIFF
--- a/apps/pre/pre-api/demo.yaml
+++ b/apps/pre/pre-api/demo.yaml
@@ -15,3 +15,4 @@ spec:
         AZURE_SUBSCRIPTION_ID: c68a4bed-4c3d-4956-af51-4ae164c1957c
         PLATFORM_ENV_TAG: Demo
         MEDIA_SERVICE: MediaKind
+        ENABLE_STREAMING_LOCATOR_ON_START: false

--- a/apps/pre/pre-api/prod.yaml
+++ b/apps/pre/pre-api/prod.yaml
@@ -15,4 +15,5 @@ spec:
         AZURE_SUBSCRIPTION_ID: 5ca62022-6aa2-4cee-aaa7-e7536c8d566c
         PLATFORM_ENV_TAG: Production
         MEDIA_SERVICE: MediaKind
+        ENABLE_STREAMING_LOCATOR_ON_START: false
         TRIGGER: init-2

--- a/apps/pre/pre-api/stg.yaml
+++ b/apps/pre/pre-api/stg.yaml
@@ -17,3 +17,4 @@ spec:
         AZURE_FINAL_SA: prefinalsastg
         MEDIA_SERVICE: MediaKind
         ENABLE_NEW_EMAIL_SERVICE: true
+        ENABLE_STREAMING_LOCATOR_ON_START: true

--- a/apps/pre/pre-api/test.yaml
+++ b/apps/pre/pre-api/test.yaml
@@ -14,3 +14,4 @@ spec:
         AZURE_SUBSCRIPTION_ID: 3eec5bde-7feb-4566-bfb6-805df6e10b90
         PLATFORM_ENV_TAG: Testing
         MEDIA_SERVICE: MediaKind
+        ENABLE_STREAMING_LOCATOR_ON_START: false


### PR DESCRIPTION
### Jira link

<!-- 
Replace PROJ-XXXXXX with your Jira key
Remove this section if its not applicable, or replace it with another reference link
-->
See [S28-3667](https://tools.hmcts.net/jira/browse/S28-3667)

### Change description
Add feature toggle for create streaming locator on start feature. Enabled in stg, disabled elsewhere

<!--
Provide a description of what change you are proposing.
A short summary here and then you can add comments in your pull request explaining your change to others.
-->




## 🤖AEP PR SUMMARY🤖


### apps/pre/pre-api/demo.yaml
- Added `ENABLE_STREAMING_LOCATOR_ON_START: false` to the configuration for the `MediaKind` service in the demo environment.

### apps/pre/pre-api/prod.yaml
- Added `ENABLE_STREAMING_LOCATOR_ON_START: false` to the configuration for the `MediaKind` service in the production environment.

### apps/pre/pre-api/stg.yaml
- Added `ENABLE_STREAMING_LOCATOR_ON_START: true` to the configuration for the `MediaKind` service in the staging environment.
  
### apps/pre/pre-api/test.yaml
- Added `ENABLE_STREAMING_LOCATOR_ON_START: false` to the configuration for the `MediaKind` service in the testing environment.