### PR TITLE
PRE: Increase memory limit on cleanup live event cron

### DIFF
--- a/apps/pre/pre-api-cron-cleanup-live-events/pre-api-cron-cleanup-live-events.yaml
+++ b/apps/pre/pre-api-cron-cleanup-live-events/pre-api-cron-cleanup-live-events.yaml
@@ -8,6 +8,7 @@ spec:
   values:
     java:
       enabled: false
+      memoryLimits: '4Gi'
     job:
       enabled: true
       environment:

--- a/apps/pre/pre-api-cron-cleanup-live-events/pre-api-cron-cleanup-live-events.yaml
+++ b/apps/pre/pre-api-cron-cleanup-live-events/pre-api-cron-cleanup-live-events.yaml
@@ -8,7 +8,6 @@ spec:
   values:
     java:
       enabled: false
-      memoryLimits: '4Gi'
     job:
       enabled: true
       environment:

--- a/apps/pre/pre-api-cron-cleanup-live-events/test.yaml
+++ b/apps/pre/pre-api-cron-cleanup-live-events/test.yaml
@@ -10,7 +10,7 @@ spec:
     job:
       memoryRequests: '1Gi'
       memoryLimits: '2Gi'
-      schedule: "15 15 * * *" # 15:15 PM UTC
+      schedule: "16 30 * * *" # 16:30 PM UTC
       image: sdshmctspublic.azurecr.io/pre/api:pr-921-9dc0127-20250430125058 # {"$imagepolicy": "flux-system:test-pre-api-cron-cleanup-live-events"}
       environment:
         AZURE_SUBSCRIPTION_ID: 3eec5bde-7feb-4566-bfb6-805df6e10b90

--- a/apps/pre/pre-api-cron-cleanup-live-events/test.yaml
+++ b/apps/pre/pre-api-cron-cleanup-live-events/test.yaml
@@ -10,7 +10,7 @@ spec:
     job:
       memoryRequests: '1Gi'
       memoryLimits: '2Gi'
-      schedule: "16 30 * * *" # 16:30 PM UTC
+      schedule: "30 16 * * *" # 16:30 PM UTC
       image: sdshmctspublic.azurecr.io/pre/api:pr-921-9dc0127-20250430125058 # {"$imagepolicy": "flux-system:test-pre-api-cron-cleanup-live-events"}
       environment:
         AZURE_SUBSCRIPTION_ID: 3eec5bde-7feb-4566-bfb6-805df6e10b90

--- a/apps/pre/pre-api-cron-cleanup-live-events/test.yaml
+++ b/apps/pre/pre-api-cron-cleanup-live-events/test.yaml
@@ -8,6 +8,8 @@ spec:
     global:
       jobKind: CronJob
     job:
+      memoryRequests: '1Gi'
+      memoryLimits: '2Gi'
       schedule: "15 15 * * *" # 15:15 PM UTC
       image: sdshmctspublic.azurecr.io/pre/api:pr-921-9dc0127-20250430125058 # {"$imagepolicy": "flux-system:test-pre-api-cron-cleanup-live-events"}
       environment:


### PR DESCRIPTION
### Jira link

<!-- 
Replace S28-3665 with your Jira key
Remove this section if its not applicable, or replace it with another reference link
-->
See [S28-3665](https://tools.hmcts.net/jira/browse/S28-3665)

### Change description
Increase memory limit on CleanupLiveEvents cron from 1Gi to 2Gi in test env
Increase memory request on CleanupLiveEvents cron from 512Mi to 1Gi in test env



<!--
Provide a description of what change you are proposing.
A short summary here and then you can add comments in your pull request explaining your change to others.
-->





## 🤖AEP PR SUMMARY🤖


### apps/pre/pre-api-cron-cleanup-live-events/test.yaml
- Changed job schedule from \"15 15 * * *\" to \"30 16 * * *\"
- Added memory requests: '1Gi'
- Added memory limits: '2Gi'