### PR TITLE
Stop the test harness

### DIFF
--- a/apps/darts-modernisation/darts-external-component-test-harness/test.yaml
+++ b/apps/darts-modernisation/darts-external-component-test-harness/test.yaml
@@ -7,7 +7,7 @@ spec:
   releaseName: darts-external-component-test-harness
   values:
     java:
-      replicas: 75
+      replicas: 0
       ingressHost: darts-external-component-test-harness.test.platform.hmcts.net
       environment:
         DARTS_LOG_LEVEL: INFO


### PR DESCRIPTION
Stop the test harness

## 🤖AEP PR SUMMARY🤖


### apps/darts-modernisation/darts-external-component-test-harness/test.yaml
- Reduced number of replicas from 75 to 0 for the `java` service.
- Updated `ingressHost` to `darts-external-component-test-harness.test.platform.hmcts.net`.
- Set environment variable `DARTS_LOG_LEVEL` to `INFO`.