### PR TITLE
Suspend pending closure cronjob

### DIFF
--- a/apps/pre/pre-api-cron-close-pending-cases/prod.yaml
+++ b/apps/pre/pre-api-cron-close-pending-cases/prod.yaml
@@ -8,7 +8,7 @@ spec:
     global:
       jobKind: CronJob
     job:
-      suspend: false
+      suspend: true
       disableActiveClusterCheck: true
       schedule: "0 * * * *"
       image: sdshmctspublic.azurecr.io/pre/api:prod-cda3aab-20250710142538 # {"$imagepolicy": "flux-system:pre-api"}


### PR DESCRIPTION
### Jira link

See [S28-4104](https://tools.hmcts.net/jira/browse/S28-4104)

### Change description

Suspend cronjob while it's broken to prevent alert oversaturation while working on the fix.