### PR TITLE
Patch dynatrace one agent

### DIFF
--- a/apps/dynatrace/dynatrace-crds/kustomization.yaml
+++ b/apps/dynatrace/dynatrace-crds/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/Dynatrace/dynatrace-operator/releases/download/v1.3.2/dynatrace-operator-crd.yaml
+  - https://github.com/Dynatrace/dynatrace-operator/releases/download/v1.4.1/dynatrace-operator-crd.yaml

--- a/apps/dynatrace/dynatrace-operator.yaml
+++ b/apps/dynatrace/dynatrace-operator.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       chart: dynatrace-operator
       # update the CRDs in dynatrace-crds when changing this value
-      version: 1.3.2
+      version: 1.4.1
       sourceRef:
         name: dynatrace-operator
         kind: HelmRepository


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-23727

### Change description

Patch dynatrace one agent to v 1.4.1



## 🤖AEP PR SUMMARY🤖


- **apps/dynatrace/dynatrace-crds/kustomization.yaml**
  - Updated the URL for Dynatrace Operator CRD from v1.3.2 to v1.4.1.

- **apps/dynatrace/dynatrace-operator.yaml**
  - Updated the version of the Dynatrace Operator from 1.3.2 to 1.4.1.