### PR TITLE
DTSPO-24310: Changing sbox image policy assignment for toffee frontend

### DIFF
--- a/apps/toffee/frontend/sbox.yaml
+++ b/apps/toffee/frontend/sbox.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   values:
     nodejs:
-      image: sdshmctspublic.azurecr.io/toffee/frontend:pr-682-arm64 #{"$imagepolicy": "flux-system:toffee-frontend-sbox"}
+      image: sdshmctspublic.azurecr.io/toffee/frontend:pr-682-arm64 #{"$imagepolicy": "flux-system:toffee-frontend"}
       ingressHost: toffee.sandbox.platform.hmcts.net
       environment:
         RECIPE_BACKEND_URL: http://toffee-recipe-backend.sandbox.platform.hmcts.net


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-24310

### Change description

- Changing sbox image policy assignment for toffee frontend

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


### apps/toffee/frontend/sbox.yaml
- Updated the image for NodeJS to sdshmctspublic.azurecr.io/toffee/frontend:pr-682-arm64
- Updated the value of ingressHost to toffee.sandbox.platform.hmcts.net