### PR TITLE
DTSPO-24310: Adding Workload Identity to flux-system demo

### DIFF
--- a/apps/flux-system/demo/base/kustomization.yaml
+++ b/apps/flux-system/demo/base/kustomization.yaml
@@ -4,5 +4,7 @@ resources:
   - ../../base
   - ../../base/gotk-components.yaml
   - git-credentials.enc.yaml
+  - ../../workload-identity
 patches:
-  - path: ../../base/patches/kustomize-controller-patch.yaml
+  - path: ../../serviceaccount/demo.yaml
+  - path: ../../base/patches/workload-identity-deployment.yaml

--- a/apps/flux-system/serviceaccount/demo.yaml
+++ b/apps/flux-system/serviceaccount/demo.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kustomize-controller
+  namespace: flux-system
+  annotations:
+    azure.workload.identity/client-id: "04561461-0f92-42b3-9328-8b0c1bba4641"
+  labels:
+    azure.workload.identity/use: "true"


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-24310

### Change description

- Adding workload identity to flux-system demo
- Demo has a serviceaccount patch and a workload-identity deployment patch
- MI has been given write access over the resource group

### Testing done

- Currently working on all other non-prod envs

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change












## 🤖AEP PR SUMMARY🤖


- Modified `kustomization.yaml` in `apps/flux-system/demo/base`:
  - Added `demo.yaml` to the patches section
  - Added `git-credentials.enc.yaml` to resources
- Added new file `demo.yaml` in `apps/flux-system/serviceaccount` with ServiceAccount configuration containing annotations and labels.