### PR TITLE
PO-1288: Add opal-frontend-test

### DIFF
--- a/apps/darts-modernisation/darts-api/demo.yaml
+++ b/apps/darts-modernisation/darts-api/demo.yaml
@@ -16,7 +16,7 @@ spec:
         APPLICATIONINSIGHTS_INSTRUMENTATION_LOGGING_LEVEL: ALL
         ARM_URL: https://www.test.court-tribunal-records-archive.service.justice.gov.uk
         FEIGN_LOG_LEVEL: full
-        CASE_EXPIRY_DELETION_ENABLED: false
+        CASE_EXPIRY_DELETION_ENABLED: true
         MANUAL_DELETION_ENABLED: true
         EVENT_OBFUSCATION_ENABLED: true
         PROCESS_E2E_ARM_RPO: true

--- a/apps/opal/automation/kustomization.yaml
+++ b/apps/opal/automation/kustomization.yaml
@@ -17,3 +17,5 @@ resources:
   - ../opal-log-audit-service/image-policy.yaml
   - ../opal-service-auth-provider-app/image-repo.yaml
   - ../opal-service-auth-provider-app/image-policy.yaml
+  - ../opal-frontend-test/image-repo.yaml
+  - ../opal-frontend-test/image-policy.yaml

--- a/apps/opal/opal-frontend-test/image-policy.yaml
+++ b/apps/opal/opal-frontend-test/image-policy.yaml
@@ -1,0 +1,7 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta1
+kind: ImagePolicy
+metadata:
+  name: opal-frontend-test
+spec:
+  imageRepositoryRef:
+    name: opal-frontend-test

--- a/apps/opal/opal-frontend-test/image-repo.yaml
+++ b/apps/opal/opal-frontend-test/image-repo.yaml
@@ -1,0 +1,6 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImageRepository
+metadata:
+  name: opal-frontend-test
+spec:
+  image: sdshmctspublic.azurecr.io/opal/frontend

--- a/apps/opal/opal-frontend-test/opal-frontend-test.yaml
+++ b/apps/opal/opal-frontend-test/opal-frontend-test.yaml
@@ -7,7 +7,7 @@ spec:
   releaseName: opal-frontend-test
   chart:
     spec:
-      chart: ./stable/opal-frontend-test
+      chart: ./stable/opal-frontend
       sourceRef:
         kind: GitRepository
         name: hmcts-charts
@@ -15,5 +15,5 @@ spec:
       interval: 1m
   values:
     nodejs:
-      image: sdshmctspublic.azurecr.io/opal/frontend:prod-4d4d9dc-20250225121607 # {"$imagepolicy": "flux-system:opal-frontend"}
+      image: sdshmctspublic.azurecr.io/opal/frontend:prod-4d4d9dc-20250225121607 # {"$imagepolicy": "flux-system:opal-frontend-test"}
       disableTraefikTls: true

--- a/apps/opal/opal-frontend-test/opal-frontend-test.yaml
+++ b/apps/opal/opal-frontend-test/opal-frontend-test.yaml
@@ -1,0 +1,19 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: opal-frontend-test
+  namespace: opal
+spec:
+  releaseName: opal-frontend-test
+  chart:
+    spec:
+      chart: ./stable/opal-frontend-test
+      sourceRef:
+        kind: GitRepository
+        name: hmcts-charts
+        namespace: flux-system
+      interval: 1m
+  values:
+    nodejs:
+      image: sdshmctspublic.azurecr.io/opal/frontend:prod-4d4d9dc-20250225121607 # {"$imagepolicy": "flux-system:opal-frontend"}
+      disableTraefikTls: true

--- a/apps/opal/opal-frontend-test/stg.yaml
+++ b/apps/opal/opal-frontend-test/stg.yaml
@@ -1,0 +1,15 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: opal-frontend-test
+  namespace: opal
+spec:
+  releaseName: opal-frontend-test
+  values:
+    nodejs:
+      ingressHost: opal-frontend-test.staging.platform.hmcts.net
+      environment:
+        DUMMY_VAR: 0
+        FRONTEND_HOSTNAME: https://opal-frontend-test.staging.platform.hmcts.net
+        OPAL_API_URL: https://opal-fines-service.staging.platform.hmcts.net
+        OPAL_FINES_SERVICE_API_URL: https://opal-fines-service.staging.platform.hmcts.net

--- a/apps/opal/stg/base/kustomization.yaml
+++ b/apps/opal/stg/base/kustomization.yaml
@@ -11,6 +11,7 @@ resources:
   - ../../opal-legacy-db-stub/opal-legacy-db-stub.yaml
   - ../../opal-log-audit-service/opal-log-audit-service.yaml
   - ../../opal-service-auth-provider-app/opal-service-auth-provider-app.yaml
+  - ../../opal-frontend-test/opal-frontend-test.yaml
   - ../../../base/slack-provider/stg
 namespace: opal
 patches:
@@ -23,3 +24,4 @@ patches:
   - path: ../../opal-legacy-db-stub/stg.yaml
   - path: ../../opal-log-audit-service/stg.yaml
   - path: ../../opal-service-auth-provider-app/stg.yaml
+  - path: ../../opal-frontend-test/stg.yaml


### PR DESCRIPTION
### Jira link
[PO-1288](https://tools.hmcts.net/jira/browse/PO-1288)

### Change description
- As part of PO-1288 we want to spin up another instance of the opal-frontend staging environment with a new url to test the cookie being exchanged between the two instances

### Testing done
N/A

### Checklist
- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
















## 🤖AEP PR SUMMARY🤖


- Modified `apps/opal/automation/kustomization.yaml`:
  - Added references to image repository and image policy for opal-frontend-test.

- Added `apps/opal/opal-frontend-test/image-policy.yaml`:
  - Defined image policy for opal-frontend-test.

- Added `apps/opal/opal-frontend-test/image-repo.yaml`:
  - Defined image repository for opal-frontend-test.

- Added `apps/opal/opal-frontend-test/opal-frontend-test.yaml`:
  - Added helm release configuration for opal-frontend-test with specified image.

- Added `apps/opal/opal-frontend-test/stg.yaml`:
  - Defined helm release configuration for opal-frontend-test with environment variables.

- Modified `apps/opal/stg/base/kustomization.yaml`:
  - Included reference to opal-frontend-test in the kustomization file.