### PR TITLE
fixing secret name

### DIFF
--- a/apps/monitoring/version-reporter/ptl/version-reporter.enc.yaml
+++ b/apps/monitoring/version-reporter/ptl/version-reporter.enc.yaml
@@ -7,7 +7,7 @@ data:
 kind: Secret
 metadata:
   creationTimestamp: null
-  name: postgres
+  name: version-reporter
   namespace: monitoring
 type: Opaque
 sops:


### PR DESCRIPTION
Fix secret name

## 🤖AEP PR SUMMARY🤖


### apps/monitoring/version-reporter/ptl/version-reporter.enc.yaml
- Changed the `name` field from `postgres` to `version-reporter` in the `data` section.