### PR TITLE
Fixed qa tag for mi-azure-functions

### DIFF
--- a/apps/mi/mi-azure-functions/image-policy.yaml
+++ b/apps/mi/mi-azure-functions/image-policy.yaml
@@ -15,22 +15,6 @@ spec:
 apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
-  name: mi-azure-functions-dev
-  annotations:
-    hmcts.github.com/prod-automated: disabled
-spec:
-  imageRepositoryRef:
-    name: mi-azure-functions
-  filterTags:
-    extract: $ts
-    pattern: '^pr-[a-f0-9]+-(?P<ts>[0-9]+-[0-9]+)'
-  policy:
-    alphabetical:
-      order: asc
----
-apiVersion: image.toolkit.fluxcd.io/v1beta2
-kind: ImagePolicy
-metadata:
   name: mi-azure-functions-qa
   annotations:
     hmcts.github.com/prod-automated: disabled

--- a/apps/mi/mi-azure-functions/image-policy.yaml
+++ b/apps/mi/mi-azure-functions/image-policy.yaml
@@ -39,7 +39,7 @@ spec:
     name: mi-azure-functions
   filterTags:
     extract: $ts
-    pattern: '^test-[a-f0-9]+-(?P<ts>[0-9]+-[0-9]+)'
+    pattern: '^test-[a-f0-9]+-(?P<ts>[0-9]+)'
   policy:
     alphabetical:
       order: asc


### PR DESCRIPTION




## 🤖AEP PR SUMMARY🤖


### apps/mi/mi-azure-functions/image-policy.yaml
- Removed the `mi-azure-functions-dev` ImagePolicy metadata and spec.
- Updated the `mi-azure-functions-qa` ImagePolicy filterTags pattern from `'^test-[a-f0-9]+-(?P<ts>[0-9]+-[0-9]+)'` to `'^test-[a-f0-9]+-(?P<ts>[0-9]+)'`.