### PR TITLE
Turning Test Harness on with 20

### DIFF
--- a/apps/darts-modernisation/darts-ucf-test-harness/test.yaml
+++ b/apps/darts-modernisation/darts-ucf-test-harness/test.yaml
@@ -7,7 +7,7 @@ spec:
   releaseName: darts-ucf-test-harness
   values:
     java:
-      replicas: 0
+      replicas: 10
       ingressHost: darts-ucf-test-harness.test.platform.hmcts.net
       environment:
         DARTS_LOG_LEVEL: DEBUG


### PR DESCRIPTION
Turning Test Harness on with 20

## 🤖AEP PR SUMMARY🤖


### apps/darts-modernisation/darts-ucf-test-harness/test.yaml
- Updated the number of replicas from 0 to 10 for the Java component.
- Changed the value of ingressHost to \"darts-ucf-test-harness.test.platform.hmcts.net\".
- Set the environment variable DARTS_LOG_LEVEL to \"DEBUG\".