### PR TITLE
Turn off test harness.

### DIFF
--- a/apps/darts-modernisation/darts-external-component-test-harness/test.yaml
+++ b/apps/darts-modernisation/darts-external-component-test-harness/test.yaml
@@ -7,7 +7,7 @@ spec:
   releaseName: darts-external-component-test-harness
   values:
     java:
-      replicas: 60
+      replicas: 0
       ingressHost: darts-external-component-test-harness.test.platform.hmcts.net
       environment:
         DARTS_LOG_LEVEL: DEBUG


### PR DESCRIPTION
Turn off test harness.

## 🤖AEP PR SUMMARY🤖


### apps/darts-modernisation/darts-external-component-test-harness/test.yaml
- Changed replicas value from 60 to 0 for the `java` component
- Updated the `ingressHost` to `darts-external-component-test-harness.test.platform.hmcts.net`
- Set the `DARTS_LOG_LEVEL` to `DEBUG` for the environment