### PR TITLE
Patch dynatrace on test env

### DIFF
--- a/apps/dynatrace/base/kustomize-upgrade.yaml
+++ b/apps/dynatrace/base/kustomize-upgrade.yaml
@@ -1,8 +1,0 @@
-apiVersion: kustomize.toolkit.fluxcd.io/v1
-kind: Kustomization
-metadata:
-  name: dynatrace-crd
-  namespace: flux-system
-spec:
-  interval: 10m
-  path: ./apps/dynatrace/dynatrace-crds-upgrade

--- a/apps/dynatrace/dynatrace-crds-upgrade/kustomization.yaml
+++ b/apps/dynatrace/dynatrace-crds-upgrade/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/Dynatrace/dynatrace-operator/releases/download/v1.2.2/dynatrace-operator-crd.yaml
+  - https://github.com/Dynatrace/dynatrace-operator/releases/download/v1.4.1/dynatrace-operator-crd.yaml

--- a/apps/dynatrace/dynatrace-operator-upgrade.yaml
+++ b/apps/dynatrace/dynatrace-operator-upgrade.yaml
@@ -10,4 +10,4 @@ spec:
     spec:
       chart: dynatrace-operator
       # update the CRDs in dynatrace-crds when changing this value
-      version: 1.2.2
+      version: 1.4.1

--- a/apps/dynatrace/test/base/kustomization.yaml
+++ b/apps/dynatrace/test/base/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
 namespace: dynatrace
 patches:
   - path: dynakube.yaml
+  - path: ../../dynatrace-operator-upgrade.yaml

--- a/apps/dynatrace/test/base/kustomize.yaml
+++ b/apps/dynatrace/test/base/kustomize.yaml
@@ -1,0 +1,24 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: dynatrace
+  namespace: flux-system
+spec:
+  interval: 10m
+  dependsOn:
+    - name: ./apps/dynatrace/dynatrace-crds-upgrade
+  path: ./apps/dynatrace/${ENVIRONMENT}/${CLUSTER}
+  postBuild:
+    substitute:
+      NAMESPACE: "dynatrace"
+      TEAM_NOTIFICATION_CHANNEL: "${ENV_MONITOR_CHANNEL}"
+      CLUSTER_FULL_NAME: "${ENVIRONMENT}-${CLUSTER}"
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: dynatrace-crd
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./apps/dynatrace/dynatrace-crds-upgrade

--- a/clusters/test/base/kustomization.yaml
+++ b/clusters/test/base/kustomization.yaml
@@ -4,7 +4,7 @@ resources:
   - ../../../apps/flux-system/test/base
   - ../../../apps/admin/base/kustomize.yaml
   - ../../../apps/azure-devops/base/kustomize.yaml
-  # - ../../../apps/dynatrace/base/kustomize.yaml
+  - ../../../apps/dynatrace/base/kustomize.yaml
   - ../../../apps/mi/base/kustomize.yaml
   - ../../../apps/neuvector/base/kustomize.yaml
   - ../../../apps/pip/base/kustomize.yaml
@@ -28,3 +28,4 @@ patches:
   - path: ../../../apps/toffee/test/base/kustomize.yaml
   - path: ../../../apps/admin/test/base/kustomize.yaml
   - path: ../../../apps/neuvector/crds/kustomize.yaml
+  - path: ../../../apps/dynatrace/test/base/kustomize.yaml


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-23727

### Change description

Apply latest dynatrace agent on test env. 
This file may have actually been the culprit in the issues with CRDs requirements `apps/dynatrace/base/kustomize-upgrade.yaml` It was not being applied as a patch when it was added in the past and had been there in the base folder causing probable conflicts. Will go ahead with the install on test env for testing
