### PR TITLE
feat(pre-api): update cron schedule for cleanup-null-durations in stg

### DIFF
--- a/apps/pre/pre-api-cron-cleanup-null-durations/stg.yaml
+++ b/apps/pre/pre-api-cron-cleanup-null-durations/stg.yaml
@@ -9,7 +9,7 @@ spec:
       jobKind: CronJob
     job:
       suspend: false
-      schedule: "0 11 * * Thu"
+      schedule: "0 8 * * Fri"
       image: sdshmctspublic.azurecr.io/pre/api:prod-ae329cf-20250724113833 # {"$imagepolicy": "flux-system:pre-api"}
       environment:
         AZURE_SUBSCRIPTION_ID: 74dacd4f-a248-45bb-a2f0-af700dc4cf68


### PR DESCRIPTION
### Jira link

<!-- 
Replace PROJ-XXXXXX with your Jira key
Remove this section if its not applicable, or replace it with another reference link
-->
See [S28-4043](https://tools.hmcts.net/jira/browse/S28-4043)

### Change description
- Runs Friday at 8am UTC (9am BST)