### PR TITLE
feat(pre-api): increase memory allocation pre-api-cron-perform-edit-requests

### DIFF
--- a/apps/pre/pre-api-cron-perform-edit-requests/pre-api-cron-perform-edit-requests.yaml
+++ b/apps/pre/pre-api-cron-perform-edit-requests/pre-api-cron-perform-edit-requests.yaml
@@ -10,8 +10,8 @@ spec:
       enabled: false
     job:
       enabled: true
-      memoryRequests: '2Gi'
-      memoryLimits: '4Gi'
+      memoryRequests: '7Gi'
+      memoryLimits: '7Gi'
       environment:
         TASK_NAME: PerformEditRequest
   chart:


### PR DESCRIPTION
### Change description
- increase memory allocation 

## 🤖AEP PR SUMMARY🤖


- pre-api-cron-perform-edit-requests.yaml
  - Increased memory requests and limits from '2Gi' and '4Gi' to '7Gi' and '7Gi' respectively.