### PR TITLE
Adding Keda 2.16.1 chart to all non-prod clusters

### DIFF
--- a/apps/keda/demo/base/kustomization.yaml
+++ b/apps/keda/demo/base/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
 namespace: keda
 patches:
   - path: workload-identity.yaml
+  - path: ../../keda/keda-patch.yaml

--- a/apps/keda/dev/base/kustomization.yaml
+++ b/apps/keda/dev/base/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
 namespace: keda
 patches:
   - path: workload-identity.yaml
+  - path: ../../keda/keda-patch.yaml

--- a/apps/keda/ithc/base/kustomization.yaml
+++ b/apps/keda/ithc/base/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
 namespace: keda
 patches:
   - path: workload-identity.yaml
+  - path: ../../keda/keda-patch.yaml

--- a/apps/keda/keda/keda-patch.yaml
+++ b/apps/keda/keda/keda-patch.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: keda
+  namespace: keda
+spec:
+  chart:
+    spec:
+      version: 2.16.1

--- a/apps/keda/ptlsbox/base/kustomization.yaml
+++ b/apps/keda/ptlsbox/base/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
 namespace: keda
 patches:
   - path: workload-identity.yaml
+  - path: ../../keda/keda-patch.yaml

--- a/apps/keda/sbox/base/kustomization.yaml
+++ b/apps/keda/sbox/base/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
 namespace: keda
 patches:
   - path: workload-identity.yaml
+  - path: ../../keda/keda-patch.yaml

--- a/apps/keda/stg/base/kustomization.yaml
+++ b/apps/keda/stg/base/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
 namespace: keda
 patches:
   - path: workload-identity.yaml
+  - path: ../../keda/keda-patch.yaml

--- a/apps/keda/test/base/kustomization.yaml
+++ b/apps/keda/test/base/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
 namespace: keda
 patches:
   - path: workload-identity.yaml
+  - path: ../../keda/keda-patch.yaml


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DTSPO-25374

### Change description
Adding Keda 2.16.1 chart to all non-prod clusters

## 🤖AEP PR SUMMARY🤖


- Updated multiple `kustomization.yaml` files in the `apps/keda` directory to include a new `keda-patch.yaml` path under patches
- Added a new file `keda-patch.yaml` under the `apps/keda/keda` directory containing a HelmRelease specification for Keda version 2.16.1