### PR TITLE
Add list assist dashboard

### DIFF
--- a/apps/jenkins/jenkins/ptl/jenkins.yaml
+++ b/apps/jenkins/jenkins/ptl/jenkins.yaml
@@ -241,6 +241,12 @@ spec:
                     name: MRD
                     recurse: true
                     title: Master and Reference Data Dashboard
+                - buildMonitor:
+                    includeRegex: >-
+                      ^HMCTS.*\/(list-assist-e2e-tests)\/master
+                    name: List Assist
+                    recurse: true
+                    title: List Assist dashboard
           authentication: |
             jenkins:
               securityRealm:


### PR DESCRIPTION


## 🤖AEP PR SUMMARY🤖


### apps/jenkins/jenkins/ptl/jenkins.yaml
- Added configuration for a new dashboard \"List Assist\" under the \"buildMonitor\" section.