### PR TITLE
NONPROD: Upgrade Flux to 2.5.1 nonprod

### DIFF
--- a/apps/flux-system/demo/base/kustomization.yaml
+++ b/apps/flux-system/demo/base/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
-  - ../../base/gotk-components.yaml
+  - ../../base/gotk-components-2.5.1.yaml
   - git-credentials.enc.yaml
 patches:
   - path: ../../base/patches/kustomize-controller-patch.yaml

--- a/apps/flux-system/dev/base/kustomization.yaml
+++ b/apps/flux-system/dev/base/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
-  - ../../base/gotk-components.yaml
+  - ../../base/gotk-components-2.5.1.yaml
   - git-credentials.enc.yaml
 patches:
   - path: ../../base/patches/kustomize-controller-patch.yaml

--- a/apps/flux-system/ithc/base/kustomization.yaml
+++ b/apps/flux-system/ithc/base/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
-  - ../../base/gotk-components.yaml
+  - ../../base/gotk-components-2.5.1.yaml
   - git-credentials.enc.yaml
   - ../../workload-identity
 patches:

--- a/apps/flux-system/stg/base/kustomization.yaml
+++ b/apps/flux-system/stg/base/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
-  - ../../base/gotk-components.yaml
+  - ../../base/gotk-components-2.5.1.yaml
   - git-credentials.enc.yaml
 patches:
   - path: ../../base/patches/kustomize-controller-patch.yaml

--- a/apps/flux-system/test/base/kustomization.yaml
+++ b/apps/flux-system/test/base/kustomization.yaml
@@ -2,7 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
-  - ../../base/gotk-components.yaml
+  - ../../base/gotk-components-2.5.1.yaml
   - git-credentials.enc.yaml
 patches:
   - path: ../../base/patches/kustomize-controller-patch.yaml


### PR DESCRIPTION
### Change description

- Upgrade Flux to 2.5.1 for nonprod


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


- `apps/flux-system/demo/base/kustomization.yaml`
  - Replaced `gotk-components.yaml` with `gotk-components-2.5.1.yaml`.
- `apps/flux-system/dev/base/kustomization.yaml`
  - Replaced `gotk-components.yaml` with `gotk-components-2.5.1.yaml`.
- `apps/flux-system/ithc/base/kustomization.yaml`
  - Replaced `gotk-components.yaml` with `gotk-components-2.5.1.yaml`.
- `apps/flux-system/stg/base/kustomization.yaml`
  - Replaced `gotk-components.yaml` with `gotk-components-2.5.1.yaml`.
- `apps/flux-system/test/base/kustomization.yaml`
  - Replaced `gotk-components.yaml` with `gotk-components-2.5.1.yaml`.