### PR TITLE
Turning on the test harness

### DIFF
--- a/apps/darts-modernisation/darts-external-component-test-harness/test.yaml
+++ b/apps/darts-modernisation/darts-external-component-test-harness/test.yaml
@@ -7,7 +7,7 @@ spec:
   releaseName: darts-external-component-test-harness
   values:
     java:
-      replicas: 0
+      replicas: 75
       ingressHost: darts-external-component-test-harness.test.platform.hmcts.net
       environment:
         DARTS_LOG_LEVEL: INFO
@@ -19,4 +19,4 @@ spec:
         TEST_HARNESS_AUTOMATION_ENABLE_START_UP_DELAY: true
         TEST_HARNESS_AUTOMATION_ENABLE_DELAY_BETWEEN_ITERATIONS: false
         TEST_HARNESS_AUTOMATION_DELAY_BETWEEN_ITERATIONS_MS: 2000
-        TEST_HARNESS_AUTOMATION_MAX_ITERATIONS: 1
+        TEST_HARNESS_AUTOMATION_MAX_ITERATIONS: -1


### PR DESCRIPTION
Turning on the test harness

## 🤖AEP PR SUMMARY🤖


### apps/darts-modernisation/darts-external-component-test-harness/test.yaml
- Increased the number of replicas for the Java service from 0 to 75.
- Set `TEST_HARNESS_AUTOMATION_MAX_ITERATIONS` to -1.