### PR TITLE
pre-api: Change Start Live Event Scheduled Time + Prepare Prod

### DIFF
--- a/apps/pre/pre-api-cron-start-live-events/demo.yaml
+++ b/apps/pre/pre-api-cron-start-live-events/demo.yaml
@@ -9,7 +9,7 @@ spec:
       jobKind: CronJob
     job:
       suspend: false
-      schedule: "30 10 * * *" # 10:30 am, every day
+      schedule: "0 7 * * *" # 7 am, every day
       image: sdshmctspublic.azurecr.io/pre/api:prod-166329a-20250416082012 # {"$imagepolicy": "flux-system:pre-api"}
       environment:
         AZURE_SUBSCRIPTION_ID: c68a4bed-4c3d-4956-af51-4ae164c1957c

--- a/apps/pre/pre-api-cron-start-live-events/prod.yaml
+++ b/apps/pre/pre-api-cron-start-live-events/prod.yaml
@@ -9,7 +9,6 @@ spec:
       jobKind: CronJob
     job:
       suspend: true
-      disableActiveClusterCheck: true
       schedule: "0 7 * * *"
       image: sdshmctspublic.azurecr.io/pre/api:prod-166329a-20250416082012 # {"$imagepolicy": "flux-system:pre-api"}
       environment:


### PR DESCRIPTION
### Jira link

<!-- 
Replace PROJ-XXXXXX with your Jira key
Remove this section if its not applicable, or replace it with another reference link
-->
See [S28-3815](https://tools.hmcts.net/jira/browse/S28-3815)

### Change description
- Revert start live event cron scheduled time to 7 am
- Remove `disableActiveClusterCheck` from prod
<!--
Provide a description of what change you are proposing.
A short summary here and then you can add comments in your pull request explaining your change to others.
-->




## 🤖AEP PR SUMMARY🤖


### apps/pre/pre-api-cron-start-live-events/demo.yaml
- Updated the schedule for the cron job from \"30 10 * * *\" to \"0 7 * * *\"
  
### apps/pre/pre-api-cron-start-live-events/prod.yaml
- Removed the 'suspend' and 'disableActiveClusterCheck' configurations
- Updated the schedule for the cron job from \"30 10 * * *\" to \"0 7 * * *\"