### PR TITLE
DTSPO-24310: Updating flux dev client id to STG MI

### DIFF
--- a/apps/flux-system/serviceaccount/dev.yaml
+++ b/apps/flux-system/serviceaccount/dev.yaml
@@ -4,6 +4,6 @@ metadata:
   name: kustomize-controller
   namespace: flux-system
   annotations:
-    azure.workload.identity/client-id: "b86d64c4-ec90-451a-ab22-77cea15aeb68"
+    azure.workload.identity/client-id: "fa0102b9-d3d3-4134-ad45-85a529ce9a9e"
   labels:
     azure.workload.identity/use: "true"

--- a/apps/flux-system/workload-identity/workload-identity-federated-credential.yaml
+++ b/apps/flux-system/workload-identity/workload-identity-federated-credential.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: flux-system
 spec:
   owner:
-    name: aks-${ENVIRONMENT}-mi
+    name: aks-${WI_ENVIRONMENT}-mi
   audiences:
     - api://AzureADTokenExchange
   issuer: ${ISSUER_URL}

--- a/apps/flux-system/workload-identity/workload-identity-ua-identity.yaml
+++ b/apps/flux-system/workload-identity/workload-identity-ua-identity.yaml
@@ -1,7 +1,7 @@
 apiVersion: managedidentity.azure.com/v1api20181130
 kind: UserAssignedIdentity
 metadata:
-  name: aks-${ENVIRONMENT}-mi
+  name: aks-${WI_ENVIRONMENT}-mi
   namespace: flux-system
   annotations:
     serviceoperator.azure.com/reconcile-policy: skip


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-24310

### Change description

- Changing ENVIRONMENT to WI_ENVIRONMENT in flux workload identity dir.
- This is needed as WI_ENVIRONMENT corresponds to 'stg' for the dev environment, which is needed for the STG Mi.
- ENVIRONMENT and WI_ENIRONMENT do not differ in other envs.
- Updating flux dev client id to point to stg MI.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


### apps/flux-system/serviceaccount/dev.yaml
- Updated client-id from \"b86d64c4-ec90-451a-ab22-77cea15aeb68\" to \"fa0102b9-d3d3-4134-ad45-85a529ce9a9e\" in the annotations.

### apps/flux-system/workload-identity/workload-identity-federated-credential.yaml
- Changed owner name from \"aks-${ENVIRONMENT}-mi\" to \"aks-${WI_ENVIRONMENT}-mi\" in the spec.

### apps/flux-system/workload-identity/workload-identity-ua-identity.yaml
- Modified the name from \"aks-${ENVIRONMENT}-mi\" to \"aks-${WI_ENVIRONMENT}-mi\" in the metadata.