### PR TITLE
Reset max handheld to 10 files on prod

### DIFF
--- a/apps/darts-modernisation/darts-api/prod.yaml
+++ b/apps/darts-modernisation/darts-api/prod.yaml
@@ -21,7 +21,7 @@ spec:
         MODERNISED_DARTS_START_DATE: '2099-01-01' # MODERNISED_DARTS_START_DATE to be updated before go-live
         CASE_EXPIRY_DELETION_ENABLED: false
         MANUAL_DELETION_ENABLED: true
-        MAX_HANDHELD_AUDIO_FILES: 500 # set back to 10 after testing
+        MAX_HANDHELD_AUDIO_FILES: 10
         DARTS_API_DB_POOL_SIZE: 200
         PROCESS_E2E_ARM_RPO: true
         ARM_RPO_DURATION: 24h


### PR DESCRIPTION


## 🤖AEP PR SUMMARY🤖


### apps/darts-modernisation/darts-api/prod.yaml
- Updated the `MAX_HANDHELD_AUDIO_FILES` from 500 to 10.