### PR TITLE
DTSPO-24310: Bumping version of cert-manager

### DIFF
--- a/apps/azureserviceoperator-system/cert-manager/kustomization.yaml
+++ b/apps/azureserviceoperator-system/cert-manager/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/jetstack/cert-manager/releases/download/v1.14.4/cert-manager.yaml
+  - https://github.com/jetstack/cert-manager/releases/download/v1.17.1/cert-manager.yaml


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-24310

### Change description

- Bumping version of cert-manager to latest
- Required to try and fix error in sds-deploy pipeline. The flux bootstrapping of the clusters is being updated to use workload identity.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change




## 🤖AEP PR SUMMARY🤖


### apps/azureserviceoperator-system/cert-manager/kustomization.yaml
- Updated the cert-manager version from 1.14.4 to 1.17.1.