### PR TITLE
Turning off 100 instances

### DIFF
--- a/apps/darts-modernisation/darts-ucf-test-harness/test.yaml
+++ b/apps/darts-modernisation/darts-ucf-test-harness/test.yaml
@@ -7,7 +7,7 @@ spec:
   releaseName: darts-ucf-test-harness
   values:
     java:
-      replicas: 50
+      replicas: 0
       ingressHost: darts-ucf-test-harness.test.platform.hmcts.net
       environment:
         DARTS_LOG_LEVEL: DEBUG


### PR DESCRIPTION
Turning off 100 instances



## 🤖AEP PR SUMMARY🤖


### apps/darts-modernisation/darts-ucf-test-harness/test.yaml
- Reduced the number of replicas for the `java` service from 50 to 0.
- Updated the `ingressHost` to `darts-ucf-test-harness.test.platform.hmcts.net`.
- Set the environment variable `DARTS_LOG_LEVEL` to `DEBUG`.