### PR TITLE
Set azure functions test to update to latest pr

### DIFF
--- a/apps/mi/mi-azure-functions/image-policy.yaml
+++ b/apps/mi/mi-azure-functions/image-policy.yaml
@@ -27,3 +27,19 @@ spec:
   policy:
     alphabetical:
       order: asc
+---
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImagePolicy
+metadata:
+  name: mi-azure-functions-qa
+  annotations:
+    hmcts.github.com/prod-automated: disabled
+spec:
+  imageRepositoryRef:
+    name: mi-azure-functions
+  filterTags:
+    extract: $ts
+    pattern: '^test-[a-f0-9]+-(?P<ts>[0-9]+-[0-9]+)'
+  policy:
+    alphabetical:
+      order: asc

--- a/apps/mi/mi-azure-functions/test.yaml
+++ b/apps/mi/mi-azure-functions/test.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   releaseName: mi-azure-functions
   values:
-    image: sdshmctspublic.azurecr.io/mi/azure-functions:test-026ced4-20250620091502 #{"$imagepolicy": "flux-system:mi-azure-functions"}
+    image: sdshmctspublic.azurecr.io/mi/azure-functions:test-026ced4-20250620091502 #{"$imagepolicy": "flux-system:mi-azure-functions-qa"}
     env:
       ADF_RESOURCEGROUP: mi-ingestion-test-rg
       ADF_NAME: mi-ingestion-adf-test

--- a/apps/mi/mi-azure-functions/test.yaml
+++ b/apps/mi/mi-azure-functions/test.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   releaseName: mi-azure-functions
   values:
-    image: sdshmctspublic.azurecr.io/mi/azure-functions:test-9099fba-20250613132610
+    image: sdshmctspublic.azurecr.io/mi/azure-functions:test-026ced4-20250620091502 #{"$imagepolicy": "flux-system:mi-azure-functions"}
     env:
       ADF_RESOURCEGROUP: mi-ingestion-test-rg
       ADF_NAME: mi-ingestion-adf-test


### PR DESCRIPTION
To assist with testing azure functions on test environment





## 🤖AEP PR SUMMARY🤖


md
- image-policy.yaml
  - Added a new ImagePolicy for mi-azure-functions-qa with filterTags and policy settings
- test.yaml
  - Updated the image tag for mi-azure-functions to test-026ced4-20250620091502
```