### PR TITLE
DTSPO-24310: Removing opal from stg temporarily

### DIFF
--- a/clusters/stg/base/kustomization.yaml
+++ b/clusters/stg/base/kustomization.yaml
@@ -20,7 +20,7 @@ resources:
   - ../../../apps/keda/base/kustomize.yaml
   - ../../../apps/pre/base/kustomize.yaml
   - ../../../apps/juror/base/kustomize.yaml
-  - ../../../apps/opal/base/kustomize.yaml
+  # - ../../../apps/opal/base/kustomize.yaml
   - ../../../apps/pdda/base/kustomize.yaml
 patches:
   - path: ../../../apps/base/kustomize.yaml


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-24310

### Change description

- Temporarily commenting out Opal in staging.
- This is needed because Opal is causing the [aks-sds-deploy pipeline to fail](https://dev.azure.com/hmcts/PlatformOperations/_build/results?buildId=792299&view=logs&j=845f5419-8480-55bc-30e7-60324046543e&t=47b59580-3d51-551c-3548-6a86d4e65d0f). The opal-user-service-java pods are ina crash loop which is causing PDB errors.
- Opal is not currently in use on staging.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change






## 🤖AEP PR SUMMARY🤖


### clusters/stg/base/kustomization.yaml
- Removed the line `- ./././apps/opal/base/kustomize.yaml` and added the line `- ./././apps/pdda/base/kustomize.yaml`.
- Applied a patch to `./././apps/base/kustomize.yaml`.