### PR TITLE
Add demoOnly flyway location

### DIFF
--- a/apps/opal/opal-fines-service/demo.yaml
+++ b/apps/opal/opal-fines-service/demo.yaml
@@ -11,4 +11,4 @@ spec:
       environment:
         DUMMY_VAR: 0
         OPAL_FRONTEND_URL: https://opal-frontend.demo.platform.hmcts.net
-        FLYWAY_LOCATIONS: classpath:db/migration/allEnvs
+        FLYWAY_LOCATIONS: classpath:db/migration/allEnvs, classpath:db/migration/demoOnly


### PR DESCRIPTION
Add demoOnly folder to flyway locations for opal-fines-service in demo env

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


### apps/opal/opal-fines-service/demo.yaml
- Added a new location to the `FLYWAY_LOCATIONS` environment variable, including demo migrations.