### PR TITLE
DTSPO-25685 Update Jenkins vars for STG_AKS to 01

### DIFF
--- a/apps/jenkins/jenkins/ptl/jenkins.yaml
+++ b/apps/jenkins/jenkins/ptl/jenkins.yaml
@@ -55,9 +55,9 @@ spec:
                       - key: PTL_AKS_RESOURCE_GROUP
                         value: ss-ptl-00-rg
                       - key: STG_AKS_CLUSTER_NAME
-                        value: ss-stg-00-aks
+                        value: ss-stg-01-aks
                       - key: STG_AKS_RESOURCE_GROUP
-                        value: ss-stg-00-rg
+                        value: ss-stg-01-rg
                       - key: DEV_AKS_CLUSTER_NAME
                         value: ss-dev-01-aks
                       - key: DEV_AKS_RESOURCE_GROUP


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-25685

### Change description

Update jenkins global vars for sds stg cluster to use 01.  

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change






## 🤖AEP PR SUMMARY🤖


### apps/jenkins/jenkins/ptl/jenkins.yaml
- Updated the value of `STG_AKS_CLUSTER_NAME` from `ss-stg-00-aks` to `ss-stg-01-aks`.
- Updated the value of `STG_AKS_RESOURCE_GROUP` from `ss-stg-00-rg` to `ss-stg-01-rg`.