### PR TITLE
feat(pre-api): enable pre-api-cron-cleanup-null-durations in stg

### DIFF
--- a/apps/pre/pre-api-cron-cleanup-null-durations/stg.yaml
+++ b/apps/pre/pre-api-cron-cleanup-null-durations/stg.yaml
@@ -8,11 +8,11 @@ spec:
     global:
       jobKind: CronJob
     job:
-      suspend: true
-      schedule: "0 19 * * *"
+      suspend: false
+      schedule: "0 11 * * Thu"
       image: sdshmctspublic.azurecr.io/pre/api:prod-b8eba80-20250723143420 # {"$imagepolicy": "flux-system:pre-api"}
       environment:
         AZURE_SUBSCRIPTION_ID: 74dacd4f-a248-45bb-a2f0-af700dc4cf68
         PLATFORM_ENV_TAG: Staging
         MEDIA_SERVICE: MediaKind
-        ENABLE_NULL_DURATION_UPSERT: false
+        ENABLE_NULL_DURATION_UPSERT: true


### PR DESCRIPTION
### Jira link

<!-- 
Replace PROJ-XXXXXX with your Jira key
Remove this section if its not applicable, or replace it with another reference link
-->
See [S28-4043](https://tools.hmcts.net/jira/browse/S28-4043)

### Change description
- Enables pre-api-cron-cleanup-null-durations in staging

## 🤖AEP PR SUMMARY🤖


- `stg.yaml`
  - Changed job schedule from `0 19 * * *` to `0 11 * * Thu`
  - Updated `suspend` from `true` to `false`
  - Updated `ENABLE_NULL_DURATION_UPSERT` from `false` to `true`