### PR TITLE
Adds PRE_PORTAL value to all PRE envs

### DIFF
--- a/apps/pre/pre-api-cron-cleanup-live-events/demo.yaml
+++ b/apps/pre/pre-api-cron-cleanup-live-events/demo.yaml
@@ -15,3 +15,4 @@ spec:
         PLATFORM_ENV_TAG: Demo
         MEDIA_SERVICE: MediaKind
         ENABLE_NEW_EMAIL_SERVICE: true
+        PORTAL_URL: https://pre-portal.demo.platform.hmcts.net/

--- a/apps/pre/pre-api-cron-cleanup-live-events/prod.yaml
+++ b/apps/pre/pre-api-cron-cleanup-live-events/prod.yaml
@@ -12,3 +12,4 @@ spec:
       image: sdshmctspublic.azurecr.io/pre/api:prod-26ed259-20250403151407 # {"$imagepolicy": "flux-system:pre-api"}
       environment:
         MEDIA_SERVICE: MediaKind
+        PORTAL_URL: https://portal.pre-recorded-evidence.justice.gov.uk/

--- a/apps/pre/pre-api-cron-cleanup-live-events/test.yaml
+++ b/apps/pre/pre-api-cron-cleanup-live-events/test.yaml
@@ -14,3 +14,4 @@ spec:
         AZURE_SUBSCRIPTION_ID: 3eec5bde-7feb-4566-bfb6-805df6e10b90
         PLATFORM_ENV_TAG: Test
         MEDIA_SERVICE: MediaKind
+        PORTAL_URL: https://pre-portal.test.platform.hmcts.net/

--- a/apps/pre/pre-api-cron-cleanup-streaming-locators/demo.yaml
+++ b/apps/pre/pre-api-cron-cleanup-streaming-locators/demo.yaml
@@ -15,3 +15,4 @@ spec:
         PLATFORM_ENV_TAG: Demo
         MEDIA_SERVICE: MediaKind
         ENABLE_NEW_EMAIL_SERVICE: true
+        PORTAL_URL: https://pre-portal.demo.platform.hmcts.net/

--- a/apps/pre/pre-api-cron-cleanup-streaming-locators/prod.yaml
+++ b/apps/pre/pre-api-cron-cleanup-streaming-locators/prod.yaml
@@ -12,3 +12,4 @@ spec:
       image: sdshmctspublic.azurecr.io/pre/api:prod-26ed259-20250403151407 # {"$imagepolicy": "flux-system:pre-api"}
       environment:
         MEDIA_SERVICE: MediaKind
+        PORTAL_URL: https://portal.pre-recorded-evidence.justice.gov.uk/

--- a/apps/pre/pre-api-cron-cleanup-streaming-locators/test.yaml
+++ b/apps/pre/pre-api-cron-cleanup-streaming-locators/test.yaml
@@ -14,3 +14,4 @@ spec:
         AZURE_SUBSCRIPTION_ID: 3eec5bde-7feb-4566-bfb6-805df6e10b90
         PLATFORM_ENV_TAG: Test
         MEDIA_SERVICE: MediaKind
+        PORTAL_URL: https://pre-portal.test.platform.hmcts.net/

--- a/apps/pre/pre-api-cron-close-pending-cases/demo.yaml
+++ b/apps/pre/pre-api-cron-close-pending-cases/demo.yaml
@@ -17,3 +17,4 @@ spec:
       PLATFORM_ENV_TAG: Demo
       MEDIA_SERVICE: MediaKind
       ENABLE_NEW_EMAIL_SERVICE: true
+      PORTAL_URL: https://pre-portal.demo.platform.hmcts.net/

--- a/apps/pre/pre-api-cron-close-pending-cases/prod.yaml
+++ b/apps/pre/pre-api-cron-close-pending-cases/prod.yaml
@@ -14,3 +14,4 @@ spec:
       image: sdshmctspublic.azurecr.io/pre/api:prod-26ed259-20250403151407 # {"$imagepolicy": "flux-system:pre-api"}
       environment:
         MEDIA_SERVICE: MediaKind
+        PORTAL_URL: https://portal.pre-recorded-evidence.justice.gov.uk/

--- a/apps/pre/pre-api-cron-close-pending-cases/test.yaml
+++ b/apps/pre/pre-api-cron-close-pending-cases/test.yaml
@@ -14,3 +14,4 @@ spec:
         AZURE_SUBSCRIPTION_ID: 3eec5bde-7feb-4566-bfb6-805df6e10b90
         PLATFORM_ENV_TAG: Test
         MEDIA_SERVICE: MediaKind
+        PORTAL_URL: https://pre-portal.test.platform.hmcts.net/

--- a/apps/pre/pre-api-cron-start-live-events/demo.yaml
+++ b/apps/pre/pre-api-cron-start-live-events/demo.yaml
@@ -16,3 +16,4 @@ spec:
       AZURE_SUBSCRIPTION_ID: c68a4bed-4c3d-4956-af51-4ae164c1957c
       PLATFORM_ENV_TAG: Demo
       MEDIA_SERVICE: MediaKind
+      PORTAL_URL: https://pre-portal.demo.platform.hmcts.net/

--- a/apps/pre/pre-api-cron-start-live-events/prod.yaml
+++ b/apps/pre/pre-api-cron-start-live-events/prod.yaml
@@ -14,3 +14,4 @@ spec:
       image: sdshmctspublic.azurecr.io/pre/api:prod-26ed259-20250403151407 # {"$imagepolicy": "flux-system:pre-api"}
       environment:
         MEDIA_SERVICE: MediaKind
+        PORTAL_URL: https://portal.pre-recorded-evidence.justice.gov.uk/

--- a/apps/pre/pre-api-cron-start-live-events/test.yaml
+++ b/apps/pre/pre-api-cron-start-live-events/test.yaml
@@ -15,3 +15,4 @@ spec:
         AZURE_SUBSCRIPTION_ID: 3eec5bde-7feb-4566-bfb6-805df6e10b90
         PLATFORM_ENV_TAG: Test
         MEDIA_SERVICE: MediaKind
+        PORTAL_URL: https://pre-portal.test.platform.hmcts.net/

--- a/apps/pre/pre-api/demo.yaml
+++ b/apps/pre/pre-api/demo.yaml
@@ -17,3 +17,4 @@ spec:
         MEDIA_SERVICE: MediaKind
         ENABLE_STREAMING_LOCATOR_ON_START: true
         ENABLE_NEW_EMAIL_SERVICE: true
+        PORTAL_URL: https://pre-portal.demo.platform.hmcts.net/

--- a/apps/pre/pre-api/prod.yaml
+++ b/apps/pre/pre-api/prod.yaml
@@ -17,3 +17,4 @@ spec:
         MEDIA_SERVICE: MediaKind
         ENABLE_STREAMING_LOCATOR_ON_START: true
         TRIGGER: init-2
+        PORTAL_URL: https://portal.pre-recorded-evidence.justice.gov.uk/

--- a/apps/pre/pre-api/test.yaml
+++ b/apps/pre/pre-api/test.yaml
@@ -15,3 +15,4 @@ spec:
         PLATFORM_ENV_TAG: Testing
         MEDIA_SERVICE: MediaKind
         ENABLE_STREAMING_LOCATOR_ON_START: false
+        PORTAL_URL: https://pre-portal.test.platform.hmcts.net/


### PR DESCRIPTION


## 🤖AEP PR SUMMARY🤖


- Updated demo.yaml, prod.yaml, and test.yaml files in apps/pre/pre-api-cron-cleanup-live-events:
  - Added PORTAL_URL with respective URLs for different environments.

- Updated demo.yaml, prod.yaml, and test.yaml files in apps/pre/pre-api-cron-cleanup-streaming-locators:
  - Added PORTAL_URL with respective URLs for different environments.

- Updated demo.yaml, prod.yaml, and test.yaml files in apps/pre/pre-api-cron-close-pending-cases:
  - Added PORTAL_URL with respective URLs for different environments.

- Updated demo.yaml, prod.yaml, and test.yaml files in apps/pre/pre-api-cron-start-live-events:
  - Added PORTAL_URL with respective URLs for different environments.

- Updated demo.yaml, prod.yaml, and test.yaml files in apps/pre/pre-api:
  - Added PORTAL_URL with respective URLs for different environments.