### PR TITLE
Turning off the test harness

### DIFF
--- a/apps/darts-modernisation/darts-ucf-test-harness/test.yaml
+++ b/apps/darts-modernisation/darts-ucf-test-harness/test.yaml
@@ -7,7 +7,7 @@ spec:
   releaseName: darts-ucf-test-harness
   values:
     java:
-      replicas: 10
+      replicas: 0
       ingressHost: darts-ucf-test-harness.test.platform.hmcts.net
       environment:
         DARTS_LOG_LEVEL: DEBUG


### PR DESCRIPTION
Turning off the test harness

## 🤖AEP PR SUMMARY🤖


- Updated replicas from 10 to 0 in `test.yaml` for the `darts-ucf-test-harness` release.