### PR TITLE
Revert "DTSPO-25673 temporarily disbling pdb for cluster upgrade"

### DIFF
--- a/apps/darts-modernisation/darts-external-component-test-harness/darts-external-component-test-harness.yaml
+++ b/apps/darts-modernisation/darts-external-component-test-harness/darts-external-component-test-harness.yaml
@@ -18,5 +18,3 @@ spec:
       image: sdshmctspublic.azurecr.io/darts/external-component-test-harness:prod-2880321-20250515204034 # {"$imagepolicy": "flux-system:darts-external-component-test-harness"}
       disableTraefikTls: true
       replicas: 0
-      pdb:
-        enabled: false

--- a/apps/pip/subscription-management/pip-subscription-management.yaml
+++ b/apps/pip/subscription-management/pip-subscription-management.yaml
@@ -8,8 +8,6 @@ spec:
     java:
       image: sdshmctspublic.azurecr.io/pip/subscription-management:prod-1a26480-20250414145100 # {"$imagepolicy": "flux-system:pip-subscription-management"}
       disableTraefikTls: true
-      pdb:
-        enabled: false
   chart:
     spec:
       chart: ./stable/pip-subscription-management


### PR DESCRIPTION
Reverts hmcts/sds-flux-config#6586









## 🤖AEP PR SUMMARY🤖


- `darts-external-component-test-harness.yaml` 🛠️ Removed the PDB configuration and its related block.
- `pip-subscription-management.yaml` 🛠️ Removed the PDB configuration and its related block.