### PR TITLE
feat(pre-api): disable cleanup-null-durations in stg

### DIFF
--- a/apps/pre/pre-api-cron-cleanup-null-durations/stg.yaml
+++ b/apps/pre/pre-api-cron-cleanup-null-durations/stg.yaml
@@ -8,7 +8,7 @@ spec:
     global:
       jobKind: CronJob
     job:
-      suspend: false
+      suspend: true
       schedule: "0 8 * * Fri"
       image: sdshmctspublic.azurecr.io/pre/api:prod-83f7e35-20250724153830 # {"$imagepolicy": "flux-system:pre-api"}
       environment:


### PR DESCRIPTION
### Jira link

<!-- 
Replace PROJ-XXXXXX with your Jira key
Remove this section if its not applicable, or replace it with another reference link
-->
See [S28-4043](https://tools.hmcts.net/jira/browse/S28-4043)

### Change description
- Disables pre-api-cron-cleanup-null-durations cron in stg


## 🤖AEP PR SUMMARY🤖


### apps/pre/pre-api-cron-cleanup-null-durations/stg.yaml
- Changed `suspend` from `false` to `true`
- Updated schedule from `\"0 8 * * Fri\"` to the new schedule time 