### PR TITLE
Patching kube prometheus stack to 69.3.1

### DIFF
--- a/apps/monitoring/kube-prometheus-stack-crds/kustomization.yaml
+++ b/apps/monitoring/kube-prometheus-stack-crds/kustomization.yaml
@@ -1,11 +1,11 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://raw.githubusercontent.com/prometheus-community/helm-charts/kube-prometheus-stack-66.2.1/charts/kube-prometheus-stack/charts/crds/crds/crd-alertmanagerconfigs.yaml
-  - https://raw.githubusercontent.com/prometheus-community/helm-charts/kube-prometheus-stack-66.2.1/charts/kube-prometheus-stack/charts/crds/crds/crd-alertmanagers.yaml
-  - https://raw.githubusercontent.com/prometheus-community/helm-charts/kube-prometheus-stack-66.2.1/charts/kube-prometheus-stack/charts/crds/crds/crd-podmonitors.yaml
-  - https://raw.githubusercontent.com/prometheus-community/helm-charts/kube-prometheus-stack-66.2.1/charts/kube-prometheus-stack/charts/crds/crds/crd-probes.yaml
-  - https://raw.githubusercontent.com/prometheus-community/helm-charts/kube-prometheus-stack-66.2.1/charts/kube-prometheus-stack/charts/crds/crds/crd-prometheuses.yaml
-  - https://raw.githubusercontent.com/prometheus-community/helm-charts/kube-prometheus-stack-66.2.1/charts/kube-prometheus-stack/charts/crds/crds/crd-prometheusrules.yaml
-  - https://raw.githubusercontent.com/prometheus-community/helm-charts/kube-prometheus-stack-66.2.1/charts/kube-prometheus-stack/charts/crds/crds/crd-servicemonitors.yaml
-  - https://raw.githubusercontent.com/prometheus-community/helm-charts/kube-prometheus-stack-66.2.1/charts/kube-prometheus-stack/charts/crds/crds/crd-thanosrulers.yaml
+  - https://raw.githubusercontent.com/prometheus-community/helm-charts/kube-prometheus-stack-69.3.1/charts/kube-prometheus-stack/charts/crds/crds/crd-alertmanagerconfigs.yaml
+  - https://raw.githubusercontent.com/prometheus-community/helm-charts/kube-prometheus-stack-69.3.1/charts/kube-prometheus-stack/charts/crds/crds/crd-alertmanagers.yaml
+  - https://raw.githubusercontent.com/prometheus-community/helm-charts/kube-prometheus-stack-69.3.1/charts/kube-prometheus-stack/charts/crds/crds/crd-podmonitors.yaml
+  - https://raw.githubusercontent.com/prometheus-community/helm-charts/kube-prometheus-stack-69.3.1/charts/kube-prometheus-stack/charts/crds/crds/crd-probes.yaml
+  - https://raw.githubusercontent.com/prometheus-community/helm-charts/kube-prometheus-stack-69.3.1/charts/kube-prometheus-stack/charts/crds/crds/crd-prometheuses.yaml
+  - https://raw.githubusercontent.com/prometheus-community/helm-charts/kube-prometheus-stack-69.3.1/charts/kube-prometheus-stack/charts/crds/crds/crd-prometheusrules.yaml
+  - https://raw.githubusercontent.com/prometheus-community/helm-charts/kube-prometheus-stack-69.3.1/charts/kube-prometheus-stack/charts/crds/crds/crd-servicemonitors.yaml
+  - https://raw.githubusercontent.com/prometheus-community/helm-charts/kube-prometheus-stack-69.3.1/charts/kube-prometheus-stack/charts/crds/crds/crd-thanosrulers.yaml

--- a/apps/monitoring/kube-prometheus-stack/kube-prometheus-stack.yaml
+++ b/apps/monitoring/kube-prometheus-stack/kube-prometheus-stack.yaml
@@ -258,7 +258,7 @@ spec:
     spec:
       chart: kube-prometheus-stack
       # update crds in kube-prometheus-stack-crds when changing this version
-      version: 66.2.1
+      version: 69.3.1
       sourceRef:
         kind: HelmRepository
         name: prometheus


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-23730

### Change description

Patching kube prometheus stack to 69.3.1


## 🤖AEP PR SUMMARY🤖


- Updated `kube-prometheus-stack-crds/kustomization.yaml` to use version 69.3.1 of the kube-prometheus-stack Helm charts instead of version 66.2.1, and updated the corresponding CRD resources.
- In `kube-prometheus-stack/kube-prometheus-stack.yaml`, the Helm chart version has been updated from 66.2.1 to 69.3.1.