### PR TITLE
DMP-4488 Clone darts test harness for rename

### DIFF
--- a/apps/darts-modernisation/automation/kustomization.yaml
+++ b/apps/darts-modernisation/automation/kustomization.yaml
@@ -5,6 +5,8 @@ resources:
   - ../darts-api/image-policy.yaml
   - ../darts-automated-tasks/image-repo.yaml
   - ../darts-automated-tasks/image-policy.yaml
+  - ../darts-external-component-test-harness/image-repo.yaml
+  - ../darts-external-component-test-harness/image-policy.yaml
   - ../darts-portal/image-repo.yaml
   - ../darts-portal/image-policy.yaml
   - ../darts-gateway/image-repo.yaml

--- a/apps/darts-modernisation/base/kustomization.yaml
+++ b/apps/darts-modernisation/base/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - ../../base
   - ../identity/identity.yaml
   - ../darts-api/darts-api.yaml
+  - ../darts-external-component-test-harness/darts-external-component-test-harness.yaml
   - ../darts-ucf-test-harness/darts-ucf-test-harness.yaml
   - ../darts-automated-tasks/darts-automated-tasks.yaml
   - ../darts-portal/darts-portal.yaml

--- a/apps/darts-modernisation/darts-external-component-test-harness/darts-external-component-test-harness.yaml
+++ b/apps/darts-modernisation/darts-external-component-test-harness/darts-external-component-test-harness.yaml
@@ -1,0 +1,20 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: darts-external-component-test-harness
+  namespace: darts-modernisation
+spec:
+  releaseName: darts-external-component-test-harness
+  chart:
+    spec:
+      chart: ./stable/darts-external-component-test-harness
+      sourceRef:
+        kind: GitRepository
+        name: hmcts-charts
+        namespace: flux-system
+      interval: 1m
+  values:
+    java:
+      image: sdshmctspublic.azurecr.io/darts/external-component-test-harness:prod-79464e6-20250228090711 # {"$imagepolicy": "flux-system:darts-external-component-test-harness"}
+      disableTraefikTls: true
+      replicas: 0

--- a/apps/darts-modernisation/darts-external-component-test-harness/demo.yaml
+++ b/apps/darts-modernisation/darts-external-component-test-harness/demo.yaml
@@ -1,0 +1,15 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: darts-external-component-test-harness
+  namespace: darts-modernisation
+spec:
+  releaseName: darts-external-component-test-harness
+  values:
+    java:
+      ingressHost: darts-external-component-test-harness.demo.platform.hmcts.net
+      replicas: 1
+      environment:
+        DARTS_LOG_LEVEL: DEBUG
+        TEST_HARNESS_AUTOMATION_ENABLED: false
+        TEST_HARNESS_PROXY_URL: http://darts-gateway.demo.platform.hmcts.net/service

--- a/apps/darts-modernisation/darts-external-component-test-harness/image-policy.yaml
+++ b/apps/darts-modernisation/darts-external-component-test-harness/image-policy.yaml
@@ -1,0 +1,7 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta1
+kind: ImagePolicy
+metadata:
+  name: darts-external-component-test-harness
+spec:
+  imageRepositoryRef:
+    name: darts-external-component-test-harness

--- a/apps/darts-modernisation/darts-external-component-test-harness/image-repo.yaml
+++ b/apps/darts-modernisation/darts-external-component-test-harness/image-repo.yaml
@@ -1,0 +1,6 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImageRepository
+metadata:
+  name: darts-external-component-test-harness
+spec:
+  image: sdshmctspublic.azurecr.io/darts/external-component-test-harness

--- a/apps/darts-modernisation/darts-external-component-test-harness/stg.yaml
+++ b/apps/darts-modernisation/darts-external-component-test-harness/stg.yaml
@@ -1,0 +1,15 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: darts-external-component-test-harness
+  namespace: darts-modernisation
+spec:
+  releaseName: darts-external-component-test-harness
+  values:
+    java:
+      ingressHost: darts-external-component-test-harness.staging.platform.hmcts.net
+      replicas: 1
+      environment:
+        DARTS_LOG_LEVEL: DEBUG
+        TEST_HARNESS_AUTOMATION_ENABLED: false
+        TEST_HARNESS_PROXY_URL: http://darts-gateway.staging.platform.hmcts.net/service

--- a/apps/darts-modernisation/darts-external-component-test-harness/test.yaml
+++ b/apps/darts-modernisation/darts-external-component-test-harness/test.yaml
@@ -1,0 +1,16 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: darts-external-component-test-harness
+  namespace: darts-modernisation
+spec:
+  releaseName: darts-external-component-test-harness
+  values:
+    java:
+      replicas: 0
+      ingressHost: darts-external-component-test-harness.test.platform.hmcts.net
+      environment:
+        DARTS_LOG_LEVEL: DEBUG
+        TEST_HARNESS_AUTOMATION_ENABLED: true
+        TEST_HARNESS_AUTOMATION_TRANSFER_FORMAT: MTOM
+        TEST_HARNESS_PROXY_URL: http://darts-gateway.test.platform.hmcts.net/service

--- a/apps/darts-modernisation/demo/base/kustomization.yaml
+++ b/apps/darts-modernisation/demo/base/kustomization.yaml
@@ -9,6 +9,7 @@ namespace: darts-modernisation
 patches:
   - path: ../../darts-api/demo.yaml
   - path: ../../darts-automated-tasks/demo.yaml
+  - path: ../../darts-external-component-test-harness/demo.yaml
   - path: ../../darts-portal/demo.yaml
   - path: ../../darts-gateway/demo.yaml
   - path: ../../darts-ucf-test-harness/demo.yaml

--- a/apps/darts-modernisation/stg/base/kustomization.yaml
+++ b/apps/darts-modernisation/stg/base/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
 namespace: darts-modernisation
 patches:
   - path: ../../darts-api/stg.yaml
+  - path: ../../darts-external-component-test-harness/stg.yaml
   - path: ../../darts-ucf-test-harness/stg.yaml
   - path: ../../darts-automated-tasks/stg.yaml
   - path: ../../darts-portal/stg.yaml

--- a/apps/darts-modernisation/test/base/kustomization.yaml
+++ b/apps/darts-modernisation/test/base/kustomization.yaml
@@ -9,6 +9,7 @@ namespace: darts-modernisation
 patches:
   - path: ../../darts-api/test.yaml
   - path: ../../darts-automated-tasks/test.yaml
+  - path: ../../darts-external-component-test-harness/test.yaml
   - path: ../../darts-portal/test.yaml
   - path: ../../darts-gateway/test.yaml
   - path: ../../darts-ucf-test-harness/test.yaml


### PR DESCRIPTION
Rename the DARTS UCF test harness to DARTS External Component test harness. 

A further PR will follow to remove the UCF references once this one is up and running. 







## 🤖AEP PR SUMMARY🤖

Request to AEP failed to process