### PR TITLE
Test S28-3665 on PRE perftest

### DIFF
--- a/apps/pre/pre-api-cron-cleanup-live-events/test-image-policy.yaml
+++ b/apps/pre/pre-api-cron-cleanup-live-events/test-image-policy.yaml
@@ -1,12 +1,12 @@
 apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
-  name: test-pre-api-cron-start-live-events
+  name: test-pre-api-cron-cleanup-live-events
   annotations:
     hmcts.github.com/prod-automated: disabled
 spec:
   filterTags:
-    pattern: '^pr-920-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^pr-921-[a-f0-9]+-(?P<ts>[0-9]+)'
     extract: '$ts'
   policy:
     alphabetical:

--- a/apps/pre/pre-api-cron-cleanup-live-events/test.yaml
+++ b/apps/pre/pre-api-cron-cleanup-live-events/test.yaml
@@ -9,7 +9,7 @@ spec:
       jobKind: CronJob
     job:
       schedule: "15 15 * * *" # 15:15 PM UTC
-      image: sdshmctspublic.azurecr.io/pre/api:prod-2d501da-20250425132045 # {"$imagepolicy": "flux-system:pre-api"}
+      image: sdshmctspublic.azurecr.io/pre/api:pr-921-9dc0127-20250430125058 # {"$imagepolicy": "flux-system:test-pre-api-cron-cleanup-live-events"}
       environment:
         AZURE_SUBSCRIPTION_ID: 3eec5bde-7feb-4566-bfb6-805df6e10b90
         PLATFORM_ENV_TAG: Test

--- a/apps/pre/pre-api-cron-start-live-events/test-image-policy.yaml
+++ b/apps/pre/pre-api-cron-start-live-events/test-image-policy.yaml
@@ -1,0 +1,15 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImagePolicy
+metadata:
+  name: test-pre-api-cron-start-live-events
+  annotations:
+    hmcts.github.com/prod-automated: disabled
+spec:
+  filterTags:
+    pattern: '^pr-921-[a-f0-9]+-(?P<ts>[0-9]+)'
+    extract: '$ts'
+  policy:
+    alphabetical:
+      order: asc
+  imageRepositoryRef:
+    name: pre-api

--- a/apps/pre/pre-api-cron-start-live-events/test.yaml
+++ b/apps/pre/pre-api-cron-start-live-events/test.yaml
@@ -10,7 +10,7 @@ spec:
     job:
       suspend: true
       schedule: "30 7 * * *"
-      image: sdshmctspublic.azurecr.io/pre/api:pr-921-9dc0127-20250430125058 # {"$imagepolicy": "flux-system:test-pre-api-cron-start-live-events"}
+      image: sdshmctspublic.azurecr.io/pre/api:pr-920-ece524a-20250430151220 # {"$imagepolicy": "flux-system:test-pre-api-cron-start-live-events"}
       environment:
         AZURE_SUBSCRIPTION_ID: 3eec5bde-7feb-4566-bfb6-805df6e10b90
         PLATFORM_ENV_TAG: Test

--- a/apps/pre/pre-api-cron-start-live-events/test.yaml
+++ b/apps/pre/pre-api-cron-start-live-events/test.yaml
@@ -10,7 +10,7 @@ spec:
     job:
       suspend: true
       schedule: "30 7 * * *"
-      image: sdshmctspublic.azurecr.io/pre/api:prod-2d501da-20250425132045 # {"$imagepolicy": "flux-system:pre-api"}
+      image: sdshmctspublic.azurecr.io/pre/api:pr-921-9dc0127-20250430125058 # {"$imagepolicy": "flux-system:test-pre-api-cron-start-live-events"}
       environment:
         AZURE_SUBSCRIPTION_ID: 3eec5bde-7feb-4566-bfb6-805df6e10b90
         PLATFORM_ENV_TAG: Test


### PR DESCRIPTION






## 🤖AEP PR SUMMARY🤖


- Added new file `test-image-policy.yaml` under `pre-api-cron-cleanup-live-events` and `pre-api-cron-start-live-events` directories for specifying image policies.
- Updated `test.yaml` files in `pre-api-cron-cleanup-live-events` and `pre-api-cron-start-live-events` directories to use a new image with a tag starting with `pr-921` and `pr-920` respectively.