### PR TITLE
DTSPO-24310: Adding WI to ptl flux kustomize-controller

### DIFF
--- a/apps/flux-system/ptl/base/kustomization.yaml
+++ b/apps/flux-system/ptl/base/kustomization.yaml
@@ -24,4 +24,4 @@ patches:
     version: v1
 - path: ../../base/patches/image-automation-components-patch.yaml
 - path: ../../base/patches/workload-identity-deployment.yaml
-- paths: ../../serviceaccount/ptl.yaml
+- path: ../../serviceaccount/ptl.yaml

--- a/apps/flux-system/ptl/base/kustomization.yaml
+++ b/apps/flux-system/ptl/base/kustomization.yaml
@@ -6,7 +6,7 @@ resources:
 - ../../base/image-update-automation.yaml
 - git-credentials.enc.yaml
 - ../../automation
-        # Add this if you are using aad pod identity with managed identity
+- ../../workload-identity
 patches:
 - patch: |-
     - op: add
@@ -23,4 +23,5 @@ patches:
     namespace: flux-system
     version: v1
 - path: ../../base/patches/image-automation-components-patch.yaml
-- path: ../../base/patches/kustomize-controller-patch.yaml
+- path: ../../base/patches/workload-identity-deployment.yaml
+- paths: ../../serviceaccount/ptl.yaml

--- a/apps/flux-system/serviceaccount/ptl.yaml
+++ b/apps/flux-system/serviceaccount/ptl.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kustomize-controller
+  namespace: flux-system
+  annotations:
+    azure.workload.identity/client-id: "73a088e4-9783-4a65-b9eb-abaf596c397e"
+  labels:
+    azure.workload.identity/use: "true"

--- a/apps/opal/opal-frontend-test/stg.yaml
+++ b/apps/opal/opal-frontend-test/stg.yaml
@@ -8,17 +8,8 @@ spec:
   values:
     nodejs:
       ingressHost: opal-frontend-test.staging.platform.hmcts.net
-      keyVaults:
-        opal:
-          secrets:
-            - app-insights-connection-string
-            - redis-connection-string
-            - opal-frontend-csrf-secret
-            - launch-darkly-client-id
       environment:
         DUMMY_VAR: 0
         FRONTEND_HOSTNAME: https://opal-frontend-test.staging.platform.hmcts.net
         OPAL_API_URL: https://opal-fines-service.staging.platform.hmcts.net
         OPAL_FINES_SERVICE_API_URL: https://opal-fines-service.staging.platform.hmcts.net
-        FRONTEND_SESSION_SECRET: 1234567890
-        FRONTEND_COOKIE_SECRET: 0987654321


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-24310

### Change description

- Changing PTL flux to use workload identity rather than aadpodidentity.
- Adding serviceaccount ptl.yaml with client ID of aks-ptl-mi.
- Permissions of manager identity have been checked.
- Image automation is still using aadpodidentity.

### Testing done

- Added and working on all non-live sds envs.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change








## 🤖AEP PR SUMMARY🤖


#### apps/flux-system/ptl/base/kustomization.yaml
- Removed the `kustomize-controller-patch.yaml` and added `workload-identity-deployment.yaml` and `ptl.yaml` in the patches section.

#### apps/flux-system/serviceaccount/ptl.yaml
- Added a new file `ptl.yaml` to define a ServiceAccount with annotations and labels for azure.workload.identity integration.