### PR TITLE
deploy interim10 for juror-api to ITHC only

### DIFF
--- a/apps/juror/juror-api/demo.yaml
+++ b/apps/juror/juror-api/demo.yaml
@@ -8,7 +8,7 @@ spec:
   values:
     java:
       # Uncomment and edit the line below to fix the environment at a specific image
-      image: sdshmctspublic.azurecr.io/juror/api:prod-b57be62-20250501130209 # {"$imagepolicy": "flux-system:juror-api-pr"}
+      image: sdshmctspublic.azurecr.io/juror/api:prod-b57be62-20250501130209
       ingressHost: juror-api.demo.platform.hmcts.net
       environment:
         RUN_DB_MIGRATION_ON_STARTUP: true

--- a/apps/juror/juror-api/image-policy.yaml
+++ b/apps/juror/juror-api/image-policy.yaml
@@ -2,14 +2,30 @@ apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: juror-api
+  annotations:
+    hmcts.github.com/prod-automated: disabled
 spec:
+  filterTags:
+    extract: $ts
+    pattern: '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'
   imageRepositoryRef:
     name: juror-api
+  policy:
+    alphabetical:
+      order: asc
 ---
 apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: juror-api-pr
+  annotations:
+    hmcts.github.com/prod-automated: disabled
 spec:
   imageRepositoryRef:
     name: juror-api
+  filterTags:
+    extract: $ts
+    pattern: '^pr-916-[a-f0-9]+-(?P<ts>[0-9]+)'
+  policy:
+    alphabetical:
+      order: asc


### PR DESCRIPTION
### Jira link


### Change description

deployment of interim10 to ITHC only

### Testing done

deployment is for testing

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change




## 🤖AEP PR SUMMARY🤖


- `demo.yaml` 🔄 Updated the image value for Java to `sdshmctspublic.azurecr.io/juror/api:prod-b57be62-20250501130209` and set `RUN_DB_MIGRATION_ON_STARTUP` to true.
- `image-policy.yaml` 🔄 Added annotations for `hmcts.github.com/prod-automated: disabled` and updated the filterTags and policy for imageRepositoryRef name `juror-api` and `juror-api-pr`.