### PR TITLE
Revert "Update strategy"

### DIFF
--- a/apps/azureserviceoperator-system/aso-upgrade/kustomization.yaml
+++ b/apps/azureserviceoperator-system/aso-upgrade/kustomization.yaml
@@ -17,9 +17,8 @@ patches:
     target:
       kind: Deployment
   - patch: |-
-      - op: replace
-        path: /spec/replicas
-        value: 1
+      - op: remove
+        path: /spec/strategy
     target:
       kind: Deployment
       name: azureserviceoperator-controller-manager


### PR DESCRIPTION
Reverts hmcts/sds-flux-config#6675


Having this as "Recreate" is what's intended by ASO for the HA changes to work... But it also breaks our kustomization object - have raised a few issues in ASO but may have to wait to hear back for a feature flag in a new release to make those changes optional