### PR TITLE
DTSPO-24310: Adding workload identity to non-prod

### DIFF
--- a/apps/flux-system/ptlsbox/base/kustomization.yaml
+++ b/apps/flux-system/ptlsbox/base/kustomization.yaml
@@ -4,5 +4,7 @@ resources:
   - ../../base
   - ../../base/gotk-components.yaml
   - git-credentials.enc.yaml
+  - ../../workload-identity
 patches:
-  - path: ../../base/patches/kustomize-controller-patch.yaml
+  - path: ../../serviceaccount/ptlsbox.yaml
+  - path: ../../base/patches/workload-identity-deployment.yaml

--- a/apps/flux-system/serviceaccount/ptlsbox.yaml
+++ b/apps/flux-system/serviceaccount/ptlsbox.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kustomize-controller
+  namespace: flux-system
+  annotations:
+    azure.workload.identity/client-id: "d864b3ca-238c-474a-a426-6e526207cf4a"
+  labels:
+    azure.workload.identity/use: "true"

--- a/apps/flux-system/serviceaccount/stg.yaml
+++ b/apps/flux-system/serviceaccount/stg.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kustomize-controller
+  namespace: flux-system
+  annotations:
+    azure.workload.identity/client-id: "fa0102b9-d3d3-4134-ad45-85a529ce9a9e"
+  labels:
+    azure.workload.identity/use: "true"
+    

--- a/apps/flux-system/serviceaccount/test.yaml
+++ b/apps/flux-system/serviceaccount/test.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kustomize-controller
+  namespace: flux-system
+  annotations:
+    azure.workload.identity/client-id: "d477322e-1f41-4bec-9fbb-fceecd4edcc2"
+  labels:
+    azure.workload.identity/use: "true"

--- a/apps/flux-system/stg/base/kustomization.yaml
+++ b/apps/flux-system/stg/base/kustomization.yaml
@@ -4,5 +4,7 @@ resources:
   - ../../base
   - ../../base/gotk-components.yaml
   - git-credentials.enc.yaml
+  - ../../workload-identity
 patches:
-  - path: ../../base/patches/kustomize-controller-patch.yaml
+  - path: ../../serviceaccount/stg.yaml
+  - path: ../../base/patches/workload-identity-deployment.yaml

--- a/apps/flux-system/test/base/kustomization.yaml
+++ b/apps/flux-system/test/base/kustomization.yaml
@@ -4,5 +4,8 @@ resources:
   - ../../base
   - ../../base/gotk-components.yaml
   - git-credentials.enc.yaml
+  - ../../workload-identity
 patches:
-  - path: ../../base/patches/kustomize-controller-patch.yaml
+  - path: ../../serviceaccount/test.yaml
+  - path: ../../base/patches/workload-identity-deployment.yaml
+


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-24310

### Change description

- Adding workload identity to non-prod environments (test, staging, ptlsbox)
- Each environment has a serviceaccount patch and have a workload-identity deployment patch.

### Testing done

- Tested in both [sbox](https://github.com/hmcts/sds-flux-config/pull/6273) and [ithc](https://github.com/hmcts/sds-flux-config/pull/6274.)

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
