### PR TITLE
DTSPO-24310: Changing WI_ENVIRONMENT to ENVIRONMENT in flux workload-identity dir

### DIFF
--- a/apps/flux-system/workload-identity/workload-identity-federated-credential.yaml
+++ b/apps/flux-system/workload-identity/workload-identity-federated-credential.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: flux-system
 spec:
   owner:
-    name: aks-${WI_ENVIRONMENT}-mi
+    name: aks-${ENVIRONMENT}-mi
   audiences:
     - api://AzureADTokenExchange
   issuer: ${ISSUER_URL}

--- a/apps/flux-system/workload-identity/workload-identity-ua-identity.yaml
+++ b/apps/flux-system/workload-identity/workload-identity-ua-identity.yaml
@@ -1,7 +1,7 @@
 apiVersion: managedidentity.azure.com/v1api20181130
 kind: UserAssignedIdentity
 metadata:
-  name: aks-${WI_ENVIRONMENT}-mi
+  name: aks-${ENVIRONMENT}-mi
   namespace: flux-system
   annotations:
     serviceoperator.azure.com/reconcile-policy: skip


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-24310

### Change description

- Changing WI_ENVIRONMENT to ENVIRONMENT in flux workload-identity dir
- This is needed because WI_ENVIRONMENT is set as stg in the dev environment whereas ENVIRONMENT is a 1 to 1 mapping with the env.
- WI_ENVIRONMENT and ENVIRONMENT do not differ in the other envs.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


### apps/flux-system/workload-identity/workload-identity-federated-credential.yaml
- Changed owner name from \"aks-${WI_ENVIRONMENT}-mi\" to \"aks-${ENVIRONMENT}-mi\"
- Updated audiences and issuer fields

### apps/flux-system/workload-identity/workload-identity-ua-identity.yaml
- Modified user assigned identity name from \"aks-${WI_ENVIRONMENT}-mi\" to \"aks-${ENVIRONMENT}-mi\"
- Updated the metadata namespace and annotations