### PR TITLE
Turning off the test harness

### DIFF
--- a/apps/darts-modernisation/darts-ucf-test-harness/test.yaml
+++ b/apps/darts-modernisation/darts-ucf-test-harness/test.yaml
@@ -7,7 +7,7 @@ spec:
   releaseName: darts-ucf-test-harness
   values:
     java:
-      replicas: 50
+      replicas: 0
       ingressHost: darts-ucf-test-harness.test.platform.hmcts.net
       environment:
         DARTS_LOG_LEVEL: DEBUG


### PR DESCRIPTION
Turning off the test harness

## 🤖AEP PR SUMMARY🤖


- `test.yaml` 🔄: Changed the `replicas` value from 50 to 0 for the Java component, and updated the `ingressHost` to `darts-ucf-test-harness.test.platform.hmcts.net`. These changes are part of the pull request.