### PR TITLE
PRE: Increase Memory for StartLiveEvents cron in all Envs

### DIFF
--- a/apps/pre/pre-api-cron-start-live-events/pre-api-cron-start-live-events.yaml
+++ b/apps/pre/pre-api-cron-start-live-events/pre-api-cron-start-live-events.yaml
@@ -10,6 +10,8 @@ spec:
       enabled: false
     job:
       enabled: true
+      memoryRequests: '1Gi'
+      memoryLimits: '2Gi'
       environment:
         TASK_NAME: StartLiveEvents
   chart:

--- a/apps/pre/pre-api-cron-start-live-events/test.yaml
+++ b/apps/pre/pre-api-cron-start-live-events/test.yaml
@@ -8,8 +8,6 @@ spec:
     global:
       jobKind: CronJob
     job:
-      memoryRequests: '1Gi'
-      memoryLimits: '2Gi'
       suspend: false
       schedule: "00 13 * * *"
       image: sdshmctspublic.azurecr.io/pre/api:pr-920-51b5474-20250519091257 # {"$imagepolicy": "flux-system:test-pre-api-cron-start-live-events"}


### PR DESCRIPTION
### Jira link

<!-- 
Replace PROJ-XXXXXX with your Jira key
Remove this section if its not applicable, or replace it with another reference link

See [PROJ-XXXXXX](https://tools.hmcts.net/jira/browse/PROJ-XXXXXX)
-->

### Change description
- Increase memory for StartLiveEvents cron in all envs


## 🤖AEP PR SUMMARY🤖


ℹ️  **apps/pre/pre-api-cron-start-live-events/pre-api-cron-start-live-events.yaml**
- Increased memory requests to '1Gi' and memory limits to '2Gi' for the enabled job.

  **apps/pre/pre-api-cron-start-live-events/test.yaml**
- Removed memory requests and memory limits for the job. Updated the schedule to run at 13:00 daily.