### PR TITLE
Turning on the test for 100 instances

### DIFF
--- a/apps/darts-modernisation/darts-external-component-test-harness/test.yaml
+++ b/apps/darts-modernisation/darts-external-component-test-harness/test.yaml
@@ -7,7 +7,7 @@ spec:
   releaseName: darts-external-component-test-harness
   values:
     java:
-      replicas: 0
+      replicas: 50
       ingressHost: darts-external-component-test-harness.test.platform.hmcts.net
       environment:
         DARTS_LOG_LEVEL: DEBUG


### PR DESCRIPTION
Turning on the test for 100 instances



## 🤖AEP PR SUMMARY🤖


### apps/darts-modernisation/darts-external-component-test-harness/test.yaml
- Updated the number of replicas for the \"java\" service from 0 to 50.
- Updated the \"ingressHost\" to \"darts-external-component-test-harness.test.platform.hmcts.net\".
- Set the environment variable \"DARTS_LOG_LEVEL\" to \"DEBUG\".