### PR TITLE
Turn off instances of test harness

### DIFF
--- a/apps/darts-modernisation/darts-ucf-test-harness/test.yaml
+++ b/apps/darts-modernisation/darts-ucf-test-harness/test.yaml
@@ -7,7 +7,7 @@ spec:
   releaseName: darts-ucf-test-harness
   values:
     java:
-      replicas: 70
+      replicas: 0
       ingressHost: darts-ucf-test-harness.test.platform.hmcts.net
       environment:
         DARTS_LOG_LEVEL: DEBUG


### PR DESCRIPTION
Turn off instances of test harness







## 🤖AEP PR SUMMARY🤖


### apps/darts-modernisation/darts-ucf-test-harness/test.yaml
- Changed the number of replicas for the \"java\" service from 70 to 0
- Updated the \"ingressHost\" to darts-ucf-test-harness.test.platform.hmcts.net