### PR TITLE
S28-0000 Fix cron job name

### DIFF
--- a/apps/pre/pre-api-cron-cleanup-null-durations/demo.yaml
+++ b/apps/pre/pre-api-cron-cleanup-null-durations/demo.yaml
@@ -1,7 +1,7 @@
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
-  name: pre-api-cron-close-pending-cases
+  name: pre-api-cron-cleanup-null-durations
   namespace: pre
 spec:
   values:

--- a/apps/pre/pre-api-cron-cleanup-null-durations/prod.yaml
+++ b/apps/pre/pre-api-cron-cleanup-null-durations/prod.yaml
@@ -1,7 +1,7 @@
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
-  name: pre-api-cron-close-pending-cases
+  name: pre-api-cron-cleanup-null-durations
   namespace: pre
 spec:
   values:

--- a/apps/pre/pre-api-cron-cleanup-null-durations/stg.yaml
+++ b/apps/pre/pre-api-cron-cleanup-null-durations/stg.yaml
@@ -1,7 +1,7 @@
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
-  name: pre-api-cron-close-pending-cases
+  name: pre-api-cron-cleanup-null-durations
   namespace: pre
 spec:
   values:

--- a/apps/pre/pre-api-cron-cleanup-null-durations/test.yaml
+++ b/apps/pre/pre-api-cron-cleanup-null-durations/test.yaml
@@ -1,7 +1,7 @@
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
-  name: pre-api-cron-close-pending-cases
+  name: pre-api-cron-cleanup-null-durations
   namespace: pre
 spec:
   values:


### PR DESCRIPTION
### Change description
Update job name in charts

## 🤖AEP PR SUMMARY🤖


- Updated files:
  - demo.yaml
  - prod.yaml
  - stg.yaml
  - test.yaml
- In each file, the name field under metadata was changed from `pre-api-cron-close-pending-cases` to `pre-api-cron-cleanup-null-durations`.