### PR TITLE
Turn off Test Harness

### DIFF
--- a/apps/darts-modernisation/darts-ucf-test-harness/test.yaml
+++ b/apps/darts-modernisation/darts-ucf-test-harness/test.yaml
@@ -7,7 +7,7 @@ spec:
   releaseName: darts-ucf-test-harness
   values:
     java:
-      replicas: 25
+      replicas: 0
       ingressHost: darts-ucf-test-harness.test.platform.hmcts.net
       environment:
         DARTS_LOG_LEVEL: DEBUG


### PR DESCRIPTION
Turn off Test Harness

## 🤖AEP PR SUMMARY🤖


**apps/darts-modernisation/darts-ucf-test-harness/test.yaml**
- Reduced the number of replicas for Java from 25 to 0.
- Updated the environment variable DARTS_LOG_LEVEL to DEBUG.