### PR TITLE
upgrade traefik to v35.2 in sbox 00 and 01

### DIFF
--- a/apps/admin/traefik-crds-upgrade-v35/kustomization.yaml
+++ b/apps/admin/traefik-crds-upgrade-v35/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v35.2.0/traefik/crds/traefik.io_ingressroutetcps.yaml
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v35.2.0/traefik/crds/traefik.io_ingressroutes.yaml
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v35.2.0/traefik/crds/traefik.io_ingressrouteudps.yaml
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v35.2.0/traefik/crds/traefik.io_middlewares.yaml
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v35.2.0/traefik/crds/traefik.io_middlewaretcps.yaml
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v35.2.0/traefik/crds/traefik.io_serverstransports.yaml
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v35.2.0/traefik/crds/traefik.io_tlsoptions.yaml
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v35.2.0/traefik/crds/traefik.io_tlsstores.yaml
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v35.2.0/traefik/crds/traefik.io_traefikservices.yaml

--- a/apps/admin/traefik-crds-upgrade-v35/kustomize.yaml
+++ b/apps/admin/traefik-crds-upgrade-v35/kustomize.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: traefik-crd
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./apps/admin/traefik-crds-upgrade-v35

--- a/apps/admin/traefik2/sbox/00-traefik2.yaml
+++ b/apps/admin/traefik2/sbox/00-traefik2.yaml
@@ -4,6 +4,14 @@ metadata:
   name: traefik2
   namespace: admin
 spec:
+  chart:
+    spec:
+      chart: traefik
+      version: 35.2.0
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: admin
   values:
     ports:
       traefik:

--- a/apps/admin/traefik2/sbox/01-traefik2.yaml
+++ b/apps/admin/traefik2/sbox/01-traefik2.yaml
@@ -4,6 +4,14 @@ metadata:
   name: traefik2
   namespace: admin
 spec:
+  chart:
+    spec:
+      chart: traefik
+      version: 35.2.0
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: admin
   values:
     ports:
       traefik:

--- a/clusters/sbox/base/kustomization.yaml
+++ b/clusters/sbox/base/kustomization.yaml
@@ -23,3 +23,4 @@ patches:
       annotationSelector: hmcts.github.com/kustomize-defaults != disabled
   - path: ../../../apps/toffee/sbox/base/kustomize.yaml
   - path: ../../../apps/admin/sbox/base/kustomize.yaml
+  - path: ../../../apps/admin/traefik-crds-upgrade-v35/kustomize.yaml


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-25373

### Change description

upgrade traefik to v35.2.0

### Testing done

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines

## 🤖AEP PR SUMMARY🤖


ℹ️ Created `traefik-crds-upgrade-v35/kustomization.yaml` to include a list of resources from the Traefik Helm chart version 35.2.0 for CRDs upgrade.
✨ Created `traefik-crds-upgrade-v35/kustomize.yaml` to specify the interval and path for customization of Traefik CRDs upgrade.
🔄 Updated `traefik2/sbox/00-traefik2.yaml` and `traefik2/sbox/01-traefik2.yaml` to use chart version 35.2.0 from HelmRepository `traefik` in the `admin` namespace.
🔄 Updated `clusters/sbox/base/kustomization.yaml` to include a path for `traefik-crds-upgrade-v35/kustomize.yaml`.