### PR TITLE
Revert "DTSPO-24310: Adding workload identity to non-prod"

### DIFF
--- a/apps/flux-system/demo/base/kustomization.yaml
+++ b/apps/flux-system/demo/base/kustomization.yaml
@@ -4,7 +4,5 @@ resources:
   - ../../base
   - ../../base/gotk-components.yaml
   - git-credentials.enc.yaml
-  - ../../workload-identity
 patches:
-  - path: ../../serviceaccount/demo.yaml
-  - path: ../../base/patches/workload-identity-deployment.yaml
+  - path: ../../base/patches/kustomize-controller-patch.yaml

--- a/apps/flux-system/dev/base/kustomization.yaml
+++ b/apps/flux-system/dev/base/kustomization.yaml
@@ -4,7 +4,5 @@ resources:
   - ../../base
   - ../../base/gotk-components.yaml
   - git-credentials.enc.yaml
-  - ../../workload-identity
 patches:
-  - path: ../../serviceaccount/dev.yaml
-  - path: ../../base/patches/workload-identity-deployment.yaml
+  - path: ../../base/patches/kustomize-controller-patch.yaml

--- a/apps/flux-system/ptlsbox/base/kustomization.yaml
+++ b/apps/flux-system/ptlsbox/base/kustomization.yaml
@@ -4,7 +4,5 @@ resources:
   - ../../base
   - ../../base/gotk-components.yaml
   - git-credentials.enc.yaml
-  - ../../workload-identity
 patches:
-  - path: ../../serviceaccount/ptlsbox.yaml
-  - path: ../../base/patches/workload-identity-deployment.yaml
+  - path: ../../base/patches/kustomize-controller-patch.yaml

--- a/apps/flux-system/serviceaccount/demo.yaml
+++ b/apps/flux-system/serviceaccount/demo.yaml
@@ -1,9 +1,0 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: kustomize-controller
-  namespace: flux-system
-  annotations:
-    azure.workload.identity/client-id: "04561461-0f92-42b3-9328-8b0c1bba4641"
-  labels:
-    azure.workload.identity/use: "true"

--- a/apps/flux-system/serviceaccount/dev.yaml
+++ b/apps/flux-system/serviceaccount/dev.yaml
@@ -1,9 +1,0 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: kustomize-controller
-  namespace: flux-system
-  annotations:
-    azure.workload.identity/client-id: "b86d64c4-ec90-451a-ab22-77cea15aeb68"
-  labels:
-    azure.workload.identity/use: "true"

--- a/apps/flux-system/serviceaccount/ptlsbox.yaml
+++ b/apps/flux-system/serviceaccount/ptlsbox.yaml
@@ -1,9 +1,0 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: kustomize-controller
-  namespace: flux-system
-  annotations:
-    azure.workload.identity/client-id: "d864b3ca-238c-474a-a426-6e526207cf4a"
-  labels:
-    azure.workload.identity/use: "true"

--- a/apps/flux-system/serviceaccount/stg.yaml
+++ b/apps/flux-system/serviceaccount/stg.yaml
@@ -1,9 +1,0 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: kustomize-controller
-  namespace: flux-system
-  annotations:
-    azure.workload.identity/client-id: "fa0102b9-d3d3-4134-ad45-85a529ce9a9e"
-  labels:
-    azure.workload.identity/use: "true"

--- a/apps/flux-system/serviceaccount/test.yaml
+++ b/apps/flux-system/serviceaccount/test.yaml
@@ -1,9 +1,0 @@
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: kustomize-controller
-  namespace: flux-system
-  annotations:
-    azure.workload.identity/client-id: "d477322e-1f41-4bec-9fbb-fceecd4edcc2"
-  labels:
-    azure.workload.identity/use: "true"

--- a/apps/flux-system/stg/base/kustomization.yaml
+++ b/apps/flux-system/stg/base/kustomization.yaml
@@ -4,7 +4,5 @@ resources:
   - ../../base
   - ../../base/gotk-components.yaml
   - git-credentials.enc.yaml
-  - ../../workload-identity
 patches:
-  - path: ../../serviceaccount/stg.yaml
-  - path: ../../base/patches/workload-identity-deployment.yaml
+  - path: ../../base/patches/kustomize-controller-patch.yaml

--- a/apps/flux-system/test/base/kustomization.yaml
+++ b/apps/flux-system/test/base/kustomization.yaml
@@ -4,7 +4,5 @@ resources:
   - ../../base
   - ../../base/gotk-components.yaml
   - git-credentials.enc.yaml
-  - ../../workload-identity
 patches:
-  - path: ../../serviceaccount/test.yaml
-  - path: ../../base/patches/workload-identity-deployment.yaml
+  - path: ../../base/patches/kustomize-controller-patch.yaml


### PR DESCRIPTION
Reverts hmcts/sds-flux-config#6280

## 🤖AEP PR SUMMARY🤖


- A new patch file `kustomize-controller-patch.yaml` was added to the `kustomization.yaml` file in the `base` directory for the `demo`, `dev`, `ptlsbox`, `stg`, and `test` environments of the flux-system.
- Service account files for `demo`, `dev`, `ptlsbox`, `stg`, and `test` environments were deleted. Each file contained a service account for the `kustomize-controller` with specific annotations and labels.