### PR TITLE
Changes to remove UCF and turn on the test harness

### DIFF
--- a/apps/darts-modernisation/darts-ucf-test-harness/test.yaml
+++ b/apps/darts-modernisation/darts-ucf-test-harness/test.yaml
@@ -1,16 +1,16 @@
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
-  name: darts-ucf-test-harness
+  name: darts-external-component-test-harness
   namespace: darts-modernisation
 spec:
-  releaseName: darts-ucf-test-harness
+  releaseName: darts-external-component-test-harness
   values:
     java:
-      replicas: 0
-      ingressHost: darts-ucf-test-harness.test.platform.hmcts.net
+      replicas: 50
+      ingressHost: darts-external-component-test-harness.test.platform.hmcts.net
       environment:
         DARTS_LOG_LEVEL: DEBUG
         TEST_HARNESS_AUTOMATION_ENABLED: true
         TEST_HARNESS_AUTOMATION_TRANSFER_FORMAT: MTOM
-        TEST_HARNESS_PROXY_URL: http://darts-gateway.test.platform.hmcts.net/service
+        TEST_HARNESS_PROXY_URL: http://darts-external-component-test-harness.test.platform.hmcts.net/service


### PR DESCRIPTION
Changes to remove UCF and turn on the test harness

## 🤖AEP PR SUMMARY🤖


### apps/darts-modernisation/darts-ucf-test-harness/test.yaml
- Updated the `name` field from \"darts-ucf-test-harness\" to \"darts-external-component-test-harness\"
- Updated the `releaseName` field from \"darts-ucf-test-harness\" to \"darts-external-component-test-harness\"
- Updated the `replicas` value from 0 to 50
- Updated the `ingressHost` value from \"darts-ucf-test-harness.test.platform.hmcts.net\" to \"darts-external-component-test-harness.test.platform.hmcts.net\"
- Updated the `TEST_HARNESS_PROXY_URL` value to \"http://darts-external-component-test-harness.test.platform.hmcts.net/service\"