### PR TITLE
juror: revert from leds testing

### DIFF
--- a/apps/juror/juror-pnc/ithc.yaml
+++ b/apps/juror/juror-pnc/ithc.yaml
@@ -15,5 +15,5 @@ spec:
         PNC_SERVICE_PNC_TERMINAL: LCRTS001
         PNC_SERVICE_PNC_AUTHORISATION: 2K01JV01
         PNC_SERVICE_GATEWAY_ID: JVJVS001
-        PNC_SERVICE_HOST: api.test.leds.police.uk
-        PNC_SERVICE_POST: 443
+        PNC_SERVICE_HOST: juror-dev-psnp.pnc.pnn.police.uk
+        PNC_SERVICE_POST: 7103


### PR DESCRIPTION
revert from leds testing for the time being



## 🤖AEP PR SUMMARY🤖


### apps/juror/juror-pnc/ithc.yaml
- Updated PNC_SERVICE_HOST and PNC_SERVICE_POST from \"api.test.leds.police.uk:443\" to \"juror-dev-psnp.pnc.pnn.police.uk:7103\" 🔄