### PR TITLE
Turning off the test harness

### DIFF
--- a/apps/darts-modernisation/darts-external-component-test-harness/test.yaml
+++ b/apps/darts-modernisation/darts-external-component-test-harness/test.yaml
@@ -7,7 +7,7 @@ spec:
   releaseName: darts-external-component-test-harness
   values:
     java:
-      replicas: 75
+      replicas: 0
       ingressHost: darts-external-component-test-harness.test.platform.hmcts.net
       environment:
         DARTS_LOG_LEVEL: INFO


### PR DESCRIPTION
Turning off the test harness



## 🤖AEP PR SUMMARY🤖


- The `test.yaml` file in `darts-external-component-test-harness` in the `darts-modernisation` app now sets the `replicas` value for `java` to 0.