### PR TITLE
pre-api: Decrement start-live-events Scheduled Time by 1 hr

### DIFF
--- a/apps/pre/pre-api-cron-start-live-events/demo.yaml
+++ b/apps/pre/pre-api-cron-start-live-events/demo.yaml
@@ -9,7 +9,7 @@ spec:
       jobKind: CronJob
     job:
       suspend: false
-      schedule: "0 7 * * *" # 7 am, every day
+      schedule: "0 6 * * *" # 7 am, every day
       image: sdshmctspublic.azurecr.io/pre/api:prod-7289383-20250422154609 # {"$imagepolicy": "flux-system:pre-api"}
       environment:
         AZURE_SUBSCRIPTION_ID: c68a4bed-4c3d-4956-af51-4ae164c1957c

--- a/apps/pre/pre-api-cron-start-live-events/prod.yaml
+++ b/apps/pre/pre-api-cron-start-live-events/prod.yaml
@@ -9,7 +9,7 @@ spec:
       jobKind: CronJob
     job:
       suspend: true
-      schedule: "0 7 * * *"
+      schedule: "0 6 * * *"
       image: sdshmctspublic.azurecr.io/pre/api:prod-7289383-20250422154609 # {"$imagepolicy": "flux-system:pre-api"}
       environment:
         MEDIA_SERVICE: MediaKind

--- a/apps/pre/pre-api-cron-start-live-events/stg.yaml
+++ b/apps/pre/pre-api-cron-start-live-events/stg.yaml
@@ -9,7 +9,7 @@ spec:
       jobKind: CronJob
     job:
       suspend: false
-      schedule: "30 8 * * *"
+      schedule: "30 7 * * *"
       image: sdshmctspublic.azurecr.io/pre/api:prod-7289383-20250422154609 # {"$imagepolicy": "flux-system:pre-api"}
       environment:
         AZURE_SUBSCRIPTION_ID: 74dacd4f-a248-45bb-a2f0-af700dc4cf68

--- a/apps/pre/pre-api-cron-start-live-events/test.yaml
+++ b/apps/pre/pre-api-cron-start-live-events/test.yaml
@@ -9,7 +9,7 @@ spec:
       jobKind: CronJob
     job:
       suspend: true
-      schedule: "30 8 * * *"
+      schedule: "30 7 * * *"
       image: sdshmctspublic.azurecr.io/pre/api:prod-7289383-20250422154609 # {"$imagepolicy": "flux-system:pre-api"}
       environment:
         AZURE_SUBSCRIPTION_ID: 3eec5bde-7feb-4566-bfb6-805df6e10b90


### PR DESCRIPTION


### Change description
- Decrement start-live-events cron start time by 1hr in all envs
<!--
Provide a description of what change you are proposing.
A short summary here and then you can add comments in your pull request explaining your change to others.
-->

## 🤖AEP PR SUMMARY🤖


- Updated schedule times in the following files within the apps/pre/pre-api-cron-start-live-events directory:
  - demo.yaml
  - prod.yaml
  - stg.yaml
  - test.yaml
  - In each file, the schedule was changed from \"0 7 * * *\" to \"0 6 * * *\" or from \"30 8 * * *\" to \"30 7 * * *\".