### PR TITLE
Turn off test harness

### DIFF
--- a/apps/darts-modernisation/darts-ucf-test-harness/test.yaml
+++ b/apps/darts-modernisation/darts-ucf-test-harness/test.yaml
@@ -7,7 +7,7 @@ spec:
   releaseName: darts-ucf-test-harness
   values:
     java:
-      replicas: 35
+      replicas: 0
       ingressHost: darts-ucf-test-harness.test.platform.hmcts.net
       environment:
         DARTS_LOG_LEVEL: DEBUG


### PR DESCRIPTION
Turn off test harness

## 🤖AEP PR SUMMARY🤖


### apps/darts-modernisation/darts-ucf-test-harness/test.yaml
- Updated the `replicas` value from 35 to 0 for the `java` deployment
- Modified the `ingressHost` to `darts-ucf-test-harness.test.platform.hmcts.net`
- Changed the `DARTS_LOG_LEVEL` environment variable to `DEBUG` in the test configuration