### PR TITLE
Revert "Remove dynatrace from test clusters"

### DIFF
--- a/clusters/test/base/kustomization.yaml
+++ b/clusters/test/base/kustomization.yaml
@@ -4,7 +4,7 @@ resources:
   - ../../../apps/flux-system/test/base
   - ../../../apps/admin/base/kustomize.yaml
   - ../../../apps/azure-devops/base/kustomize.yaml
-  # - ../../../apps/dynatrace/base/kustomize.yaml
+  - ../../../apps/dynatrace/base/kustomize.yaml
   - ../../../apps/mi/base/kustomize.yaml
   - ../../../apps/neuvector/base/kustomize.yaml
   - ../../../apps/pip/base/kustomize.yaml


### PR DESCRIPTION
Put dynatrace back onto test clusters

Reverts hmcts/sds-flux-config#6151

## 🤖AEP PR SUMMARY🤖


- **kustomization.yaml**
  - Added a reference to the `dynatrace` application kustomization file.