### PR TITLE
Push patch for dynatrace to rest of nle

### DIFF
--- a/apps/dynatrace/demo/base/kustomization.yaml
+++ b/apps/dynatrace/demo/base/kustomization.yaml
@@ -7,3 +7,5 @@ resources:
 namespace: dynatrace
 patches:
   - path: dynakube.yaml
+  - path: ../../dynatrace-operator-upgrade.yaml
+  - path: ../../dynatrace-operator-helmrepo-upgrade.yaml

--- a/apps/dynatrace/demo/base/kustomize.yaml
+++ b/apps/dynatrace/demo/base/kustomize.yaml
@@ -1,0 +1,24 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: dynatrace
+  namespace: flux-system
+spec:
+  interval: 10m
+  dependsOn:
+    - name: dynatrace-crd
+  path: ./apps/dynatrace/${ENVIRONMENT}/${CLUSTER}
+  postBuild:
+    substitute:
+      NAMESPACE: "dynatrace"
+      TEAM_NOTIFICATION_CHANNEL: "${ENV_MONITOR_CHANNEL}"
+      CLUSTER_FULL_NAME: "${ENVIRONMENT}-${CLUSTER}"
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: dynatrace-crd
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./apps/dynatrace/dynatrace-crds-upgrade

--- a/apps/dynatrace/stg/base/kustomization.yaml
+++ b/apps/dynatrace/stg/base/kustomization.yaml
@@ -7,3 +7,5 @@ resources:
 namespace: dynatrace
 patches:
   - path: dynakube.yaml
+  - path: ../../dynatrace-operator-upgrade.yaml
+  - path: ../../dynatrace-operator-helmrepo-upgrade.yaml

--- a/apps/dynatrace/stg/base/kustomize.yaml
+++ b/apps/dynatrace/stg/base/kustomize.yaml
@@ -1,0 +1,24 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: dynatrace
+  namespace: flux-system
+spec:
+  interval: 10m
+  dependsOn:
+    - name: dynatrace-crd
+  path: ./apps/dynatrace/${ENVIRONMENT}/${CLUSTER}
+  postBuild:
+    substitute:
+      NAMESPACE: "dynatrace"
+      TEAM_NOTIFICATION_CHANNEL: "${ENV_MONITOR_CHANNEL}"
+      CLUSTER_FULL_NAME: "${ENVIRONMENT}-${CLUSTER}"
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: dynatrace-crd
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./apps/dynatrace/dynatrace-crds-upgrade

--- a/clusters/demo/base/kustomization.yaml
+++ b/clusters/demo/base/kustomization.yaml
@@ -22,3 +22,4 @@ patches:
       annotationSelector: hmcts.github.com/kustomize-defaults != disabled
   - path: ../../../apps/toffee/demo/base/kustomize.yaml
   - path: ../../../apps/admin/demo/base/kustomize.yaml
+  - path: ../../../apps/dynatrace/demo/base/kustomize.yaml

--- a/clusters/stg/base/kustomization.yaml
+++ b/clusters/stg/base/kustomization.yaml
@@ -29,3 +29,4 @@ patches:
   - path: ../../../apps/toffee/stg/base/kustomize.yaml
   - path: ../../../apps/admin/stg/base/kustomize.yaml
   - path: ../../../apps/neuvector/crds/kustomize.yaml
+  - path: ../../../apps/dynatrace/stg/base/kustomize.yaml


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-25380


### Change description

Push patch for dynatrace to rest of nle

### Testing done

test env working


## 🤖AEP PR SUMMARY🤖


- Added/modified kustomization.yaml in apps/dynatrace/demo/base and apps/dynatrace/stg/base to include paths for dynatrace-operator-upgrade.yaml and dynatrace-operator-helmrepo-upgrade.yaml, and added a new file apps/dynatrace/demo/base/kustomize.yaml
- Added a new file apps/dynatrace/stg/base/kustomize.yaml
- Updated clusters/demo/base/kustomization.yaml and clusters/stg/base/kustomization.yaml to include path for apps/dynatrace/demo/base/kustomize.yaml and apps/dynatrace/stg/base/kustomize.yaml