### PR TITLE
juror deployments for JS-280

### DIFF
--- a/apps/juror/juror-api/ithc.yaml
+++ b/apps/juror/juror-api/ithc.yaml
@@ -8,7 +8,7 @@ spec:
   values:
     java:
       # Uncomment and edit the line below to fix the environment at a specific image
-      image: sdshmctspublic.azurecr.io/juror/api:pr-857-cd66242-20250225164902 # {"$imagepolicy": "flux-system:juror-api-pr"}
+      image: sdshmctspublic.azurecr.io/juror/api:pr-876-1c91eb3-20250226121104
       ingressHost: juror-api.ithc.platform.hmcts.net
       environment:
         RUN_DB_MIGRATION_ON_STARTUP: true

--- a/apps/juror/juror-bureau/ithc.yaml
+++ b/apps/juror/juror-bureau/ithc.yaml
@@ -8,7 +8,7 @@ spec:
   values:
     nodejs:
       # Uncomment and edit the line below to fix the environment at a specific image
-      image: sdshmctspublic.azurecr.io/juror/bureau:pr-888-051bf68-20250221112614 # {"$imagepolicy": "flux-system:juror-bureau-pr"}
+      image: sdshmctspublic.azurecr.io/juror/bureau:pr-899-edd1399-20250224164846
       ingressHost: juror.ithc.apps.hmcts.net
       environment:
         SKIP_SSO: true


### PR DESCRIPTION
### Jira link

[JS-280](https://tools.hmcts.net/jira/browse/JS-280)

### Change description

deployment of JS-280 for testing

### Testing done

Deployment for testing in ITHC only

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


### apps/juror/juror-api/ithc.yaml
- Updated the image version to `pr-876-1c91eb3-20250226121104` for the `java` container.
  
### apps/juror/juror-bureau/ithc.yaml
- Updated the image version to `pr-899-edd1399-20250224164846` for the `nodejs` container.