### PR TITLE
Revert "DMP-4775 Temporarily disable DARTS automated tasks on staging"

### DIFF
--- a/apps/darts-modernisation/darts-automated-tasks/stg.yaml
+++ b/apps/darts-modernisation/darts-automated-tasks/stg.yaml
@@ -7,7 +7,6 @@ spec:
   releaseName: darts-automated-tasks
   values:
     java:
-      replicas: 0
       environment:
         DARTS_GATEWAY_URL: http://darts-gateway.staging.platform.hmcts.net
         DARTS_PORTAL_URL: https://darts.staging.apps.hmcts.net


### PR DESCRIPTION
Reverts hmcts/sds-flux-config#6394





## 🤖AEP PR SUMMARY🤖


### apps/darts-modernisation/darts-automated-tasks/stg.yaml
- Removed a replica specification for Java, setting it to 0.
- Updated the environment variables `DARTS_GATEWAY_URL` and `DARTS_PORTAL_URL`.