### PR TITLE
Removed branch lock from test

### DIFF
--- a/apps/darts-modernisation/darts-api/test.yaml
+++ b/apps/darts-modernisation/darts-api/test.yaml
@@ -8,7 +8,7 @@ spec:
   values:
     java:
       ingressHost: darts-api.test.platform.hmcts.net
-      image: sdshmctspublic.azurecr.io/darts/api:pr-2568-f9f2007-20250211125721 #{"$imagepolicy": "flux-system:darts-api-pr"}
+      #image: sdshmctspublic.azurecr.io/darts/api:pr-2568-f9f2007-20250211125721 #{"$imagepolicy": "flux-system:darts-api-pr"}
       environment:
         DARTS_GATEWAY_URL: http://darts-gateway.test.platform.hmcts.net
         DARTS_LOG_LEVEL: DEBUG


### PR DESCRIPTION
### Jira link

<!-- 
Replace PROJ-XXXXXX with your Jira key
Remove this section if its not applicable, or replace it with another reference link
-->
See [PROJ-XXXXXX](https://tools.hmcts.net/jira/browse/PROJ-XXXXXX)

### Change description

<!--
Provide a description of what change you are proposing.
A short summary here and then you can add comments in your pull request explaining your change to others.
-->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


- The `test.yaml` file in `darts-modernisation/darts-api` has been modified.
- The `image` value has been updated to point to a new image: `sdshmctspublic.azurecr.io/darts/api:pr-2568-f9f2007-20250211125721`.
- An `environment` block has been added with two key-value pairs: `DARTS_GATEWAY_URL: http://darts-gateway.test.platform.hmcts.net` and `DARTS_LOG_LEVEL: DEBUG`.