### PR TITLE
Configure missing recordings alert to run early morning

### DIFF
--- a/apps/pre/pre-api-cron-check-for-missing-recordings/prod.yaml
+++ b/apps/pre/pre-api-cron-check-for-missing-recordings/prod.yaml
@@ -8,7 +8,7 @@ spec:
     global:
       jobKind: CronJob
     job:
-      schedule: "30 21 * * *" # 9:30 PM UTC
+      schedule: "15 6 * * *" # 6:15 AM UTC
       image: sdshmctspublic.azurecr.io/pre/api:prod-ca98f53-20250702120854 # {"$imagepolicy": "flux-system:pre-api"}
       environment:
         MEDIA_SERVICE: MediaKind


### PR DESCRIPTION
### Jira link

See [S28-4013](https://tools.hmcts.net/jira/browse/S28-4013)

### Change description

Configure the Missing Recordings cron job to run early morning instead of evening, since it checks for missing recordings from the previous day. 

Why: it will alert us earlier to incidents such as https://hmcts.haloitsm.com/tickets?area=1&mainview=team&viewid=0&selid=109&sellevel=1&selparentid=all%20teams&id=19283 

### Testing done

Not needed. Config change only. 

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖



- Updated file: apps/pre/pre-api-cron-check-for-missing-recordings/prod.yaml
- Changed schedule from \"30 21 * * *\" to \"15 6 * * *\"
```