### PR TITLE
Pin PRE test env to api pr 1118

### DIFF
--- a/apps/pre/demo/base/kustomization.yaml
+++ b/apps/pre/demo/base/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - ../../pre-api-cron-check-for-missing-recordings/pre-api-cron-check-for-missing-recordings.yaml
   - ../../pre-api-cron-perform-edit-requests/pre-api-cron-perform-edit-requests.yaml
   - ../../pre-api-cron-start-live-events/pre-api-cron-start-live-events.yaml
+  - ../../pre-api-cron-cleanup-null-durations/pre-api-cron-cleanup-null-durations.yaml
   - ../../pre-api-cron-vodafone-etl/pre-api-cron-vodafone-etl.yaml
 namespace: pre
 patches:
@@ -22,5 +23,6 @@ patches:
   - path: ../../pre-api-cron-check-for-missing-recordings/demo.yaml
   - path: ../../pre-api-cron-perform-edit-requests/demo.yaml
   - path: ../../pre-api-cron-start-live-events/demo.yaml
+  - path: ../../pre-api-cron-cleanup-null-durations/demo.yaml
   - path: ../../pre-api-cron-vodafone-etl/demo.yaml
   - path: ../../serviceaccount/demo.yaml

--- a/apps/pre/pre-api-cron-check-for-missing-recordings/test-image-policy.yaml
+++ b/apps/pre/pre-api-cron-check-for-missing-recordings/test-image-policy.yaml
@@ -1,7 +1,7 @@
 apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
-  name: test-pre-api-cron-vodafone-etl
+  name: test-pre-api-cron-check-for-missing-recordings
   annotations:
     hmcts.github.com/prod-automated: disabled
 spec:

--- a/apps/pre/pre-api-cron-check-for-missing-recordings/test.yaml
+++ b/apps/pre/pre-api-cron-check-for-missing-recordings/test.yaml
@@ -9,7 +9,7 @@ spec:
       jobKind: CronJob
     job:
       schedule: "20 19 * * *" # 7:20 PM UTC
-      image: sdshmctspublic.azurecr.io/pre/api:prod-cda3aab-20250710142538 # {"$imagepolicy": "flux-system:pre-api"}
+      image: sdshmctspublic.azurecr.io/pre/api:pr-1118 # {"$imagepolicy": "flux-system:test-pre-api-cron-check-for-missing-recordings"}
       environment:
         AZURE_SUBSCRIPTION_ID: 3eec5bde-7feb-4566-bfb6-805df6e10b90
         PLATFORM_ENV_TAG: Testing

--- a/apps/pre/pre-api-cron-cleanup-live-events/test-image-policy.yaml
+++ b/apps/pre/pre-api-cron-cleanup-live-events/test-image-policy.yaml
@@ -6,7 +6,7 @@ metadata:
     hmcts.github.com/prod-automated: disabled
 spec:
   filterTags:
-    pattern: 'pr\-921\-5878407\-20250520121648'
+    pattern: 'pr\-1118'
   policy:
     alphabetical:
       order: asc

--- a/apps/pre/pre-api-cron-cleanup-live-events/test.yaml
+++ b/apps/pre/pre-api-cron-cleanup-live-events/test.yaml
@@ -11,7 +11,7 @@ spec:
       memoryRequests: '1Gi'
       memoryLimits: '2Gi'
       schedule: "30 11 * * *" # 11:30 AM UTC
-      image: sdshmctspublic.azurecr.io/pre/api:pr-921-5878407-20250520121648 # {"$imagepolicy": "flux-system:test-pre-api-cron-cleanup-live-events"}
+      image: sdshmctspublic.azurecr.io/pre/api:pr-1118 # {"$imagepolicy": "flux-system:test-pre-api-cron-cleanup-live-events"}
       environment:
         AZURE_SUBSCRIPTION_ID: 3eec5bde-7feb-4566-bfb6-805df6e10b90
         PLATFORM_ENV_TAG: Testing

--- a/apps/pre/pre-api-cron-cleanup-null-durations/demo.yaml
+++ b/apps/pre/pre-api-cron-cleanup-null-durations/demo.yaml
@@ -1,0 +1,19 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: pre-api-cron-close-pending-cases
+  namespace: pre
+spec:
+  values:
+    global:
+      jobKind: CronJob
+    job:
+      suspend: true
+      disableActiveClusterCheck: true
+      schedule: "0 19 * * *"
+      image: sdshmctspublic.azurecr.io/pre/api:prod-cda3aab-20250710142538 # {"$imagepolicy": "flux-system:pre-api"}
+      environment:
+        AZURE_SUBSCRIPTION_ID: c68a4bed-4c3d-4956-af51-4ae164c1957c
+        PLATFORM_ENV_TAG: Demo
+        MEDIA_SERVICE: MediaKind
+        ENABLE_NULL_DURATION_UPSERT: false

--- a/apps/pre/pre-api-cron-cleanup-null-durations/pre-api-cron-cleanup-null-durations.yaml
+++ b/apps/pre/pre-api-cron-cleanup-null-durations/pre-api-cron-cleanup-null-durations.yaml
@@ -1,0 +1,22 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: pre-api-cron-cleanup-null-durations
+  namespace: pre
+spec:
+  releaseName: pre-api-cron-cleanup-null-durations
+  values:
+    java:
+      enabled: false
+    job:
+      enabled: true
+      environment:
+        TASK_NAME: CleanupNullRecordingDuration
+  chart:
+    spec:
+      chart: ./stable/pre-api
+      sourceRef:
+        kind: GitRepository
+        name: hmcts-charts
+        namespace: flux-system
+      interval: 1m

--- a/apps/pre/pre-api-cron-cleanup-null-durations/prod.yaml
+++ b/apps/pre/pre-api-cron-cleanup-null-durations/prod.yaml
@@ -1,0 +1,18 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: pre-api-cron-close-pending-cases
+  namespace: pre
+spec:
+  values:
+    global:
+      jobKind: CronJob
+    job:
+      suspend: true
+      disableActiveClusterCheck: true
+      schedule: "0 19 * * *"
+      image: sdshmctspublic.azurecr.io/pre/api:prod-cda3aab-20250710142538 # {"$imagepolicy": "flux-system:pre-api"}
+      environment:
+        MEDIA_SERVICE: MediaKind
+        PORTAL_URL: https://portal.pre-recorded-evidence.justice.gov.uk/
+        ENABLE_NULL_DURATION_UPSERT: false

--- a/apps/pre/pre-api-cron-cleanup-null-durations/stg.yaml
+++ b/apps/pre/pre-api-cron-cleanup-null-durations/stg.yaml
@@ -1,0 +1,18 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: pre-api-cron-close-pending-cases
+  namespace: pre
+spec:
+  values:
+    global:
+      jobKind: CronJob
+    job:
+      suspend: true
+      schedule: "0 19 * * *"
+      image: sdshmctspublic.azurecr.io/pre/api:prod-cda3aab-20250710142538 # {"$imagepolicy": "flux-system:pre-api"}
+      environment:
+        AZURE_SUBSCRIPTION_ID: 74dacd4f-a248-45bb-a2f0-af700dc4cf68
+        PLATFORM_ENV_TAG: Staging
+        MEDIA_SERVICE: MediaKind
+        ENABLE_NULL_DURATION_UPSERT: false

--- a/apps/pre/pre-api-cron-cleanup-null-durations/test-image-policy.yaml
+++ b/apps/pre/pre-api-cron-cleanup-null-durations/test-image-policy.yaml
@@ -1,0 +1,14 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImagePolicy
+metadata:
+  name: test-pre-api-cron-cleanup-null-durations
+  annotations:
+    hmcts.github.com/prod-automated: disabled
+spec:
+  filterTags:
+    pattern: 'pr\-1118'
+  policy:
+    alphabetical:
+      order: asc
+  imageRepositoryRef:
+    name: pre-api

--- a/apps/pre/pre-api-cron-cleanup-null-durations/test.yaml
+++ b/apps/pre/pre-api-cron-cleanup-null-durations/test.yaml
@@ -1,0 +1,18 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: pre-api-cron-close-pending-cases
+  namespace: pre
+spec:
+  values:
+    global:
+      jobKind: CronJob
+    job:
+      suspend: true
+      schedule: "0 19 * * *"
+      image: sdshmctspublic.azurecr.io/pre/api:pr-1118 # {"$imagepolicy": "flux-system:test-pre-api-cron-check-for-missing-recordings"}
+      environment:
+        AZURE_SUBSCRIPTION_ID: 3eec5bde-7feb-4566-bfb6-805df6e10b90
+        PLATFORM_ENV_TAG: Testing
+        MEDIA_SERVICE: MediaKind
+        ENABLE_NULL_DURATION_UPSERT: false

--- a/apps/pre/pre-api-cron-cleanup-streaming-locators/test-image-policy.yaml
+++ b/apps/pre/pre-api-cron-cleanup-streaming-locators/test-image-policy.yaml
@@ -1,7 +1,7 @@
 apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
-  name: test-pre-api-cron-vodafone-etl
+  name: test-pre-api-cron-cleanup-streaming-locators
   annotations:
     hmcts.github.com/prod-automated: disabled
 spec:

--- a/apps/pre/pre-api-cron-cleanup-streaming-locators/test.yaml
+++ b/apps/pre/pre-api-cron-cleanup-streaming-locators/test.yaml
@@ -9,7 +9,7 @@ spec:
       jobKind: CronJob
     job:
       schedule: "30 09 * * *" # 6:30 PM UTC
-      image: sdshmctspublic.azurecr.io/pre/api:prod-cda3aab-20250710142538 # {"$imagepolicy": "flux-system:pre-api"}
+      image: sdshmctspublic.azurecr.io/pre/api:pr-1118 # {"$imagepolicy": "flux-system:test-pre-api-cron-cleanup-streaming-locators"}
       environment:
         AZURE_SUBSCRIPTION_ID: 3eec5bde-7feb-4566-bfb6-805df6e10b90
         PLATFORM_ENV_TAG: Testing

--- a/apps/pre/pre-api-cron-close-pending-cases/test-image-policy.yaml
+++ b/apps/pre/pre-api-cron-close-pending-cases/test-image-policy.yaml
@@ -1,7 +1,7 @@
 apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
-  name: test-pre-api-cron-vodafone-etl
+  name: test-pre-api-cron-close-pending-cases
   annotations:
     hmcts.github.com/prod-automated: disabled
 spec:

--- a/apps/pre/pre-api-cron-close-pending-cases/test.yaml
+++ b/apps/pre/pre-api-cron-close-pending-cases/test.yaml
@@ -9,7 +9,7 @@ spec:
       jobKind: CronJob
     job:
       schedule: "0 * * * *"
-      image: sdshmctspublic.azurecr.io/pre/api:prod-cda3aab-20250710142538 # {"$imagepolicy": "flux-system:pre-api"}
+      image: sdshmctspublic.azurecr.io/pre/api:pr-1118 # {"$imagepolicy": "flux-system:test-pre-api-cron-close-pending-cases"}
       environment:
         AZURE_SUBSCRIPTION_ID: 3eec5bde-7feb-4566-bfb6-805df6e10b90
         PLATFORM_ENV_TAG: Testing

--- a/apps/pre/pre-api-cron-perform-edit-requests/test-image-policy.yaml
+++ b/apps/pre/pre-api-cron-perform-edit-requests/test-image-policy.yaml
@@ -1,7 +1,7 @@
 apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
-  name: test-pre-api-cron-vodafone-etl
+  name: test-pre-api-cron-perform-edit-requests
   annotations:
     hmcts.github.com/prod-automated: disabled
 spec:

--- a/apps/pre/pre-api-cron-perform-edit-requests/test.yaml
+++ b/apps/pre/pre-api-cron-perform-edit-requests/test.yaml
@@ -10,7 +10,7 @@ spec:
     job:
       suspend: true
       schedule: "*/5 * * * *" # every 5 mins
-      image: sdshmctspublic.azurecr.io/pre/api:prod-cda3aab-20250710142538 # {"$imagepolicy": "flux-system:pre-api"}
+      image: sdshmctspublic.azurecr.io/pre/api:pr-1118 # {"$imagepolicy": "flux-system:test-pre-api-cron-perform-edit-requests"}
       environment:
         AZURE_SUBSCRIPTION_ID: 3eec5bde-7feb-4566-bfb6-805df6e10b90
         PLATFORM_ENV_TAG: Test

--- a/apps/pre/pre-api-cron-start-live-events/test-image-policy.yaml
+++ b/apps/pre/pre-api-cron-start-live-events/test-image-policy.yaml
@@ -6,7 +6,7 @@ metadata:
     hmcts.github.com/prod-automated: disabled
 spec:
   filterTags:
-    pattern: 'pr\-920\-51b5474\-20250519091257'
+    pattern: 'pr\-1118'
   policy:
     alphabetical:
       order: asc

--- a/apps/pre/pre-api-cron-start-live-events/test.yaml
+++ b/apps/pre/pre-api-cron-start-live-events/test.yaml
@@ -10,7 +10,7 @@ spec:
     job:
       suspend: false
       schedule: "00 13 * * *"
-      image: sdshmctspublic.azurecr.io/pre/api:pr-920-51b5474-20250519091257 # {"$imagepolicy": "flux-system:test-pre-api-cron-start-live-events"}
+      image: sdshmctspublic.azurecr.io/pre/api:pr-1118 # {"$imagepolicy": "flux-system:test-pre-api-cron-start-live-events"}
       environment:
         AZURE_SUBSCRIPTION_ID: 3eec5bde-7feb-4566-bfb6-805df6e10b90
         PLATFORM_ENV_TAG: Testing

--- a/apps/pre/pre-api-cron-vodafone-etl/test.yaml
+++ b/apps/pre/pre-api-cron-vodafone-etl/test.yaml
@@ -11,7 +11,7 @@ spec:
       memoryRequests: '1Gi'
       memoryLimits: '2Gi'
       schedule: "10 10 1 5 *" # 10 AM 1st May UTC
-      image: sdshmctspublic.azurecr.io/pre/api:prod-cda3aab-20250710142538 # {"$imagepolicy": "flux-system:pre-api"}
+      image: sdshmctspublic.azurecr.io/pre/api:pr-1118 # {"$imagepolicy": "flux-system:test-pre-api-cron-vodafone-etl"}
       environment:
         AZURE_SUBSCRIPTION_ID: 3eec5bde-7feb-4566-bfb6-805df6e10b90
         PLATFORM_ENV_TAG: Testing

--- a/apps/pre/pre-api/demo.yaml
+++ b/apps/pre/pre-api/demo.yaml
@@ -19,3 +19,4 @@ spec:
         ENABLE_NEW_EMAIL_SERVICE: true
         PORTAL_URL: https://pre-portal.demo.platform.hmcts.net/
         ENABLE_AUTOMATED_EDITING: false
+        ENABLE_NULL_DURATION_UPSERT: false

--- a/apps/pre/pre-api/prod.yaml
+++ b/apps/pre/pre-api/prod.yaml
@@ -20,3 +20,4 @@ spec:
         TRIGGER: init-2
         PORTAL_URL: https://portal.pre-recorded-evidence.justice.gov.uk/
         ENABLE_AUTOMATED_EDITING: false
+        ENABLE_NULL_DURATION_UPSERT: false

--- a/apps/pre/pre-api/stg.yaml
+++ b/apps/pre/pre-api/stg.yaml
@@ -21,5 +21,6 @@ spec:
         ENABLE_NEW_EMAIL_SERVICE: true
         ENABLE_STREAMING_LOCATOR_ON_START: true
         ENABLE_AUTOMATED_EDITING: true
+        ENABLE_NULL_DURATION_UPSERT: false
         HIKARI_POOL_SIZE: 25
         VAR_TA: Trigger-1

--- a/apps/pre/pre-api/test-image-policy.yaml
+++ b/apps/pre/pre-api/test-image-policy.yaml
@@ -1,7 +1,7 @@
 apiVersion: image.toolkit.fluxcd.io/v1beta2
 kind: ImagePolicy
 metadata:
-  name: test-pre-api-cron-vodafone-etl
+  name: test-pre-api
   annotations:
     hmcts.github.com/prod-automated: disabled
 spec:

--- a/apps/pre/pre-api/test.yaml
+++ b/apps/pre/pre-api/test.yaml
@@ -8,6 +8,7 @@ spec:
   values:
     java:
       ingressHost: pre-api.test.platform.hmcts.net
+      image: sdshmctspublic.azurecr.io/pre/api:pr-1118 # {"$imagepolicy": "flux-system:test-pre-api"}
       environment:
         AZURE_MEDIA_SERVICES_ACCOUNT_NAME: preamstest
         AZURE_RESOURCE_GROUP: pre-test

--- a/apps/pre/pre-api/test.yaml
+++ b/apps/pre/pre-api/test.yaml
@@ -17,4 +17,5 @@ spec:
         MEDIA_SERVICE: MediaKind
         ENABLE_STREAMING_LOCATOR_ON_START: false
         ENABLE_AUTOMATED_EDITING: false
+        ENABLE_NULL_DURATION_UPSERT: false
         PORTAL_URL: https://pre-portal.test.platform.hmcts.net/

--- a/apps/pre/prod/base/kustomization.yaml
+++ b/apps/pre/prod/base/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - ../../pre-api-cron-check-for-missing-recordings/pre-api-cron-check-for-missing-recordings.yaml
   - ../../pre-api-cron-perform-edit-requests/pre-api-cron-perform-edit-requests.yaml
   - ../../pre-api-cron-start-live-events/pre-api-cron-start-live-events.yaml
+  - ../../pre-api-cron-cleanup-null-durations/pre-api-cron-cleanup-null-durations.yaml
   - ../../pre-api-cron-vodafone-etl/pre-api-cron-vodafone-etl.yaml
   - ../../../base/slack-provider/prod
 namespace: pre
@@ -21,5 +22,6 @@ patches:
   - path: ../../pre-api-cron-check-for-missing-recordings/prod.yaml
   - path: ../../pre-api-cron-perform-edit-requests/prod.yaml
   - path: ../../pre-api-cron-start-live-events/prod.yaml
+  - path: ../../pre-api-cron-cleanup-null-durations/prod.yaml
   - path: ../../pre-api-cron-vodafone-etl/prod.yaml
   - path: ../../serviceaccount/prod.yaml

--- a/apps/pre/stg/base/kustomization.yaml
+++ b/apps/pre/stg/base/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - ../../pre-api-cron-check-for-missing-recordings/pre-api-cron-check-for-missing-recordings.yaml
   - ../../pre-api-cron-perform-edit-requests/pre-api-cron-perform-edit-requests.yaml
   - ../../pre-api-cron-start-live-events/pre-api-cron-start-live-events.yaml
+  - ../../pre-api-cron-cleanup-null-durations/pre-api-cron-cleanup-null-durations.yaml
   - ../../pre-api-cron-vodafone-etl/pre-api-cron-vodafone-etl.yaml
   - ../../../rbac/nonprod-role.yaml
   - ../../../base/slack-provider/stg
@@ -22,5 +23,6 @@ patches:
   - path: ../../pre-api-cron-check-for-missing-recordings/stg.yaml
   - path: ../../pre-api-cron-perform-edit-requests/stg.yaml
   - path: ../../pre-api-cron-start-live-events/stg.yaml
+  - path: ../../pre-api-cron-cleanup-null-durations/stg.yaml
   - path: ../../pre-api-cron-vodafone-etl/stg.yaml
   - path: ../../serviceaccount/stg.yaml

--- a/apps/pre/test/base/kustomization.yaml
+++ b/apps/pre/test/base/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - ../../pre-api-cron-check-for-missing-recordings/pre-api-cron-check-for-missing-recordings.yaml
   - ../../pre-api-cron-perform-edit-requests/pre-api-cron-perform-edit-requests.yaml
   - ../../pre-api-cron-start-live-events/pre-api-cron-start-live-events.yaml
+  - ../../pre-api-cron-cleanup-null-durations/pre-api-cron-cleanup-null-durations.yaml
   - ../../pre-api-cron-vodafone-etl/pre-api-cron-vodafone-etl.yaml
   - ../../../rbac/nonprod-role.yaml
   - ../../../base/slack-provider/test
@@ -22,5 +23,6 @@ patches:
   - path: ../../pre-api-cron-check-for-missing-recordings/test.yaml
   - path: ../../pre-api-cron-perform-edit-requests/test.yaml
   - path: ../../pre-api-cron-start-live-events/test.yaml
+  - path: ../../pre-api-cron-cleanup-null-durations/test.yaml
   - path: ../../pre-api-cron-vodafone-etl/test.yaml
   - path: ../../serviceaccount/test.yaml


### PR DESCRIPTION












## 🤖AEP PR SUMMARY🤖


- apps/pre/demo/base/kustomization.yaml
  - Added a new YAML file for pre-api-cron-cleanup-null-durations.
  - Updated the resources and patches sections to include pre-api-cron-cleanup-null-durations.yaml and demo.yaml respectively.
  - Updated the schedule for pre-api-cron-cleanup-null-durations.yaml.
  - Added a new path for pre-api-cron-cleanup-null-durations/demo.yaml.

- apps/pre/pre-api-cron-check-for-missing-recordings/test-image-policy.yaml
  - Created a new file for test-image-policy for pre-api-cron-check-for-missing-recordings.

- apps/pre/pre-api-cron-check-for-missing-recordings/test.yaml
  - Changed the image tag from prod-cda3aab-20250710142538 to pr-1118.
  - Updated the schedule to \"20 19 * * *\".

- apps/pre/pre-api-cron-cleanup-live-events/test-image-policy.yaml
  - Updated the image tag pattern to 'pr\-1118'.

... (and many more similar changes in different files)