### PR TITLE
Updated cron timer for CaTH

### DIFF
--- a/apps/pip/publication-services-mi-reporting-cron/test/01.yaml
+++ b/apps/pip/publication-services-mi-reporting-cron/test/01.yaml
@@ -6,7 +6,8 @@ spec:
   releaseName: pip-publication-services-mi-reporting-cron
   values:
     job:
-      schedule: "01 08 * * 1,3,5"
+      image: sdshmctspublic.azurecr.io/pip/cron-trigger:pr-192-9df4529-20250414103358
+      schedule: "50 14 * * 1,3,5"
       environment:
         PUBLICATION_SERVICES_URL: https://pip-publication-services.test.platform.hmcts.net
         TRIGGER_TYPE: MI_DATA_REPORTING

--- a/apps/pip/refresh-views-cron/test/01.yaml
+++ b/apps/pip/refresh-views-cron/test/01.yaml
@@ -7,7 +7,7 @@ spec:
   values:
     job:
       image: sdshmctspublic.azurecr.io/pip/cron-trigger:pr-192-9df4529-20250414103358
-      schedule: "48 14 * * 1,3,5"
+      schedule: "50 14 * * 1,3,5"
       environment:
         DATA_MANAGEMENT_URL: https://pip-data-management.test.platform.hmcts.net
         ACCOUNT_MANAGEMENT_URL: https://pip-account-management.test.platform.hmcts.net

--- a/apps/pip/refresh-views-cron/test/01.yaml
+++ b/apps/pip/refresh-views-cron/test/01.yaml
@@ -7,7 +7,7 @@ spec:
   values:
     job:
       image: sdshmctspublic.azurecr.io/pip/cron-trigger:pr-192-9df4529-20250414103358
-      schedule: "0 8 * * 1,3,5"
+      schedule: "48 14 * * 1,3,5"
       environment:
         DATA_MANAGEMENT_URL: https://pip-data-management.test.platform.hmcts.net
         ACCOUNT_MANAGEMENT_URL: https://pip-account-management.test.platform.hmcts.net


### PR DESCRIPTION
### Jira link

PUB-2870

### Change description

Updated cron trigger




## 🤖AEP PR SUMMARY🤖


- In `apps/pip/publication-services-mi-reporting-cron/test/01.yaml`, the image for the job has been updated to `sdshmctspublic.azurecr.io/pip/cron-trigger:pr-192-9df4529-20250414103358` and the schedule has been changed from \"01 08 * * 1,3,5\" to \"50 14 * * 1,3,5\"
- In `apps/pip/refresh-views-cron/test/01.yaml`, the schedule for the job has been updated from \"0 8 * * 1,3,5\" to \"50 14 * * 1,3,5\"