### PR TITLE
Enable start live event cron in DEMO

### DIFF
--- a/apps/pre/pre-api-cron-start-live-events/demo.yaml
+++ b/apps/pre/pre-api-cron-start-live-events/demo.yaml
@@ -8,7 +8,7 @@ spec:
     global:
       jobKind: CronJob
     job:
-      suspend: true
+      suspend: false
       disableActiveClusterCheck: true
       schedule: "0 7 * * *"
       image: sdshmctspublic.azurecr.io/pre/api:prod-26ed259-20250403151407 # {"$imagepolicy": "flux-system:pre-api"}


### PR DESCRIPTION

### Change description
Enables start live event cron in DEMO
<!--
Provide a description of what change you are proposing.
A short summary here and then you can add comments in your pull request explaining your change to others.
-->


## 🤖AEP PR SUMMARY🤖


### apps/pre/pre-api-cron-start-live-events/demo.yaml
- Unset the `suspend` attribute to `false` to enable the cron job.
- Modified the schedule to run the job every day at 7:00 AM.