### PR TITLE
feat: exclude darts-automation from DARTs dashboard

### DIFF
--- a/apps/jenkins/jenkins/ptl/jenkins.yaml
+++ b/apps/jenkins/jenkins/ptl/jenkins.yaml
@@ -201,7 +201,7 @@ spec:
                     title: DTS Legacy Apps
                 - buildMonitor:
                     includeRegex: >-
-                      ^HMCTS.*\/darts.*\/master
+                      ^HMCTS.*\/darts(?!-automation\/).*\/master
                     name: DARTS Modernisation
                     recurse: true
                     title: DARTS Modernisastion


### PR DESCRIPTION
### Jira link

N/A

### Change description

Update DARTs dashboard regex to exclude darts-automation.

<!--
Provide a description of what change you are proposing.
A short summary here and then you can add comments in your pull request explaining your change to others.
-->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


- **jenkins.yaml**
  - Changed the `includeRegex` for `buildMonitor` to exclude `HMCTS.*\/darts-automation` branches from DARTS Modernisation.