### PR TITLE
DTSPO-24310: Adding workload identity to ithc

### DIFF
--- a/apps/flux-system/ithc/base/kustomization.yaml
+++ b/apps/flux-system/ithc/base/kustomization.yaml
@@ -4,5 +4,7 @@ resources:
   - ../../base
   - ../../base/gotk-components.yaml
   - git-credentials.enc.yaml
+  - ../../workload-identity
 patches:
-  - path: ../../base/patches/kustomize-controller-patch.yaml
+  - path: ../../serviceaccount/ithc.yaml
+  - path: ../../base/patches/workload-identity-deployment.yaml

--- a/apps/flux-system/serviceaccount/ithc.yaml
+++ b/apps/flux-system/serviceaccount/ithc.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kustomize-controller
+  namespace: flux-system
+  annotations:
+    azure.workload.identity/client-id: "9bcd6a33-c10b-4a8b-a77d-7341592874de"
+  labels:
+    azure.workload.identity/use: "true"


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-24310

### Change description

- Changes should only affect ithc.
- Adding workload-identity to ithc as done and working in cnp-flux-config.

### Testing done

- Added to sbox in [this PR](https://github.com/hmcts/sds-flux-config/pull/6273)

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


### apps/flux-system/ithc/base/kustomization.yaml
- Added a new workload-identity patch.
- Added a new service account patch for ithc.
- Added a reference to git-credentials.enc.yaml.

### apps/flux-system/serviceaccount/ithc.yaml
- Created a new file for ServiceAccount ithc.
- Includes metadata for name, namespace, annotations, and labels.