### PR TITLE
PUB-2981 - Removed old staging image

### DIFF
--- a/apps/pip/frontend/stg.yaml
+++ b/apps/pip/frontend/stg.yaml
@@ -8,7 +8,6 @@ spec:
     nodejs:
       replicas: 2
       ingressHost: pip-frontend.staging.platform.hmcts.net
-      image: sdshmctspublic.azurecr.io/pip/frontend:pr-1322-e2cc8bb-20250718080615
       keyVaults:
         pip-ss-kv:
           resourceGroup: pip-ss-stg-rg


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/PUB-2981

### Change description

Remove old staging image




## 🤖AEP PR SUMMARY🤖


### apps/pip/frontend/stg.yaml
- Removed the `image` field that specifies the image URL for the frontend application.
- The image field was removed from spec, which indicates a removal of a specified image for the frontend application.