### PR TITLE
DTSPO-26524 - Fix v5 helm chart upgrade

### DIFF
--- a/apps/jenkins/jenkins/jenkins.yaml
+++ b/apps/jenkins/jenkins/jenkins.yaml
@@ -17,7 +17,10 @@ spec:
       # Used for label app.kubernetes.io/component
       componentName: "jenkins-controller"
       # image version is managed in jenkins-controller-version.yaml
-      image: "hmctspublic.azurecr.io/jenkins/jenkins"
+      image: 
+        registry: hmctspublic.azurecr.io
+        repository: jenkins/jenkins
+        tag: 2.517-957
       podLabels:
         azure.workload.identity/use: "true"
       containerSecurityContext:
@@ -244,7 +247,10 @@ spec:
 
       sidecars:
         configAutoReload:
-          image: hmctspublic.azurecr.io/imported/kiwigrid/k8s-sidecar:1.25.2
+          image: 
+            registry: hmctspublic.azurecr.io
+            repository: imported/kiwigrid/k8s-sidecar
+            tag: 1.25.2
           # If enabled: true, Jenkins Configuration as Code will be reloaded on-the-fly without a reboot.  If false or not-specified,
           # jcasc changes will cause a reboot and will only be applied at the subsequent start-up.  Auto-reload uses the Jenkins CLI
           # over SSH to reapply config when changes to the configScripts are detected.  The admin user (or account you specify in

--- a/apps/jenkins/jenkins/jenkins.yaml
+++ b/apps/jenkins/jenkins/jenkins.yaml
@@ -17,10 +17,7 @@ spec:
       # Used for label app.kubernetes.io/component
       componentName: "jenkins-controller"
       # image version is managed in jenkins-controller-version.yaml
-      image: 
-        registry: hmctspublic.azurecr.io
-        repository: jenkins/jenkins
-        tag: 2.517-957
+      image: "hmctspublic.azurecr.io/jenkins/jenkins"
       podLabels:
         azure.workload.identity/use: "true"
       containerSecurityContext:
@@ -247,10 +244,7 @@ spec:
 
       sidecars:
         configAutoReload:
-          image: 
-            registry: hmctspublic.azurecr.io
-            repository: imported/kiwigrid/k8s-sidecar
-            tag: 1.25.2
+          image: hmctspublic.azurecr.io/imported/kiwigrid/k8s-sidecar:1.25.2
           # If enabled: true, Jenkins Configuration as Code will be reloaded on-the-fly without a reboot.  If false or not-specified,
           # jcasc changes will cause a reboot and will only be applied at the subsequent start-up.  Auto-reload uses the Jenkins CLI
           # over SSH to reapply config when changes to the configScripts are detected.  The admin user (or account you specify in

--- a/apps/jenkins/jenkins/jenkins.yaml
+++ b/apps/jenkins/jenkins/jenkins.yaml
@@ -16,8 +16,6 @@ spec:
     controller:
       # Used for label app.kubernetes.io/component
       componentName: "jenkins-controller"
-      # image version is managed in jenkins-controller-version.yaml
-      image: "hmctspublic.azurecr.io/jenkins/jenkins"
       podLabels:
         azure.workload.identity/use: "true"
       containerSecurityContext:
@@ -244,7 +242,6 @@ spec:
 
       sidecars:
         configAutoReload:
-          image: hmctspublic.azurecr.io/imported/kiwigrid/k8s-sidecar:1.25.2
           # If enabled: true, Jenkins Configuration as Code will be reloaded on-the-fly without a reboot.  If false or not-specified,
           # jcasc changes will cause a reboot and will only be applied at the subsequent start-up.  Auto-reload uses the Jenkins CLI
           # over SSH to reapply config when changes to the configScripts are detected.  The admin user (or account you specify in

--- a/apps/jenkins/jenkins/ptl/jenkins.yaml
+++ b/apps/jenkins/jenkins/ptl/jenkins.yaml
@@ -15,6 +15,8 @@ spec:
         namespace: jenkins
   values:
     controller:
+      # image version is managed in jenkins-controller-version.yaml
+      image: "hmctspublic.azurecr.io/jenkins/jenkins"
       ingress:
         hostName: sds-build.hmcts.net
       secondaryingress:
@@ -403,3 +405,6 @@ spec:
                                         values:
                                           - jenkins-master
                                   topologyKey: "kubernetes.io/hostname"
+      sidecars:
+        configAutoReload:
+          image: hmctspublic.azurecr.io/imported/kiwigrid/k8s-sidecar:1.25.2

--- a/apps/jenkins/jenkins/ptlsbox/jenkins.yaml
+++ b/apps/jenkins/jenkins/ptlsbox/jenkins.yaml
@@ -21,7 +21,7 @@ spec:
         runAsGroup: 0
         readOnlyRootFilesystem: false
         allowPrivilegeEscalation: true
-      image: 
+      image:
         registry: hmctspublic.azurecr.io
         repository: jenkins/jenkins
       ingress:
@@ -294,7 +294,7 @@ spec:
                                   topologyKey: "kubernetes.io/hostname"
       sidecars:
         configAutoReload:
-          image: 
+          image:
             registry: hmctspublic.azurecr.io
             repository: imported/kiwigrid/k8s-sidecar
             tag: 1.25.2

--- a/apps/jenkins/jenkins/ptlsbox/jenkins.yaml
+++ b/apps/jenkins/jenkins/ptlsbox/jenkins.yaml
@@ -24,7 +24,6 @@ spec:
       image: 
         registry: hmctspublic.azurecr.io
         repository: jenkins/jenkins
-        tag: 2.517-957
       ingress:
         hostName: sds-sandbox-build.hmcts.net
       secondaryingress:

--- a/apps/jenkins/jenkins/ptlsbox/jenkins.yaml
+++ b/apps/jenkins/jenkins/ptlsbox/jenkins.yaml
@@ -21,6 +21,10 @@ spec:
         runAsGroup: 0
         readOnlyRootFilesystem: false
         allowPrivilegeEscalation: true
+      image: 
+        registry: hmctspublic.azurecr.io
+        repository: jenkins/jenkins
+        tag: 2.517-957
       ingress:
         hostName: sds-sandbox-build.hmcts.net
       secondaryingress:
@@ -289,3 +293,9 @@ spec:
                                         values:
                                           - jenkins-master
                                   topologyKey: "kubernetes.io/hostname"
+      sidecars:
+        configAutoReload:
+          image: 
+            registry: hmctspublic.azurecr.io
+            repository: imported/kiwigrid/k8s-sidecar
+            tag: 1.25.2


### PR DESCRIPTION
### Jira link

See [DTSPO-26524](https://tools.hmcts.net/jira/browse/DTSPO-26524)

### Change description

Some fields have been altered in the new version
Updating them as per the guidance in https://github.com/jenkinsci/helm-charts/blob/main/charts/jenkins/UPGRADING.md
Had to move some fields from base into patches due to changes in value type. Actual values aren't changing.

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change








## 🤖AEP PR SUMMARY🤖


### apps/jenkins/jenkins/jenkins.yaml
- Removed duplicate `image` field in the `spec` section.
- Updated the `configAutoReload` sidecar image to version 1.25.2.

### apps/jenkins/jenkins/ptl/jenkins.yaml
- Added `image: \"hmctspublic.azurecr.io/jenkins/jenkins\"` under `controller` in the `spec` section.
- Updated the `configAutoReload` sidecar image to version 1.25.2.

### apps/jenkins/jenkins/ptlsbox/jenkins.yaml
- Added image registry, repository, and tag under `image` in the `spec` section.
- Updated the `configAutoReload` sidecar image to version 1.25.2.