### PR TITLE
fix: set custom service account on libragob pod delete cron

### DIFF
--- a/apps/met/pod-delete-cron/pod-delete-cron.yaml
+++ b/apps/met/pod-delete-cron/pod-delete-cron.yaml
@@ -11,6 +11,7 @@ spec:
     schedule: "50 22 * * *"
     suspend: true
     disableActiveClusterCheck: true
+    customServiceAccountName: pod-delete-service-account
     command:
       - kubectl
     args:


### PR DESCRIPTION


## 🤖AEP PR SUMMARY🤖


### apps/met/pod-delete-cron/pod-delete-cron.yaml
- Added a new field `customServiceAccountName` with the value `pod-delete-service-account` within the `spec` section.