### PR TITLE
Flux 2.5.1: API Upgrades

### DIFF
--- a/apps/admin/external-dns/external-dns-helmrepo.yaml
+++ b/apps/admin/external-dns/external-dns-helmrepo.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: external-dns

--- a/apps/admin/traefik2/traefik2-helmrepo.yaml
+++ b/apps/admin/traefik2/traefik2-helmrepo.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: traefik

--- a/apps/azure-devops/azure-devops-agent-keda/image-policy.yaml
+++ b/apps/azure-devops/azure-devops-agent-keda/image-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: azure-devops-agent

--- a/apps/darts-modernisation/darts-api/image-policy.yaml
+++ b/apps/darts-modernisation/darts-api/image-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: darts-api

--- a/apps/darts-modernisation/darts-automated-tasks/image-policy.yaml
+++ b/apps/darts-modernisation/darts-automated-tasks/image-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: darts-automated-tasks

--- a/apps/darts-modernisation/darts-external-component-test-harness/image-policy.yaml
+++ b/apps/darts-modernisation/darts-external-component-test-harness/image-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: darts-external-component-test-harness

--- a/apps/darts-modernisation/darts-gateway/image-policy.yaml
+++ b/apps/darts-modernisation/darts-gateway/image-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: darts-gateway

--- a/apps/darts-modernisation/darts-portal/image-policy.yaml
+++ b/apps/darts-modernisation/darts-portal/image-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: darts-portal

--- a/apps/darts-modernisation/darts-proxy/image-policy.yaml
+++ b/apps/darts-modernisation/darts-proxy/image-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: darts-proxy

--- a/apps/darts-modernisation/darts-stub-services/image-policy.yaml
+++ b/apps/darts-modernisation/darts-stub-services/image-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: darts-stub-services

--- a/apps/dts-legacy/lgy-iac-web/image-policy.yaml
+++ b/apps/dts-legacy/lgy-iac-web/image-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: lgy-iac-web

--- a/apps/dynatrace/dynatrace-operator-helmrepo-upgrade.yaml
+++ b/apps/dynatrace/dynatrace-operator-helmrepo-upgrade.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: dynatrace-operator

--- a/apps/dynatrace/dynatrace-operator-helmrepo.yaml
+++ b/apps/dynatrace/dynatrace-operator-helmrepo.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: dynatrace-operator

--- a/apps/flux-system/base/hmctspublic-helmrepo.yaml
+++ b/apps/flux-system/base/hmctspublic-helmrepo.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: hmctspublic

--- a/apps/flux-system/base/hmctspublic-ocirepo.yaml
+++ b/apps/flux-system/base/hmctspublic-ocirepo.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: hmctspublic-oci

--- a/apps/hmi/hmi-rota-dtu/image-policy.yaml
+++ b/apps/hmi/hmi-rota-dtu/image-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: hmi-rota-dtu

--- a/apps/jenkins/jenkins-webhook-relay/image-policy.yaml
+++ b/apps/jenkins/jenkins-webhook-relay/image-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: jenkins-webhook-relay

--- a/apps/jenkins/jenkins/helmrepo.yaml
+++ b/apps/jenkins/jenkins/helmrepo.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: jenkins

--- a/apps/keda/keda/keda-helmrepo.yaml
+++ b/apps/keda/keda/keda-helmrepo.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: keda

--- a/apps/mailrelay/mailrelay/image-policy.yaml
+++ b/apps/mailrelay/mailrelay/image-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: mailrelay

--- a/apps/mailrelay2/mailrelay2/image-policy.yaml
+++ b/apps/mailrelay2/mailrelay2/image-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: mailrelay

--- a/apps/met/batch-jobs/image-policy.yaml
+++ b/apps/met/batch-jobs/image-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: libragob-batch-housekeeping
@@ -12,7 +12,7 @@ spec:
     alphabetical:
       order: asc
 ---
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: libragob-batch-ams-reporting

--- a/apps/mi/mi-adf-shir/image-policy.yaml
+++ b/apps/mi/mi-adf-shir/image-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: mi-adf-shir
@@ -16,7 +16,7 @@ spec:
 
 ---
 
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: mi-adf-shir-dev

--- a/apps/mi/mi-azure-functions/image-policy.yaml
+++ b/apps/mi/mi-azure-functions/image-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: mi-azure-functions
@@ -12,7 +12,7 @@ spec:
     alphabetical:
       order: asc
 ---
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: mi-azure-functions-dev

--- a/apps/mi/mi-house-keeping-service/image-policy.yaml
+++ b/apps/mi/mi-house-keeping-service/image-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: mi-house-keeping-service

--- a/apps/monitoring/cveinfo/image-policy.yaml
+++ b/apps/monitoring/cveinfo/image-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: cveinfo

--- a/apps/monitoring/kube-prometheus-stack/prometheus-helmrepo.yaml
+++ b/apps/monitoring/kube-prometheus-stack/prometheus-helmrepo.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: prometheus

--- a/apps/monitoring/loki/repository.yaml
+++ b/apps/monitoring/loki/repository.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: grafana-charts-loki

--- a/apps/monitoring/promtail/repository.yaml
+++ b/apps/monitoring/promtail/repository.yaml
@@ -1,4 +1,4 @@
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: grafana-charts

--- a/apps/monitoring/version-reporter/aksversions/image-policy.yaml
+++ b/apps/monitoring/version-reporter/aksversions/image-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: version-reporter-aksversions

--- a/apps/monitoring/version-reporter/docsoutdated/image-policy.yaml
+++ b/apps/monitoring/version-reporter/docsoutdated/image-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: version-reporter-docsoutdated

--- a/apps/monitoring/version-reporter/helmcharts/image-policy.yaml
+++ b/apps/monitoring/version-reporter/helmcharts/image-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: version-reporter-helmcharts

--- a/apps/monitoring/version-reporter/renovate/image-policy.yaml
+++ b/apps/monitoring/version-reporter/renovate/image-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: version-reporter-renovate

--- a/apps/monitoring/vm-hourlyusage/image-policy.yaml
+++ b/apps/monitoring/vm-hourlyusage/image-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: vm-hourlyusage

--- a/apps/my-time/my-time-api/image-policy.yaml
+++ b/apps/my-time/my-time-api/image-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: my-time-api

--- a/apps/my-time/my-time-frontend/image-policy.yaml
+++ b/apps/my-time/my-time-frontend/image-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: my-time-frontend

--- a/apps/opal/opal-external-api/image-policy.yaml
+++ b/apps/opal/opal-external-api/image-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: opal-external-api

--- a/apps/opal/opal-file-handler/image-policy.yaml
+++ b/apps/opal/opal-file-handler/image-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: opal-file-handler

--- a/apps/opal/opal-fines-service/image-policy.yaml
+++ b/apps/opal/opal-fines-service/image-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: opal-fines-service

--- a/apps/opal/opal-frontend-test/image-policy.yaml
+++ b/apps/opal/opal-frontend-test/image-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: opal-frontend-test

--- a/apps/opal/opal-frontend/image-policy.yaml
+++ b/apps/opal/opal-frontend/image-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: opal-frontend

--- a/apps/opal/opal-legacy-db-stub/image-policy.yaml
+++ b/apps/opal/opal-legacy-db-stub/image-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: opal-legacy-db-stub

--- a/apps/opal/opal-log-audit-service/image-policy.yaml
+++ b/apps/opal/opal-log-audit-service/image-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: opal-log-audit-service

--- a/apps/opal/opal-service-auth-provider-app/image-policy.yaml
+++ b/apps/opal/opal-service-auth-provider-app/image-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: opal-service-auth-provider-app

--- a/apps/opal/opal-user-service/image-policy.yaml
+++ b/apps/opal/opal-user-service/image-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: opal-user-service

--- a/apps/pdda/pdda-interfaces/image-policy.yaml
+++ b/apps/pdda/pdda-interfaces/image-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: pdda-public-display-data-aggregator

--- a/apps/pdda/pdda-public-display-data-aggregator/image-policy.yaml
+++ b/apps/pdda/pdda-public-display-data-aggregator/image-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: pdda-public-display-data-aggregator

--- a/apps/pdda/pdda-public-display-manager/image-policy.yaml
+++ b/apps/pdda/pdda-public-display-manager/image-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: pdda-public-display-manager

--- a/apps/pip/account-management-clear-audit-cron/image-policy.yaml
+++ b/apps/pip/account-management-clear-audit-cron/image-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: pip-account-management-clear-audit-cron

--- a/apps/pip/account-management-inactive-verification-cron/image-policy.yaml
+++ b/apps/pip/account-management-inactive-verification-cron/image-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: pip-account-management-inactive-verification-cron

--- a/apps/pip/account-management-media-reporting-cron/image-policy.yaml
+++ b/apps/pip/account-management-media-reporting-cron/image-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: pip-account-management-media-reporting-cron

--- a/apps/pip/account-management/image-policy.yaml
+++ b/apps/pip/account-management/image-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: pip-account-management

--- a/apps/pip/data-management-expired-artefacts-cron/image-policy.yaml
+++ b/apps/pip/data-management-expired-artefacts-cron/image-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: pip-data-management-expired-artefacts-cron

--- a/apps/pip/data-management-no-match-artefacts-cron/image-policy.yaml
+++ b/apps/pip/data-management-no-match-artefacts-cron/image-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: pip-data-management-no-match-artefacts-cron

--- a/apps/pip/data-management-subscriptions-cron/image-policy.yaml
+++ b/apps/pip/data-management-subscriptions-cron/image-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: pip-data-management-subscriptions-cron

--- a/apps/pip/data-management/image-policy.yaml
+++ b/apps/pip/data-management/image-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: pip-data-management

--- a/apps/pip/frontend/image-policy.yaml
+++ b/apps/pip/frontend/image-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: pip-frontend

--- a/apps/pip/publication-services-mi-reporting-cron/image-policy.yaml
+++ b/apps/pip/publication-services-mi-reporting-cron/image-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: pip-publication-services-mi-reporting-cron

--- a/apps/pip/publication-services/image-policy.yaml
+++ b/apps/pip/publication-services/image-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: pip-publication-services

--- a/apps/pip/refresh-views-cron/image-policy.yaml
+++ b/apps/pip/refresh-views-cron/image-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: pip-refresh-views-cron

--- a/apps/pip/subscription-management/image-policy.yaml
+++ b/apps/pip/subscription-management/image-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: pip-subscription-management

--- a/apps/pre/pre-api/image-policy.yaml
+++ b/apps/pre/pre-api/image-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: pre-api

--- a/apps/pre/pre-portal/demo-image-policy.yaml
+++ b/apps/pre/pre-portal/demo-image-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: demo-pre-portal

--- a/apps/pre/pre-portal/image-policy.yaml
+++ b/apps/pre/pre-portal/image-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: pre-portal

--- a/apps/testkube/testkube/helmrepo.yaml
+++ b/apps/testkube/testkube/helmrepo.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: source.toolkit.fluxcd.io/v1beta2
+apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
 metadata:
   name: kubeshop

--- a/apps/toffee/frontend/image-policy.yaml
+++ b/apps/toffee/frontend/image-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: toffee-frontend

--- a/apps/toffee/recipe-backend/image-policy.yaml
+++ b/apps/toffee/recipe-backend/image-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: toffee-recipe-backend

--- a/apps/toffee/recipe-receiver/image-policy.yaml
+++ b/apps/toffee/recipe-receiver/image-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: toffee-recipe-receiver

--- a/apps/vh/admin-web/image-policy.yaml
+++ b/apps/vh/admin-web/image-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: vh-admin-web-dev
@@ -14,7 +14,7 @@ spec:
     alphabetical:
       order: asc
 ---
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: vh-admin-web-test
@@ -30,7 +30,7 @@ spec:
     alphabetical:
       order: asc
 ---
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: vh-admin-web
@@ -46,7 +46,7 @@ spec:
     alphabetical:
       order: asc
 ---
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: vh-admin-web-staging
@@ -62,7 +62,7 @@ spec:
     alphabetical:
       order: asc
 ---
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: vh-admin-web-demo

--- a/apps/vh/booking-queue-subscriber/image-policy.yaml
+++ b/apps/vh/booking-queue-subscriber/image-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: vh-booking-queue-subscriber-dev
@@ -14,7 +14,7 @@ spec:
     alphabetical:
       order: asc
 ---
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: vh-booking-queue-subscriber-test
@@ -30,7 +30,7 @@ spec:
     alphabetical:
       order: asc
 ---
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: vh-booking-queue-subscriber-staging
@@ -46,7 +46,7 @@ spec:
     alphabetical:
       order: asc
 ---
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: vh-booking-queue-subscriber
@@ -62,7 +62,7 @@ spec:
     alphabetical:
       order: asc
 ---
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: vh-booking-queue-subscriber-demo

--- a/apps/vh/bookings-api/image-policy.yaml
+++ b/apps/vh/bookings-api/image-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: vh-bookings-api-dev
@@ -14,7 +14,7 @@ spec:
     alphabetical:
       order: asc
 ---
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: vh-bookings-api-test
@@ -30,7 +30,7 @@ spec:
     alphabetical:
       order: asc
 ---
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: vh-bookings-api-staging
@@ -46,7 +46,7 @@ spec:
     alphabetical:
       order: asc
 ---
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: vh-bookings-api
@@ -62,7 +62,7 @@ spec:
     alphabetical:
       order: asc
 ---
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: vh-bookings-api-demo

--- a/apps/vh/notification-api/image-policy.yaml
+++ b/apps/vh/notification-api/image-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: vh-notification-api-dev
@@ -14,7 +14,7 @@ spec:
     alphabetical:
       order: asc
 ---
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: vh-notification-api-test
@@ -30,7 +30,7 @@ spec:
     alphabetical:
       order: asc
 ---
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: vh-notification-api-staging
@@ -46,7 +46,7 @@ spec:
     alphabetical:
       order: asc
 ---
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: vh-notification-api
@@ -62,7 +62,7 @@ spec:
     alphabetical:
       order: asc
 ---
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: vh-notification-api-demo

--- a/apps/vh/scheduler-jobs/image-policy.yaml
+++ b/apps/vh/scheduler-jobs/image-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: vh-scheduler-jobs-dev
@@ -14,7 +14,7 @@ spec:
     alphabetical:
       order: asc
 ---
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: vh-scheduler-jobs-test
@@ -30,7 +30,7 @@ spec:
     alphabetical:
       order: asc
 ---
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: vh-scheduler-jobs-staging
@@ -46,7 +46,7 @@ spec:
     alphabetical:
       order: asc
 ---
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: vh-scheduler-jobs
@@ -62,7 +62,7 @@ spec:
     alphabetical:
       order: asc
 ---
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: vh-scheduler-jobs-demo

--- a/apps/vh/user-api/image-policy.yaml
+++ b/apps/vh/user-api/image-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: vh-user-api-dev
@@ -14,7 +14,7 @@ spec:
     alphabetical:
       order: asc
 ---
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: vh-user-api-test
@@ -30,7 +30,7 @@ spec:
     alphabetical:
       order: asc
 ---
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: vh-user-api
@@ -46,7 +46,7 @@ spec:
     alphabetical:
       order: asc
 ---
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: vh-user-api-staging
@@ -62,7 +62,7 @@ spec:
     alphabetical:
       order: asc
 ---
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: vh-user-api-demo

--- a/apps/vh/video-api/image-policy.yaml
+++ b/apps/vh/video-api/image-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: vh-video-api-dev
@@ -14,7 +14,7 @@ spec:
     alphabetical:
       order: asc
 ---
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: vh-video-api-test
@@ -30,7 +30,7 @@ spec:
     alphabetical:
       order: asc
 ---
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: vh-video-api-staging
@@ -46,7 +46,7 @@ spec:
     alphabetical:
       order: asc
 ---
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name:  vh-video-api
@@ -62,7 +62,7 @@ spec:
     alphabetical:
       order: asc
 ---
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: vh-video-api-demo

--- a/apps/vh/video-web/image-policy.yaml
+++ b/apps/vh/video-web/image-policy.yaml
@@ -1,4 +1,4 @@
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: vh-video-web-dev
@@ -14,7 +14,7 @@ spec:
     alphabetical:
       order: asc
 ---
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: vh-video-web-test
@@ -30,7 +30,7 @@ spec:
     alphabetical:
       order: asc
 ---
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: vh-video-web-staging
@@ -46,7 +46,7 @@ spec:
     alphabetical:
       order: asc
 ---
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: vh-video-web
@@ -62,7 +62,7 @@ spec:
     alphabetical:
       order: asc
 ---
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: vh-video-web-demo

--- a/bin/v2/add-image-policies.sh
+++ b/bin/v2/add-image-policies.sh
@@ -29,7 +29,7 @@ fi
 
 (
 cat <<EOF
-apiVersion: image.toolkit.fluxcd.io/v1beta1
+apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: ${PRODUCT}-${COMPONENT}


### PR DESCRIPTION
### Change description

- Upgrade Flux apiVersions, with backfills for any prior api upgrades missed


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change






## 🤖AEP PR SUMMARY🤖


- Updated the API version to `v1` from `v1beta2` in the following files:
  - external-dns-helmrepo.yaml
  - traefik2-helmrepo.yaml
  - image-policy.yaml for various apps
- Also updated schedules and alphabetical orders in some of the files for different apps.