### PR TITLE
Revert "DTSPO-24310: Commenting out workload identity changes"

### DIFF
--- a/apps/flux-system/stg/base/kustomization.yaml
+++ b/apps/flux-system/stg/base/kustomization.yaml
@@ -4,8 +4,7 @@ resources:
   - ../../base
   - ../../base/gotk-components.yaml
   - git-credentials.enc.yaml
-  #- ../../workload-identity
+  - ../../workload-identity
 patches:
-  #- path: ../../serviceaccount/stg.yaml
-  #- path: ../../base/patches/workload-identity-deployment.yaml
-  - path: ../../base/patches/kustomize-controller-patch.yaml
+  - path: ../../serviceaccount/stg.yaml
+  - path: ../../base/patches/workload-identity-deployment.yaml


### PR DESCRIPTION
Reverts hmcts/sds-flux-config#6301

## 🤖AEP PR SUMMARY🤖


- `apps/flux-system/stg/base/kustomization.yaml` 🛠️
  - Removed the `git-credentials.enc.yaml` resource
  - Added the `././serviceaccount/stg.yaml` path
  - Modified the `././base/patches/kustomize-controller-patch.yaml` to `././base/patches/workload-identity-deployment.yaml`