### PR TITLE
Set replica to zero for subscription-management on ITHC

### DIFF
--- a/apps/pip/subscription-management/ithc.yaml
+++ b/apps/pip/subscription-management/ithc.yaml
@@ -7,6 +7,7 @@ spec:
   releaseName: pip-subscription-management
   values:
     java:
+      replicas: 0
       ingressHost: pip-subscription-management.ithc.platform.hmcts.net
       environment:
         DATA_MANAGEMENT_URL: https://pip-data-management.ithc.platform.hmcts.net


### PR DESCRIPTION
### Jira link


### Change description

Set replica to zero for subscription-management on ITHC

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


### apps/pip/subscription-management/ithc.yaml
- Changed the `replicas` value to 0
- Added `ingressHost` with value `pip-subscription-management.ithc.platform.hmcts.net`