### PR TITLE
feat: separate service account for libragob reporting

### DIFF
--- a/apps/met/batch-jobs/batch-jobs.yaml
+++ b/apps/met/batch-jobs/batch-jobs.yaml
@@ -37,6 +37,8 @@ spec:
     image: hmctspublic.azurecr.io/libragob/ams-reporting:prod-dfe32bfc-1746608066 #{"$imagepolicy": "flux-system:libragob-batch-ams-reporting"}
     schedule: "*/1 * * * *"
     suspend: false
+    saEnabled: false
+    customServiceAccountName: libragob-batch-jobs-service-account
     kind: CronJob
     aadIdentityName: met-schema
     global:

--- a/apps/met/batch-jobs/test.yaml
+++ b/apps/met/batch-jobs/test.yaml
@@ -46,8 +46,6 @@ spec:
     image: hmctspublic.azurecr.io/libragob/ams-reporting:prod-dfe32bfc-1746608066 #{"$imagepolicy": "flux-system:libragob-batch-ams-reporting"}
     schedule: "*/15 * * * *"
     suspend: false
-    saEnabled: false
-    customServiceAccountName: libragob-batch-jobs-service-account
     keyVaults:
       libragob-test-kv:
         excludeEnvironmentSuffix: true


### PR DESCRIPTION


## 🤖AEP PR SUMMARY🤖


- Changed `batch-jobs.yaml`:
  - Added `saEnabled: false` and `customServiceAccountName: libragob-batch-jobs-service-account` to the spec.

- Changed `test.yaml`:
  - Removed `saEnabled: false` and `customServiceAccountName: libragob-batch-jobs-service-account` from the spec.