### PR TITLE
feat: use separate service account for batch jobs

### DIFF
--- a/apps/met/batch-jobs/batch-jobs-rbac.yaml
+++ b/apps/met/batch-jobs/batch-jobs-rbac.yaml
@@ -1,22 +1,22 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: libragob-pod-delete-role
+  name: libragob-batch-jobs-role
   namespace: met
 rules:
   - apiGroups: [""]
     resources: ["pods"]
-    verbs: ["delete", "get", "list", "watch"]
+    verbs: ["get", "list", "logs"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: libragob-pod-delete-role-binding
+  name: libragob-batch-jobs-role-binding
   namespace: met
 subjects:
   - kind: ServiceAccount
-    name: pod-delete-service-account
+    name: libragob-batch-jobs-service-account
 roleRef:
   kind: Role
-  name: libragob-pod-delete-role
+  name: libragob-batch-jobs-role
   apiGroup: rbac.authorization.k8s.io

--- a/apps/met/batch-jobs/batch-jobs-service-account-prod.yaml
+++ b/apps/met/batch-jobs/batch-jobs-service-account-prod.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: libragob-batch-jobs-service-account
+  namespace: met
+  annotations:
+    azure.workload.identity/client-id: "3590c75d-8ad2-4b4e-bf25-27485d807cf4"

--- a/apps/met/batch-jobs/batch-jobs-service-account-test.yaml
+++ b/apps/met/batch-jobs/batch-jobs-service-account-test.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: libragob-batch-jobs-service-account
+  namespace: met
+  annotations:
+    azure.workload.identity/client-id: "f50fe277-9215-4519-a1d4-8b88e8f7cb92"

--- a/apps/met/batch-jobs/test.yaml
+++ b/apps/met/batch-jobs/test.yaml
@@ -46,6 +46,8 @@ spec:
     image: hmctspublic.azurecr.io/libragob/ams-reporting:prod-dfe32bfc-1746608066 #{"$imagepolicy": "flux-system:libragob-batch-ams-reporting"}
     schedule: "*/15 * * * *"
     suspend: false
+    saEnabled: false
+    customServiceAccountName: libragob-batch-jobs-service-account
     keyVaults:
       libragob-test-kv:
         excludeEnvironmentSuffix: true

--- a/apps/met/prod/base/kustomization.yaml
+++ b/apps/met/prod/base/kustomization.yaml
@@ -3,6 +3,8 @@ kind: Kustomization
 resources:
   - ../../base
   - ../../batch-jobs/batch-jobs.yaml
+  - ../../batch-jobs/batch-jobs-rbac.yaml
+  - ../../batch-jobs/batch-jobs-service-account-prod.yaml
   - ../../pod-delete-cron/pod-delete-cron-rbac.yaml
   - ../../pod-delete-cron/pod-delete-cron.yaml
   - ../../pod-delete-cron/pod-delete-service-account-prod.yaml

--- a/apps/met/test/base/kustomization.yaml
+++ b/apps/met/test/base/kustomization.yaml
@@ -3,6 +3,8 @@ kind: Kustomization
 resources:
   - ../../base
   - ../../../rbac/nonprod-role.yaml
+  - ../../batch-jobs/batch-jobs-rbac.yaml
+  - ../../batch-jobs/batch-jobs-service-account-test.yaml
   - ../../batch-jobs/batch-jobs.yaml
   - ../../pod-delete-cron/pod-delete-cron-rbac.yaml
   - ../../pod-delete-cron/pod-delete-cron.yaml


### PR DESCRIPTION


## 🤖AEP PR SUMMARY🤖


- Created `batch-jobs-rbac.yaml` defining a Role and RoleBinding for managing pods in the `met` namespace.
- Added `batch-jobs-service-account-prod.yaml` to define a ServiceAccount for batch jobs in the `met` namespace, with an Azure workload identity client ID annotation.
- Added `batch-jobs-service-account-test.yaml` to define a ServiceAccount for batch jobs in the `met` namespace, with an Azure workload identity client ID annotation.
- In `test.yaml`, set `saEnabled` to false and provided a custom service account name for the batch job, in the `met` namespace.
- Updated `pod-delete-cron-rbac.yaml` to add the \"watch\" verb for pods resource, in the `met` namespace.
- In `prod/base/kustomization.yaml`, added references to the new RBAC and ServiceAccount YAML files for batch jobs in the `met` namespace.
- In `test/base/kustomization.yaml`, added references to the new RBAC and ServiceAccount YAML files for batch jobs in the `met` namespace.