### PR TITLE
DTSPO-22833 - Add pods log resource

### DIFF
--- a/apps/met/batch-jobs/batch-jobs-rbac.yaml
+++ b/apps/met/batch-jobs/batch-jobs-rbac.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: met
 rules:
   - apiGroups: [""]
-    resources: ["pods"]
+    resources: ["pods", "pods/log"]
     verbs: ["get", "list", "logs"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
### Jira link

See [DTSPO-22833](https://tools.hmcts.net/jira/browse/DTSPO-22833)

### Change description

Add missing pods/log resource to fix error:

```
User "system:serviceaccount:met:libragob-batch-jobs-service-account" cannot get resource "pods/log" in API group "" in the namespace "met"
```

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


- Updated file: `batch-jobs-rbac.yaml`
- Added `\"pods/log\"` to the list of resources under the `pods` section with the `verbs` \"get\", \"list\", \"logs\".