### PR TITLE
Change flux-config-gitrepo (sds-flux-config) back to SSH auth to fix …

### DIFF
--- a/apps/flux-system/base/flux-config-gitrepo.yaml
+++ b/apps/flux-system/base/flux-config-gitrepo.yaml
@@ -9,7 +9,6 @@ spec:
   timeout: 3m0s
   ref:
     branch: master
-  provider: github
   secretRef:
-    name: github-app-credentials
-  url: https://github.com/hmcts/sds-flux-config
+    name: git-credentials
+  url: ssh://git@github.com/hmcts/sds-flux-config


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DTSPO-24241

Revert flux config repo back to SSH authentication to fix image automation controller which is not able to make writes and update versions at the moment.
Looks like I have installed the GitHub apps in the wrong space - hmcts platops account instead of hmcts org and will need to transfer them over.

### Testing done
N/A

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
