### PR TITLE
Revert "Patch dynatrace one agent"

### DIFF
--- a/apps/dynatrace/dynatrace-crds/kustomization.yaml
+++ b/apps/dynatrace/dynatrace-crds/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/Dynatrace/dynatrace-operator/releases/download/v1.4.1/dynatrace-operator-crd.yaml
+  - https://github.com/Dynatrace/dynatrace-operator/releases/download/v1.3.2/dynatrace-operator-crd.yaml

--- a/apps/dynatrace/dynatrace-operator.yaml
+++ b/apps/dynatrace/dynatrace-operator.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       chart: dynatrace-operator
       # update the CRDs in dynatrace-crds when changing this value
-      version: 1.4.1
+      version: 1.3.2
       sourceRef:
         name: dynatrace-operator
         kind: HelmRepository


### PR DESCRIPTION
Reverts hmcts/sds-flux-config#6135

## 🤖AEP PR SUMMARY🤖


### apps/dynatrace/dynatrace-crds/kustomization.yaml
- The source URL for the Dynatrace operator custom resource definition (CRD) has been downgraded from v1.4.1 to v1.3.2.

### apps/dynatrace/dynatrace-operator.yaml
- The version of the Dynatrace operator has been downgraded from 1.4.1 to 1.3.2.