### PR TITLE
Turn off the test harness

### DIFF
--- a/apps/darts-modernisation/darts-external-component-test-harness/test.yaml
+++ b/apps/darts-modernisation/darts-external-component-test-harness/test.yaml
@@ -7,7 +7,7 @@ spec:
   releaseName: darts-external-component-test-harness
   values:
     java:
-      replicas: 60
+      replicas: 0
       ingressHost: darts-external-component-test-harness.test.platform.hmcts.net
       environment:
         DARTS_LOG_LEVEL: DEBUG
@@ -19,4 +19,4 @@ spec:
         TEST_HARNESS_AUTOMATION_ENABLE_START_UP_DELAY: true
         TEST_HARNESS_AUTOMATION_ENABLE_DELAY_BETWEEN_ITERATIONS: false
         TEST_HARNESS_AUTOMATION_DELAY_BETWEEN_ITERATIONS_MS: 2000
-        TEST_HARNESS_AUTOMATION_MAX_ITERATIONS: -1
+        TEST_HARNESS_AUTOMATION_MAX_ITERATIONS: 30


### PR DESCRIPTION
Turn off the test harness





## 🤖AEP PR SUMMARY🤖


- Updated test.yaml``` in ```darts-external-component-test-harness```:
  - Changed the number of replicas from 60 to 0.
  - Updated the value of ```TEST_HARNESS_AUTOMATION_MAX_ITERATIONS``` from -1 to 30.