### PR TITLE
set image policy to latest pr-921

### DIFF
--- a/apps/pre/pre-api-cron-cleanup-live-events/test-image-policy.yaml
+++ b/apps/pre/pre-api-cron-cleanup-live-events/test-image-policy.yaml
@@ -6,8 +6,7 @@ metadata:
     hmcts.github.com/prod-automated: disabled
 spec:
   filterTags:
-    pattern: '^pr-921-[a-f0-9]+-(?P<ts>[0-9]+)'
-    extract: '$ts'
+    pattern: 'pr\-921\-3a04c4e\-20250516081344'
   policy:
     alphabetical:
       order: asc

--- a/apps/pre/pre-api-cron-cleanup-live-events/test.yaml
+++ b/apps/pre/pre-api-cron-cleanup-live-events/test.yaml
@@ -10,7 +10,7 @@ spec:
     job:
       memoryRequests: '1Gi'
       memoryLimits: '2Gi'
-      schedule: "30 15 * * *" # 11:30 AM UTC
+      schedule: "30 9 * * *" # 9:30 AM UTC
       image: sdshmctspublic.azurecr.io/pre/api:pr-921-3a04c4e-20250516081344 # {"$imagepolicy": "flux-system:test-pre-api-cron-cleanup-live-events"}
       environment:
         AZURE_SUBSCRIPTION_ID: 3eec5bde-7feb-4566-bfb6-805df6e10b90


### PR DESCRIPTION




## 🤖AEP PR SUMMARY🤖


### apps/pre/pre-api-cron-cleanup-live-events/test-image-policy.yaml
- Removed the old pattern and extract rules and added a new pattern rule for test-image-policy.yaml.

### apps/pre/pre-api-cron-cleanup-live-events/test.yaml
- Updated the schedule from \"30 15 * * *\" to \"30 9 * * *\" in test.yaml.