### PR TITLE
Turning 50 instances on for the test harness

### DIFF
--- a/apps/darts-modernisation/darts-ucf-test-harness/test.yaml
+++ b/apps/darts-modernisation/darts-ucf-test-harness/test.yaml
@@ -7,7 +7,7 @@ spec:
   releaseName: darts-ucf-test-harness
   values:
     java:
-      replicas: 0
+      replicas: 25
       ingressHost: darts-ucf-test-harness.test.platform.hmcts.net
       environment:
         DARTS_LOG_LEVEL: DEBUG


### PR DESCRIPTION
Turning 50 instances on for the test harness

## 🤖AEP PR SUMMARY🤖


### apps/darts-modernisation/darts-ucf-test-harness/test.yaml
- Updated the `replicas` value from 0 to 25 for the `java` service.
- Updated the `ingressHost` to `darts-ucf-test-harness.test.platform.hmcts.net`.
- Set the `DARTS_LOG_LEVEL` environment variable to `DEBUG`.