### PR TITLE
Remove dynatrace from test env

### DIFF
--- a/clusters/test/base/kustomization.yaml
+++ b/clusters/test/base/kustomization.yaml
@@ -4,7 +4,7 @@ resources:
   - ../../../apps/flux-system/test/base
   - ../../../apps/admin/base/kustomize.yaml
   - ../../../apps/azure-devops/base/kustomize.yaml
-  - ../../../apps/dynatrace/base/kustomize.yaml
+  # - ../../../apps/dynatrace/base/kustomize.yaml
   - ../../../apps/mi/base/kustomize.yaml
   - ../../../apps/neuvector/base/kustomize.yaml
   - ../../../apps/pip/base/kustomize.yaml


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-23727



### Change description

Removing dynatrace agent from test, will clean env of deployment then do clean install of new version


## 🤖AEP PR SUMMARY🤖


The file `clusters/test/base/kustomization.yaml` has been modified. The change involves replacing the path to `apps/dynatrace/base/kustomize.yaml` with the path to `apps/mi/base/kustomize.yaml`.