### PR TITLE
Revert "Enable gov notify on demo for PRE"

### DIFF
--- a/apps/pre/pre-api-cron-cleanup-live-events/demo.yaml
+++ b/apps/pre/pre-api-cron-cleanup-live-events/demo.yaml
@@ -14,4 +14,3 @@ spec:
         AZURE_SUBSCRIPTION_ID: c68a4bed-4c3d-4956-af51-4ae164c1957c
         PLATFORM_ENV_TAG: Demo
         MEDIA_SERVICE: MediaKind
-        ENABLE_NEW_EMAIL_SERVICE: true

--- a/apps/pre/pre-api-cron-cleanup-streaming-locators/demo.yaml
+++ b/apps/pre/pre-api-cron-cleanup-streaming-locators/demo.yaml
@@ -14,4 +14,3 @@ spec:
         AZURE_SUBSCRIPTION_ID: c68a4bed-4c3d-4956-af51-4ae164c1957c
         PLATFORM_ENV_TAG: Demo
         MEDIA_SERVICE: MediaKind
-        ENABLE_NEW_EMAIL_SERVICE: true

--- a/apps/pre/pre-api-cron-close-pending-cases/demo.yaml
+++ b/apps/pre/pre-api-cron-close-pending-cases/demo.yaml
@@ -16,4 +16,3 @@ spec:
       AZURE_SUBSCRIPTION_ID: c68a4bed-4c3d-4956-af51-4ae164c1957c
       PLATFORM_ENV_TAG: Demo
       MEDIA_SERVICE: MediaKind
-      ENABLE_NEW_EMAIL_SERVICE: true

--- a/apps/pre/pre-api-cron-start-live-events/demo.yaml
+++ b/apps/pre/pre-api-cron-start-live-events/demo.yaml
@@ -16,4 +16,3 @@ spec:
       AZURE_SUBSCRIPTION_ID: c68a4bed-4c3d-4956-af51-4ae164c1957c
       PLATFORM_ENV_TAG: Demo
       MEDIA_SERVICE: MediaKind
-      ENABLE_NEW_EMAIL_SERVICE: true

--- a/apps/pre/pre-api/demo.yaml
+++ b/apps/pre/pre-api/demo.yaml
@@ -16,4 +16,3 @@ spec:
         PLATFORM_ENV_TAG: Demo
         MEDIA_SERVICE: MediaKind
         ENABLE_STREAMING_LOCATOR_ON_START: true
-        ENABLE_NEW_EMAIL_SERVICE: true


### PR DESCRIPTION
Reverts hmcts/sds-flux-config#6347

## 🤖AEP PR SUMMARY🤖


### apps/pre/pre-api-cron-cleanup-live-events/demo.yaml
- Removed the `ENABLE_NEW_EMAIL_SERVICE` field.

### apps/pre/pre-api-cron-cleanup-streaming-locators/demo.yaml
- Removed the `ENABLE_NEW_EMAIL_SERVICE` field.

### apps/pre/pre-api-cron-close-pending-cases/demo.yaml
- Removed the `ENABLE_NEW_EMAIL_SERVICE` field.

### apps/pre/pre-api-cron-start-live-events/demo.yaml
- Removed the `ENABLE_NEW_EMAIL_SERVICE` field.

### apps/pre/pre-api/demo.yaml
- Removed the `ENABLE_NEW_EMAIL_SERVICE` field.
- Removed the `ENABLE_STREAMING_LOCATOR_ON_START` field.