### PR TITLE
fix: update cleanup crons to run earlier

### DIFF
--- a/apps/pre/pre-api-cron-cleanup-live-events/stg.yaml
+++ b/apps/pre/pre-api-cron-cleanup-live-events/stg.yaml
@@ -8,7 +8,7 @@ spec:
     global:
       jobKind: CronJob
     job:
-      schedule: "0 19 * * *" # 7pm UTC
+      schedule: "0 18 * * *" # 6pm UTC
       image: sdshmctspublic.azurecr.io/pre/api:prod-34c944f-20250613110758 # {"$imagepolicy": "flux-system:pre-api"}
       environment:
         AZURE_SUBSCRIPTION_ID: 74dacd4f-a248-45bb-a2f0-af700dc4cf68

--- a/apps/pre/pre-api-cron-cleanup-streaming-locators/stg.yaml
+++ b/apps/pre/pre-api-cron-cleanup-streaming-locators/stg.yaml
@@ -8,7 +8,7 @@ spec:
     global:
       jobKind: CronJob
     job:
-      schedule: "10 19 * * *" # 7:10 PM UTC
+      schedule: "10 18 * * *" # 6:10 PM UTC
       image: sdshmctspublic.azurecr.io/pre/api:prod-34c944f-20250613110758 # {"$imagepolicy": "flux-system:pre-api"}
       environment:
         AZURE_SUBSCRIPTION_ID: 74dacd4f-a248-45bb-a2f0-af700dc4cf68


### PR DESCRIPTION
### Jira link

<!-- 
Replace PROJ-XXXXXX with your Jira key
Remove this section if its not applicable, or replace it with another reference link
-->
See [PROJ-XXXXXX](https://tools.hmcts.net/jira/browse/PROJ-XXXXXX)

### Change description
Updates cleanup-live-events and cleanup-streaming-locators crons to run 1 hr earlier to avoid env shutdown