### PR TITLE
turning off the test harness

### DIFF
--- a/apps/darts-modernisation/darts-external-component-test-harness/test.yaml
+++ b/apps/darts-modernisation/darts-external-component-test-harness/test.yaml
@@ -7,7 +7,7 @@ spec:
   releaseName: darts-external-component-test-harness
   values:
     java:
-      replicas: 60
+      replicas: 0
       ingressHost: darts-external-component-test-harness.test.platform.hmcts.net
       environment:
         DARTS_LOG_LEVEL: DEBUG


### PR DESCRIPTION
turning off the test harness

## 🤖AEP PR SUMMARY🤖


- **test.yaml**
  - Changed replicas from 60 to 0 for the `java` component.
  - Updated `ingressHost` to darts-external-component-test-harness.test.platform.hmcts.net.