### PR TITLE
Turn on test harness for 120

### DIFF
--- a/apps/darts-modernisation/darts-external-component-test-harness/test.yaml
+++ b/apps/darts-modernisation/darts-external-component-test-harness/test.yaml
@@ -7,7 +7,7 @@ spec:
   releaseName: darts-external-component-test-harness
   values:
     java:
-      replicas: 0
+      replicas: 60
       ingressHost: darts-external-component-test-harness.test.platform.hmcts.net
       environment:
         DARTS_LOG_LEVEL: DEBUG


### PR DESCRIPTION
Turn on test harness for 120







## 🤖AEP PR SUMMARY🤖


### apps/darts-modernisation/darts-external-component-test-harness/test.yaml
- Changed replicas value from 0 to 60 for the Java component.
- Updated the ingress host to darts-external-component-test-harness.test.platform.hmcts.net.
- Set the environment variable DARTS_LOG_LEVEL to DEBUG.