### PR TITLE
DTSPO-24310: Removing aadpodidentity and adding workload identity to sbox

### DIFF
--- a/apps/flux-system/base/patches/workload-identity-deployment.yaml
+++ b/apps/flux-system/base/patches/workload-identity-deployment.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kustomize-controller
+  namespace: flux-system
+  labels:
+    azure.workload.identity/use: "true"
+spec:
+  template:
+    metadata:
+      labels:
+        azure.workload.identity/use: "true"

--- a/apps/flux-system/sbox/base/kustomization.yaml
+++ b/apps/flux-system/sbox/base/kustomization.yaml
@@ -4,5 +4,7 @@ resources:
   - ../../base
   - ../../base/gotk-components.yaml
   - git-credentials.enc.yaml
+  - ../workload-identity
 patches:
-  - path: ../../base/patches/kustomize-controller-patch.yaml
+  - path: ../../serviceaccount/sbox.yaml
+  - path: ../../base/patches/workload-identity-deployment.yaml

--- a/apps/flux-system/sbox/workload-identity/kustomization.yaml
+++ b/apps/flux-system/sbox/workload-identity/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - workload-identity-federated-credential.yaml
+  - workload-identity-rg.yaml
+  - workload-identity-ua-identity.yaml

--- a/apps/flux-system/sbox/workload-identity/workload-identity-federated-credential.yaml
+++ b/apps/flux-system/sbox/workload-identity/workload-identity-federated-credential.yaml
@@ -1,0 +1,12 @@
+apiVersion: managedidentity.azure.com/v1api20220131preview
+kind: FederatedIdentityCredential
+metadata:
+  name: aks-${WI_CLUSTER}-fic
+  namespace: flux-system
+spec:
+  owner:
+    name: aks-${WI_ENVIRONMENT}-mi
+  audiences:
+    - api://AzureADTokenExchange
+  issuer: ${ISSUER_URL}
+  subject: system:serviceaccount:flux-system:kustomize-controller

--- a/apps/flux-system/sbox/workload-identity/workload-identity-rg.yaml
+++ b/apps/flux-system/sbox/workload-identity/workload-identity-rg.yaml
@@ -1,0 +1,10 @@
+apiVersion: resources.azure.com/v1api20200601
+kind: ResourceGroup
+metadata:
+  name: genesis-rg
+  namespace: flux-system
+  annotations:
+    serviceoperator.azure.com/reconcile-policy: detach-on-delete
+spec:
+  location: uksouth
+  azureName: genesis-rg

--- a/apps/flux-system/sbox/workload-identity/workload-identity-ua-identity.yaml
+++ b/apps/flux-system/sbox/workload-identity/workload-identity-ua-identity.yaml
@@ -1,0 +1,11 @@
+apiVersion: managedidentity.azure.com/v1api20181130
+kind: UserAssignedIdentity
+metadata:
+  name: aks-${WI_ENVIRONMENT}-mi
+  namespace: flux-system
+  annotations:
+    serviceoperator.azure.com/reconcile-policy: skip
+spec:
+  location: uksouth
+  owner:
+    name: genesis-rg

--- a/apps/flux-system/serviceaccount/sbox.yaml
+++ b/apps/flux-system/serviceaccount/sbox.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kustomize-controller
+  namespace: flux-system
+  annotations:
+    azure.workload.identity/client-id: "09d99cb4-e1e7-49c2-a8e6-b5b1740e9c3b"
+  labels:
+    azure.workload.identity/use: "true"


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-24310

### Change description

- Changes should only affect sbox.
- Adding workload-identity to sbox as done and working in cnp-flux-config.
- Adding workload-identity folder to flux-system to customise resource group name to genesis-rg. Hardcoded values to avoid substitution errors encountered in cft.
- Added patches for deployment and service account.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
