### PR TITLE
Turning off the test harness

### DIFF
--- a/apps/darts-modernisation/darts-external-component-test-harness/test.yaml
+++ b/apps/darts-modernisation/darts-external-component-test-harness/test.yaml
@@ -7,7 +7,7 @@ spec:
   releaseName: darts-external-component-test-harness
   values:
     java:
-      replicas: 75
+      replicas: 0
       ingressHost: darts-external-component-test-harness.test.platform.hmcts.net
       environment:
         DARTS_LOG_LEVEL: INFO


### PR DESCRIPTION
Turning off the test harness

## 🤖AEP PR SUMMARY🤖


### apps/darts-modernisation/darts-external-component-test-harness/test.yaml
- Reduced the number of replicas for the Java service from 75 to 0.
- Updated the `ingressHost` to `darts-external-component-test-harness.test.platform.hmcts.net`.
- Set the environment variable `DARTS_LOG_LEVEL` to `INFO`.