### PR TITLE
feat(pre-api): `ENABLE_STREAMING_LOCATOR_ON_START` for start live event cron

### DIFF
--- a/apps/pre/pre-api-cron-start-live-events/demo.yaml
+++ b/apps/pre/pre-api-cron-start-live-events/demo.yaml
@@ -16,3 +16,4 @@ spec:
         PLATFORM_ENV_TAG: Demo
         MEDIA_SERVICE: MediaKind
         PORTAL_URL: https://pre-portal.demo.platform.hmcts.net/
+        ENABLE_STREAMING_LOCATOR_ON_START: false

--- a/apps/pre/pre-api-cron-start-live-events/prod.yaml
+++ b/apps/pre/pre-api-cron-start-live-events/prod.yaml
@@ -14,3 +14,4 @@ spec:
       environment:
         MEDIA_SERVICE: MediaKind
         PORTAL_URL: https://portal.pre-recorded-evidence.justice.gov.uk/
+        ENABLE_STREAMING_LOCATOR_ON_START: false

--- a/apps/pre/pre-api-cron-start-live-events/stg.yaml
+++ b/apps/pre/pre-api-cron-start-live-events/stg.yaml
@@ -15,3 +15,4 @@ spec:
         AZURE_SUBSCRIPTION_ID: 74dacd4f-a248-45bb-a2f0-af700dc4cf68
         PLATFORM_ENV_TAG: Staging
         MEDIA_SERVICE: MediaKind
+        ENABLE_STREAMING_LOCATOR_ON_START: true

--- a/apps/pre/pre-api-cron-start-live-events/test.yaml
+++ b/apps/pre/pre-api-cron-start-live-events/test.yaml
@@ -16,3 +16,4 @@ spec:
         PLATFORM_ENV_TAG: Testing
         MEDIA_SERVICE: MediaKind
         PORTAL_URL: https://pre-portal.test.platform.hmcts.net/
+        ENABLE_STREAMING_LOCATOR_ON_START: false


### PR DESCRIPTION
### Jira link

<!-- 
Replace PROJ-XXXXXX with your Jira key
Remove this section if its not applicable, or replace it with another reference link
-->
See [S28-4106](https://tools.hmcts.net/jira/browse/S28-4106)

### Change description
- Adds ENABLE_STREAMING_LOCATOR_ON_START flag to start-live-events crons in all envs
    - stg = true
    - test, demo, prod = false 

## 🤖AEP PR SUMMARY🤖


- Updated files:
  - demo.yaml
  - prod.yaml
  - stg.yaml
  - test.yaml
- Added `ENABLE_STREAMING_LOCATOR_ON_START: false` to the spec in demo.yaml, prod.yaml, and test.yaml
- Added `ENABLE_STREAMING_LOCATOR_ON_START: true` to the spec in stg.yaml