### PR TITLE
DTSPO-24310: Adding workload identity to flux dev

### DIFF
--- a/apps/flux-system/dev/base/kustomization.yaml
+++ b/apps/flux-system/dev/base/kustomization.yaml
@@ -4,5 +4,7 @@ resources:
   - ../../base
   - ../../base/gotk-components.yaml
   - git-credentials.enc.yaml
+  - ../../workload-identity
 patches:
-  - path: ../../base/patches/kustomize-controller-patch.yaml
+  - path: ../../serviceaccount/dev.yaml
+  - path: ../../base/patches/workload-identity-deployment.yaml

--- a/apps/flux-system/serviceaccount/dev.yaml
+++ b/apps/flux-system/serviceaccount/dev.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kustomize-controller
+  namespace: flux-system
+  annotations:
+    azure.workload.identity/client-id: "b86d64c4-ec90-451a-ab22-77cea15aeb68"
+  labels:
+    azure.workload.identity/use: "true"


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-24310

### Change description

- Adding workload identity to flux dev
- Dev has a serviceaccount patch and have a workload-identity deployment patch.

### Testing done

- Tested in both [sbox](https://github.com/hmcts/sds-flux-config/pull/6273) and [ithc](https://github.com/hmcts/sds-flux-config/pull/6274.)

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


### apps/flux-system/dev/base/kustomization.yaml
- Added a new file `dev.yaml` in the `serviceaccount` directory.
- Added a path for `workload-identity-deployment.yaml` in the patches section.

### apps/flux-system/serviceaccount/dev.yaml
- Created a new file `dev.yaml` containing specifications for a service account with metadata and annotations for Azure workload identity.