### PR TITLE
Updated flux config for Court Fines

### DIFF
--- a/apps/courtfines/automation/kustomization.yaml
+++ b/apps/courtfines/automation/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../courtfines-app/image-repo.yaml
+  - ../courtfines-app/image-policy.yaml

--- a/apps/courtfines/base/kustomization.yaml
+++ b/apps/courtfines/base/kustomization.yaml
@@ -3,4 +3,5 @@ kind: Kustomization
 resources:
   - ../../base
   - ../../base/workload-identity
+  - ../courtfines-app/courtfines-app.yaml
 namespace: courtfines

--- a/apps/courtfines/courtfines-app/courtfines-app.yaml
+++ b/apps/courtfines/courtfines-app/courtfines-app.yaml
@@ -1,0 +1,20 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: courtfines-app
+  namespace: courtfines
+spec:
+  releaseName: courtfines-app
+  chart:
+    spec:
+      chart: ./stable/courtfines-app
+      sourceRef:
+        kind: GitRepository
+        name: hmcts-charts
+        namespace: flux-system
+      interval: 1m
+  values:
+    nodejs:
+      replicas: 2
+      image: sdshmctspublic.azurecr.io/courtfines/app:prod-bea5b8a-20250619161653 # {"$imagepolicy": "flux-system:courtfines-app"}
+      disableTraefikTls: true

--- a/apps/courtfines/courtfines-app/image-policy.yaml
+++ b/apps/courtfines/courtfines-app/image-policy.yaml
@@ -1,0 +1,7 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImagePolicy
+metadata:
+  name: courtfines-app
+spec:
+  imageRepositoryRef:
+    name: courtfines-app

--- a/apps/courtfines/courtfines-app/image-repo.yaml
+++ b/apps/courtfines/courtfines-app/image-repo.yaml
@@ -1,0 +1,6 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImageRepository
+metadata:
+  name: courtfines-app
+spec:
+  image: sdshmctspublic.azurecr.io/courtfines/app

--- a/apps/courtfines/serviceaccount/test.yaml
+++ b/apps/courtfines/serviceaccount/test.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ${NAMESPACE}
+  namespace: ${NAMESPACE}
+  annotations:
+    azure.workload.identity/client-id: "727aa8bc-36f6-4790-bc22-37cda798eebf"

--- a/apps/courtfines/stg/base/kustomization.yaml
+++ b/apps/courtfines/stg/base/kustomization.yaml
@@ -4,3 +4,5 @@ resources:
   - ../../base
   - ../../../rbac/nonprod-role.yaml
 namespace: courtfines
+patches:
+  - path: ../../serviceaccount/stg.yaml

--- a/apps/courtfines/test/base/kustomization.yaml
+++ b/apps/courtfines/test/base/kustomization.yaml
@@ -2,4 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
+  - ../../../rbac/nonprod-role.yaml
 namespace: courtfines
+patches:
+  - path: ../../serviceaccount/test.yaml

--- a/apps/flux-system/automation/kustomization.yaml
+++ b/apps/flux-system/automation/kustomization.yaml
@@ -19,6 +19,7 @@ resources:
   - ../../opal/automation
   - ../../met/automation
   - ../../pdda/automation
+  - ../../courtfines/automation
 patches:
   - path: sdshmctspublic-image-repo.yaml
     target:

--- a/clusters/prod/base/kustomization.yaml
+++ b/clusters/prod/base/kustomization.yaml
@@ -21,7 +21,6 @@ resources:
   - ../../../apps/hmi/base/kustomize.yaml
   - ../../../apps/juror/base/kustomize.yaml
   - ../../../apps/darts-modernisation/base/kustomize.yaml
-  - ../../../apps/courtfines/base/kustomize.yaml
 patches:
   - path: ../../../apps/base/kustomize.yaml
     target:

--- a/clusters/test/base/kustomization.yaml
+++ b/clusters/test/base/kustomization.yaml
@@ -19,6 +19,7 @@ resources:
   - ../../../apps/keda/base/kustomize.yaml
   - ../../../apps/pre/base/kustomize.yaml
   - ../../../apps/juror/base/kustomize.yaml
+  - ../../../apps/courtfines/base/kustomize.yaml
 patches:
   - path: ../../../apps/base/kustomize.yaml
     target:


### PR DESCRIPTION
Updated flux config for Court Fines











## 🤖AEP PR SUMMARY🤖


- Added new files: 
  - `apps/courtfines/automation/kustomization.yaml`
  - `apps/courtfines/courtfines-app/courtfines-app.yaml`
  - `apps/courtfines/courtfines-app/image-policy.yaml`
  - `apps/courtfines/courtfines-app/image-repo.yaml`
  - `apps/courtfines/serviceaccount/test.yaml`
  - `apps/courtfines/test/base/kustomization.yaml` (renamed from prod/base/kustomization.yaml) 

- Modified files:
  - `apps/courtfines/base/kustomization.yaml`: Added reference to courtfines-app/courtfines-app.yaml and removed workload-identity
  - `apps/courtfines/stg/base/kustomization.yaml`: Added a patch to include serviceaccount/stg.yaml
  - `apps/flux-system/automation/kustomization.yaml`: Added reference to courtfines/automation
  - `clusters/prod/base/kustomization.yaml`: Removed reference to apps/courtfines/base/kustomize.yaml
  - `clusters/test/base/kustomization.yaml`: Added reference to apps/courtfines/base/kustomize.yaml