### PR TITLE
feat(pre-api prod): Enable Feature Toggles for GovNotify + Enable start-live-events Cron

### DIFF
--- a/apps/pre/pre-api-cron-cleanup-live-events/prod.yaml
+++ b/apps/pre/pre-api-cron-cleanup-live-events/prod.yaml
@@ -12,4 +12,5 @@ spec:
       image: sdshmctspublic.azurecr.io/pre/api:prod-7289383-20250422154609 # {"$imagepolicy": "flux-system:pre-api"}
       environment:
         MEDIA_SERVICE: MediaKind
+        ENABLE_NEW_EMAIL_SERVICE: true
         PORTAL_URL: https://portal.pre-recorded-evidence.justice.gov.uk/

--- a/apps/pre/pre-api-cron-cleanup-streaming-locators/prod.yaml
+++ b/apps/pre/pre-api-cron-cleanup-streaming-locators/prod.yaml
@@ -13,3 +13,4 @@ spec:
       environment:
         MEDIA_SERVICE: MediaKind
         PORTAL_URL: https://portal.pre-recorded-evidence.justice.gov.uk/
+        ENABLE_NEW_EMAIL_SERVICE: true

--- a/apps/pre/pre-api-cron-close-pending-cases/prod.yaml
+++ b/apps/pre/pre-api-cron-close-pending-cases/prod.yaml
@@ -15,3 +15,4 @@ spec:
       environment:
         MEDIA_SERVICE: MediaKind
         PORTAL_URL: https://portal.pre-recorded-evidence.justice.gov.uk/
+        ENABLE_NEW_EMAIL_SERVICE: true

--- a/apps/pre/pre-api-cron-start-live-events/prod.yaml
+++ b/apps/pre/pre-api-cron-start-live-events/prod.yaml
@@ -8,7 +8,7 @@ spec:
     global:
       jobKind: CronJob
     job:
-      suspend: true
+      suspend: false
       schedule: "0 6 * * *"
       image: sdshmctspublic.azurecr.io/pre/api:prod-7289383-20250422154609 # {"$imagepolicy": "flux-system:pre-api"}
       environment:

--- a/apps/pre/pre-api/prod.yaml
+++ b/apps/pre/pre-api/prod.yaml
@@ -16,6 +16,7 @@ spec:
         PLATFORM_ENV_TAG: Production
         MEDIA_SERVICE: MediaKind
         ENABLE_STREAMING_LOCATOR_ON_START: true
+        ENABLE_NEW_EMAIL_SERVICE: true
         TRIGGER: init-2
         PORTAL_URL: https://portal.pre-recorded-evidence.justice.gov.uk/
         ENABLE_AUTOMATED_EDITING: false


### PR DESCRIPTION
### Change description
- Enable GovNotify feature flag in pre-api prod + all crons
- Enable start-live-events cron job

<!--
Provide a description of what change you are proposing.
A short summary here and then you can add comments in your pull request explaining your change to others.
-->




## 🤖AEP PR SUMMARY🤖


- apps/pre/pre-api-cron-cleanup-live-events/prod.yaml
  - Added ENABLE_NEW_EMAIL_SERVICE: true to the environment variables.

- apps/pre/pre-api-cron-cleanup-streaming-locators/prod.yaml
  - Added ENABLE_NEW_EMAIL_SERVICE: true to the environment variables.

- apps/pre/pre-api-cron-close-pending-cases/prod.yaml
  - Added ENABLE_NEW_EMAIL_SERVICE: true to the environment variables.

- apps/pre/pre-api-cron-start-live-events/prod.yaml
  - Changed job suspension from true to false.
  - Updated the schedule from \"0 6 * * *\" to its new value.
  - Modified environment variables.

- apps/pre/pre-api/prod.yaml
  - Added ENABLE_NEW_EMAIL_SERVICE: true to the environment variables.