### PR TITLE
Spin down pods for CaTH

### DIFF
--- a/apps/pip/subscription-management/demo.yaml
+++ b/apps/pip/subscription-management/demo.yaml
@@ -7,6 +7,7 @@ spec:
   releaseName: pip-subscription-management
   values:
     java:
+      replicas: 0
       ingressHost: pip-subscription-management.demo.platform.hmcts.net
       environment:
         DATA_MANAGEMENT_URL: https://pip-data-management.demo.platform.hmcts.net

--- a/apps/pip/subscription-management/prod.yaml
+++ b/apps/pip/subscription-management/prod.yaml
@@ -7,7 +7,7 @@ spec:
   releaseName: pip-subscription-management
   values:
     java:
-      replicas: 2
+      replicas: 0
       ingressHost: pip-subscription-management.platform.hmcts.net
       environment:
         DATA_MANAGEMENT_URL: https://pip-data-management.platform.hmcts.net

--- a/apps/pip/subscription-management/stg.yaml
+++ b/apps/pip/subscription-management/stg.yaml
@@ -7,7 +7,7 @@ spec:
   releaseName: pip-subscription-management
   values:
     java:
-      replicas: 2
+      replicas: 0
       ingressHost: pip-subscription-management.staging.platform.hmcts.net
       environment:
         DATA_MANAGEMENT_URL: https://pip-data-management.staging.platform.hmcts.net


### PR DESCRIPTION
### Jira link

CHG5020830

### Change description

Spin down subscription management for CaTH






## 🤖AEP PR SUMMARY🤖


- Updated `demo.yaml`, `prod.yaml`, and `stg.yaml` in `apps/pip/subscription-management/`:
  - Set the `replicas` value for `java` to 0 in all three files.
  - Updated `ingressHost` for each environment accordingly.