### PR TITLE
Revert "DTSPO-24310: Removing opal from stg temporarily"

### DIFF
--- a/clusters/stg/base/kustomization.yaml
+++ b/clusters/stg/base/kustomization.yaml
@@ -20,7 +20,7 @@ resources:
   - ../../../apps/keda/base/kustomize.yaml
   - ../../../apps/pre/base/kustomize.yaml
   - ../../../apps/juror/base/kustomize.yaml
-  # - ../../../apps/opal/base/kustomize.yaml
+  - ../../../apps/opal/base/kustomize.yaml
   - ../../../apps/pdda/base/kustomize.yaml
 patches:
   - path: ../../../apps/base/kustomize.yaml


### PR DESCRIPTION
Reverts hmcts/sds-flux-config#6460

- Adding Opal back into staging after it was removed temporarily to allow the rollout of the new bootstrapping for sds.

## 🤖AEP PR SUMMARY🤖


- File: clusters/stg/base/kustomization.yaml
- Removed the reference to ./././apps/opal/base/kustomize.yaml from resources
- Added a patch to ./././apps/base/kustomize.yaml