### PR TITLE
Turn 35 replicas on for 70 instances

### DIFF
--- a/apps/darts-modernisation/darts-ucf-test-harness/test.yaml
+++ b/apps/darts-modernisation/darts-ucf-test-harness/test.yaml
@@ -7,7 +7,7 @@ spec:
   releaseName: darts-ucf-test-harness
   values:
     java:
-      replicas: 0
+      replicas: 35
       ingressHost: darts-ucf-test-harness.test.platform.hmcts.net
       environment:
         DARTS_LOG_LEVEL: DEBUG


### PR DESCRIPTION
Turn 35 replicas on for 70 instances

## 🤖AEP PR SUMMARY🤖


### apps/darts-modernisation/darts-ucf-test-harness/test.yaml
- Increased the number of replicas for the `java` service from 0 to 35.
- Updated the `ingressHost` to `darts-ucf-test-harness.test.platform.hmcts.net`.
- Set the `DARTS_LOG_LEVEL` environment variable to `DEBUG`.