### PR TITLE
Remove dynatrace from test clusters

### DIFF
--- a/clusters/test/base/kustomization.yaml
+++ b/clusters/test/base/kustomization.yaml
@@ -4,7 +4,7 @@ resources:
   - ../../../apps/flux-system/test/base
   - ../../../apps/admin/base/kustomize.yaml
   - ../../../apps/azure-devops/base/kustomize.yaml
-  - ../../../apps/dynatrace/base/kustomize.yaml
+  # - ../../../apps/dynatrace/base/kustomize.yaml
   - ../../../apps/mi/base/kustomize.yaml
   - ../../../apps/neuvector/base/kustomize.yaml
   - ../../../apps/pip/base/kustomize.yaml


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-23727

### Change description

Remove dynatrace from test clusters to fully remove then will re add to troubleshoot issues




## 🤖AEP PR SUMMARY🤖


### clusters/test/base/kustomization.yaml
- Replaced the reference to `apps/dynatrace` with `apps/mi` in the resources list.