### PR TITLE
Turning off Test Harness

### DIFF
--- a/apps/darts-modernisation/darts-ucf-test-harness/test.yaml
+++ b/apps/darts-modernisation/darts-ucf-test-harness/test.yaml
@@ -7,7 +7,7 @@ spec:
   releaseName: darts-ucf-test-harness
   values:
     java:
-      replicas: 10
+      replicas: 0
       ingressHost: darts-ucf-test-harness.test.platform.hmcts.net
       environment:
         DARTS_LOG_LEVEL: DEBUG


### PR DESCRIPTION
Turning off Test Harness

## 🤖AEP PR SUMMARY🤖


### apps/darts-modernisation/darts-ucf-test-harness/test.yaml
- Changed the number of replicas from 10 to 0 for the `darts-ucf-test-harness` service.
- Updated the `ingressHost` to `darts-ucf-test-harness.test.platform.hmcts.net`.
- Modified the `DARTS_LOG_LEVEL` environment variable to `DEBUG`.