### PR TITLE
Revert "DTSPO-24310: Bumping version of cert-manager"

### DIFF
--- a/apps/azureserviceoperator-system/cert-manager/kustomization.yaml
+++ b/apps/azureserviceoperator-system/cert-manager/kustomization.yaml
@@ -1,4 +1,4 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - https://github.com/jetstack/cert-manager/releases/download/v1.17.1/cert-manager.yaml
+  - https://github.com/jetstack/cert-manager/releases/download/v1.14.4/cert-manager.yaml


### PR DESCRIPTION
Reverts hmcts/sds-flux-config#6400

## 🤖AEP PR SUMMARY🤖


- File: apps/azureserviceoperator-system/cert-manager/kustomization.yaml
- Updated the cert-manager version from v1.17.1 to v1.14.4.