### PR TITLE
Stop the test harness

### DIFF
--- a/apps/darts-modernisation/darts-external-component-test-harness/test.yaml
+++ b/apps/darts-modernisation/darts-external-component-test-harness/test.yaml
@@ -7,7 +7,7 @@ spec:
   releaseName: darts-external-component-test-harness
   values:
     java:
-      replicas: 75
+      replicas: 0
       ingressHost: darts-external-component-test-harness.test.platform.hmcts.net
       environment:
         DARTS_LOG_LEVEL: INFO


### PR DESCRIPTION
Stop the test harness





## 🤖AEP PR SUMMARY🤖


- The file `test.yaml` in `darts-external-component-test-harness` has been modified.
- The `replicas` value for `java` has been changed from 75 to 0.