### PR TITLE
point to newer traefik CRD v35.2 customisation files

### DIFF
--- a/apps/admin/traefik2/demo/00-traefik2.yaml
+++ b/apps/admin/traefik2/demo/00-traefik2.yaml
@@ -4,6 +4,14 @@ metadata:
   name: traefik2
   namespace: admin
 spec:
+  chart:
+    spec:
+      chart: traefik
+      version: 35.2.0
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: admin
   values:
     ports:
       traefik:

--- a/apps/admin/traefik2/demo/01-traefik2.yaml
+++ b/apps/admin/traefik2/demo/01-traefik2.yaml
@@ -4,6 +4,14 @@ metadata:
   name: traefik2
   namespace: admin
 spec:
+  chart:
+    spec:
+      chart: traefik
+      version: 35.2.0
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: admin
   values:
     ports:
       traefik:

--- a/apps/admin/traefik2/dev/00-traefik2.yaml
+++ b/apps/admin/traefik2/dev/00-traefik2.yaml
@@ -4,6 +4,14 @@ metadata:
   name: traefik2
   namespace: admin
 spec:
+  chart:
+    spec:
+      chart: traefik
+      version: 35.2.0
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: admin
   values:
     service:
       spec:

--- a/apps/admin/traefik2/dev/01-traefik2.yaml
+++ b/apps/admin/traefik2/dev/01-traefik2.yaml
@@ -4,6 +4,14 @@ metadata:
   name: traefik2
   namespace: admin
 spec:
+  chart:
+    spec:
+      chart: traefik
+      version: 35.2.0
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: admin
   values:
     service:
       spec:

--- a/apps/admin/traefik2/ithc/00-traefik2.yaml
+++ b/apps/admin/traefik2/ithc/00-traefik2.yaml
@@ -4,6 +4,14 @@ metadata:
   name: traefik2
   namespace: admin
 spec:
+  chart:
+    spec:
+      chart: traefik
+      version: 35.2.0
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: admin
   values:
     service:
       spec:

--- a/apps/admin/traefik2/ithc/01-traefik2.yaml
+++ b/apps/admin/traefik2/ithc/01-traefik2.yaml
@@ -4,6 +4,14 @@ metadata:
   name: traefik2
   namespace: admin
 spec:
+  chart:
+    spec:
+      chart: traefik
+      version: 35.2.0
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: admin
   values:
     service:
       spec:

--- a/apps/admin/traefik2/ptl/00-traefik.yaml
+++ b/apps/admin/traefik2/ptl/00-traefik.yaml
@@ -4,6 +4,14 @@ metadata:
   name: traefik2
   namespace: admin
 spec:
+  chart:
+    spec:
+      chart: traefik
+      version: 35.2.0
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: admin
   values:
     service:
       spec:

--- a/apps/admin/traefik2/ptlsbox/00-traefik.yaml
+++ b/apps/admin/traefik2/ptlsbox/00-traefik.yaml
@@ -4,6 +4,14 @@ metadata:
   name: traefik2
   namespace: admin
 spec:
+  chart:
+    spec:
+      chart: traefik
+      version: 35.2.0
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: admin
   values:
     entryPoints:
       websecure:

--- a/apps/admin/traefik2/stg/00-traefik2.yaml
+++ b/apps/admin/traefik2/stg/00-traefik2.yaml
@@ -4,6 +4,14 @@ metadata:
   name: traefik2
   namespace: admin
 spec:
+  chart:
+    spec:
+      chart: traefik
+      version: 35.2.0
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: admin
   values:
     service:
       spec:

--- a/apps/admin/traefik2/stg/01-traefik2.yaml
+++ b/apps/admin/traefik2/stg/01-traefik2.yaml
@@ -4,6 +4,14 @@ metadata:
   name: traefik2
   namespace: admin
 spec:
+  chart:
+    spec:
+      chart: traefik
+      version: 35.2.0
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: admin
   values:
     service:
       spec:

--- a/apps/admin/traefik2/test/00-traefik2.yaml
+++ b/apps/admin/traefik2/test/00-traefik2.yaml
@@ -4,6 +4,14 @@ metadata:
   name: traefik2
   namespace: admin
 spec:
+  chart:
+    spec:
+      chart: traefik
+      version: 35.2.0
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: admin
   values:
     service:
       spec:

--- a/apps/admin/traefik2/test/01-traefik2.yaml
+++ b/apps/admin/traefik2/test/01-traefik2.yaml
@@ -4,6 +4,14 @@ metadata:
   name: traefik2
   namespace: admin
 spec:
+  chart:
+    spec:
+      chart: traefik
+      version: 35.2.0
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: admin
   values:
     service:
       spec:

--- a/clusters/demo/base/kustomization.yaml
+++ b/clusters/demo/base/kustomization.yaml
@@ -22,3 +22,4 @@ patches:
       annotationSelector: hmcts.github.com/kustomize-defaults != disabled
   - path: ../../../apps/toffee/demo/base/kustomize.yaml
   - path: ../../../apps/admin/demo/base/kustomize.yaml
+  - path: ../../../apps/admin/traefik-crds-upgrade-v35/kustomize.yaml

--- a/clusters/dev/base/kustomization.yaml
+++ b/clusters/dev/base/kustomization.yaml
@@ -31,3 +31,4 @@ patches:
       annotationSelector: hmcts.github.com/kustomize-defaults != disabled
   - path: ../../../apps/toffee/dev/base/kustomize.yaml
   - path: ../../../apps/admin/dev/base/kustomize.yaml
+  - path: ../../../apps/admin/traefik-crds-upgrade-v35/kustomize.yaml

--- a/clusters/ithc/base/kustomization.yaml
+++ b/clusters/ithc/base/kustomization.yaml
@@ -25,3 +25,4 @@ patches:
   - path: ../../../apps/toffee/ithc/base/kustomize.yaml
   - path: ../../../apps/admin/ithc/base/kustomize.yaml
   - path: ../../../apps/neuvector/crds/kustomize.yaml
+  - path: ../../../apps/admin/traefik-crds-upgrade-v35/kustomize.yaml

--- a/clusters/ptl/base/kustomization.yaml
+++ b/clusters/ptl/base/kustomization.yaml
@@ -16,3 +16,4 @@ patches:
       kind: Kustomization
       annotationSelector: hmcts.github.com/kustomize-defaults != disabled
   - path: ../../../apps/admin/ptl/base/kustomize.yaml
+  - path: ../../../apps/admin/traefik-crds-upgrade-v35/kustomize.yaml

--- a/clusters/ptlsbox/base/kustomization.yaml
+++ b/clusters/ptlsbox/base/kustomization.yaml
@@ -16,3 +16,4 @@ patches:
       kind: Kustomization
       annotationSelector: hmcts.github.com/kustomize-defaults != disabled
   - path: ../../../apps/admin/ptlsbox/base/kustomize.yaml
+  - path: ../../../apps/admin/traefik-crds-upgrade-v35/kustomize.yaml

--- a/clusters/stg/base/kustomization.yaml
+++ b/clusters/stg/base/kustomization.yaml
@@ -30,3 +30,4 @@ patches:
   - path: ../../../apps/toffee/stg/base/kustomize.yaml
   - path: ../../../apps/admin/stg/base/kustomize.yaml
   - path: ../../../apps/neuvector/crds/kustomize.yaml
+  - path: ../../../apps/admin/traefik-crds-upgrade-v35/kustomize.yaml

--- a/clusters/test/base/kustomization.yaml
+++ b/clusters/test/base/kustomization.yaml
@@ -28,3 +28,4 @@ patches:
   - path: ../../../apps/toffee/test/base/kustomize.yaml
   - path: ../../../apps/admin/test/base/kustomize.yaml
   - path: ../../../apps/neuvector/crds/kustomize.yaml
+  - path: ../../../apps/admin/traefik-crds-upgrade-v35/kustomize.yaml


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-25373

### Change description

upgrade traefik crds to v35.2 in NLEs e.g. test, stg, ptl, ptlbox, etc

### Testing done


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines

## 🤖AEP PR SUMMARY🤖


- Updated multiple YAML files in `apps/admin/traefik2/` with a new chart configuration for Traefik version 35.2.0 and source reference
- Updated multiple YAML files in `clusters/` with a path to `apps/admin/traefik-crds-upgrade-v35/kustomize.yaml` for different environments: demo, dev, ithc, ptl, ptlsbox, stg, test