### PR TITLE
DTSPO-26524 - Set controller version in ptlsbox patch

### DIFF
--- a/apps/jenkins/jenkins/ptlsbox/jenkins.yaml
+++ b/apps/jenkins/jenkins/ptlsbox/jenkins.yaml
@@ -24,6 +24,7 @@ spec:
       image:
         registry: hmctspublic.azurecr.io
         repository: jenkins/jenkins
+        tag: 2.517-957
       ingress:
         hostName: sds-sandbox-build.hmcts.net
       secondaryingress:

--- a/apps/jenkins/ptlsbox/00/kustomization.yaml
+++ b/apps/jenkins/ptlsbox/00/kustomization.yaml
@@ -9,4 +9,4 @@ patches:
 - path: ../../jenkins/ptlsbox/disk.yaml
 - path: ../../jenkins/ptlsbox/jenkins.yaml
 - path: ../../jenkins/ptlsbox/jenkins-azure-vm-agent.yaml
-- path: ../../jenkins/ptlsbox/jenkins-controller-version.yaml
+# - path: ../../jenkins/ptlsbox/jenkins-controller-version.yaml


### PR DESCRIPTION
### Jira link

See [DTSPO-26524](https://tools.hmcts.net/jira/browse/DTSPO-26524)

### Change description

Set controller version in patch to avoid deprecation
Required to be `image.tag`

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


- jenkins.yaml: Added a new tag \"2.517-957\" to the Jenkins image.
- kustomization.yaml: Removed a path for \"jenkins-controller-version.yaml\".