### PR TITLE
Starting up E2E Test harness

### DIFF
--- a/apps/darts-modernisation/darts-external-component-test-harness/test.yaml
+++ b/apps/darts-modernisation/darts-external-component-test-harness/test.yaml
@@ -7,7 +7,7 @@ spec:
   releaseName: darts-external-component-test-harness
   values:
     java:
-      replicas: 0
+      replicas: 75
       ingressHost: darts-external-component-test-harness.test.platform.hmcts.net
       environment:
         DARTS_LOG_LEVEL: INFO


### PR DESCRIPTION
Starting up E2E Test harness



## 🤖AEP PR SUMMARY🤖


### apps/darts-modernisation/darts-external-component-test-harness/test.yaml
- Changed the number of replicas from 0 to 75 for the Java component.
- Updated the ingressHost to \"darts-external-component-test-harness.test.platform.hmcts.net\".
- Set the environment variable DARTS_LOG_LEVEL to \"INFO\".