### PR TITLE
DTSPO-25673 temporarily disbling pdb for cluster upgrade

### DIFF
--- a/apps/darts-modernisation/darts-external-component-test-harness/darts-external-component-test-harness.yaml
+++ b/apps/darts-modernisation/darts-external-component-test-harness/darts-external-component-test-harness.yaml
@@ -18,3 +18,5 @@ spec:
       image: sdshmctspublic.azurecr.io/darts/external-component-test-harness:prod-41eda30-20250514095538 # {"$imagepolicy": "flux-system:darts-external-component-test-harness"}
       disableTraefikTls: true
       replicas: 0
+      pdb:
+        enabled: false

--- a/apps/pip/subscription-management/pip-subscription-management.yaml
+++ b/apps/pip/subscription-management/pip-subscription-management.yaml
@@ -8,6 +8,8 @@ spec:
     java:
       image: sdshmctspublic.azurecr.io/pip/subscription-management:prod-1a26480-20250414145100 # {"$imagepolicy": "flux-system:pip-subscription-management"}
       disableTraefikTls: true
+      pdb:
+        enabled: false
   chart:
     spec:
       chart: ./stable/pip-subscription-management


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-25673

### Change description

Temporarily disabling pdb for these two services for SDS ITHC cluster upgrade.
This will be reverted once the upgrade is completed.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change




## 🤖AEP PR SUMMARY🤖


### apps/darts-modernisation/darts-external-component-test-harness/darts-external-component-test-harness.yaml
- Enabled pdb key with value `false`.

### apps/pip/subscription-management/pip-subscription-management.yaml
- Enabled pdb key with value `false`.