### PR TITLE
Turning off the test harness

### DIFF
--- a/apps/darts-modernisation/darts-external-component-test-harness/test.yaml
+++ b/apps/darts-modernisation/darts-external-component-test-harness/test.yaml
@@ -7,7 +7,7 @@ spec:
   releaseName: darts-external-component-test-harness
   values:
     java:
-      replicas: 120
+      replicas: 0
       ingressHost: darts-external-component-test-harness.test.platform.hmcts.net
       environment:
         DARTS_LOG_LEVEL: DEBUG


### PR DESCRIPTION
Turning off the test harness


## 🤖AEP PR SUMMARY🤖


### apps/darts-modernisation/darts-external-component-test-harness/test.yaml
- Changed the number of replicas from 120 to 0.