### PR TITLE
Turning on the test harness for 120 and 30 iterations

### DIFF
--- a/apps/darts-modernisation/darts-external-component-test-harness/test.yaml
+++ b/apps/darts-modernisation/darts-external-component-test-harness/test.yaml
@@ -7,7 +7,7 @@ spec:
   releaseName: darts-external-component-test-harness
   values:
     java:
-      replicas: 0
+      replicas: 60
       ingressHost: darts-external-component-test-harness.test.platform.hmcts.net
       environment:
         DARTS_LOG_LEVEL: DEBUG
@@ -19,3 +19,4 @@ spec:
         TEST_HARNESS_AUTOMATION_ENABLE_START_UP_DELAY: true
         TEST_HARNESS_AUTOMATION_ENABLE_DELAY_BETWEEN_ITERATIONS: false
         TEST_HARNESS_AUTOMATION_DELAY_BETWEEN_ITERATIONS_MS: 2000
+        TEST_HARNESS_AUTOMATION_MAX_ITERATIONS: 30


### PR DESCRIPTION
Turning on the test harness for 120 and 30 iterations

## 🤖AEP PR SUMMARY🤖


### apps/darts-modernisation/darts-external-component-test-harness/test.yaml
- Changed the number of replicas from 0 to 60.
- Added a new configuration for maximum iterations: 30.