### PR TITLE
Juror deploys into ITHC and Demo

### DIFF
--- a/apps/juror/juror-api/demo.yaml
+++ b/apps/juror/juror-api/demo.yaml
@@ -8,7 +8,7 @@ spec:
   values:
     java:
       # Uncomment and edit the line below to fix the environment at a specific image
-      image: sdshmctspublic.azurecr.io/juror/api:prod-b57be62-20250501130209
+      image: sdshmctspublic.azurecr.io/juror/api:prod-b57be62-20250501130209 # {"$imagepolicy": "flux-system:juror-api-pr"}
       ingressHost: juror-api.demo.platform.hmcts.net
       environment:
         RUN_DB_MIGRATION_ON_STARTUP: true

--- a/apps/juror/juror-api/image-policy.yaml
+++ b/apps/juror/juror-api/image-policy.yaml
@@ -2,14 +2,30 @@ apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: juror-api
+  annotations:
+    hmcts.github.com/prod-automated: disabled
 spec:
+  filterTags:
+    extract: $ts
+    pattern: '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'
   imageRepositoryRef:
     name: juror-api
+  policy:
+    alphabetical:
+      order: asc
 ---
 apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: juror-api-pr
+  annotations:
+    hmcts.github.com/prod-automated: disabled
 spec:
   imageRepositoryRef:
     name: juror-api
+  filterTags:
+    extract: $ts
+    pattern: '^pr-922-[a-f0-9]+-(?P<ts>[0-9]+)'
+  policy:
+    alphabetical:
+      order: asc

--- a/apps/juror/juror-bureau/image-policy.yaml
+++ b/apps/juror/juror-bureau/image-policy.yaml
@@ -2,14 +2,30 @@ apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: juror-bureau
+  annotations:
+    hmcts.github.com/prod-automated: disabled
 spec:
+  filterTags:
+    extract: $ts
+    pattern: '^prod-[a-f0-9]+-(?P<ts>[0-9]+)'
   imageRepositoryRef:
     name: juror-bureau
+  policy:
+    alphabetical:
+      order: asc
 ---
 apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
   name: juror-bureau-pr
+  annotations:
+    hmcts.github.com/prod-automated: disabled
 spec:
   imageRepositoryRef:
     name: juror-bureau
+  filterTags:
+    extract: $ts
+    pattern: '^pr-941-[a-f0-9]+-(?P<ts>[0-9]+)'
+  policy:
+    alphabetical:
+      order: asc


### PR DESCRIPTION
### Jira link

### Change description

deployment of juror release5.7 into ITHC and Demo

### Testing done

deployment is for testing

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change




## 🤖AEP PR SUMMARY🤖


- Updated demo.yaml``` in ```juror-api```:
  - Changed the Java image to ```sdshmctspublic.azurecr.io/juror/api:prod-b57be62-20250501130209```.

- Updated ```image-policy.yaml``` in ```juror-api``` and ```juror-bureau```:
  - Added annotations for disabling automated production.
  - Added filter tags for extracting timestamps.
  - Applied an alphabetical order policy for image tagging.