### PR TITLE
juror deployment to scheduler exec service on for release5.11

### DIFF
--- a/apps/juror/juror-scheduler-execution/demo.yaml
+++ b/apps/juror/juror-scheduler-execution/demo.yaml
@@ -8,5 +8,5 @@ spec:
   values:
     java:
       # Uncomment and edit the line below to fix the environment at a specific image
-      image: sdshmctspublic.azurecr.io/juror/scheduler-execution:pr-246-0ad76d5-20250716134840
+      image: sdshmctspublic.azurecr.io/juror/scheduler-execution:prod-804c9ab-20250724132741
       ingressHost: juror-scheduler-execution.demo.platform.hmcts.net

--- a/apps/juror/juror-scheduler-execution/image-policy.yaml
+++ b/apps/juror/juror-scheduler-execution/image-policy.yaml
@@ -25,7 +25,7 @@ spec:
     name: juror-scheduler-execution
   filterTags:
     extract: $ts
-    pattern: '^pr-239-[a-f0-9]+-(?P<ts>[0-9]+)'
+    pattern: '^pr-248-[a-f0-9]+-(?P<ts>[0-9]+)'
   policy:
     alphabetical:
       order: asc

--- a/apps/juror/juror-scheduler-execution/ithc.yaml
+++ b/apps/juror/juror-scheduler-execution/ithc.yaml
@@ -8,5 +8,5 @@ spec:
   values:
     java:
       # Uncomment and edit the line below to fix the environment at a specific image
-      image: sdshmctspublic.azurecr.io/juror/scheduler-execution:pr-246-0ad76d5-20250716134840
+      image: sdshmctspublic.azurecr.io/juror/scheduler-execution:pr-246-0ad76d5-20250716134840 # {"$imagepolicy": "flux-system:juror-scheduler-execution-pr"}
       ingressHost: juror-scheduler-execution.ithc.platform.hmcts.net


### PR DESCRIPTION
only deploying into ITHC for now via image policy

### Jira link


### Change description

deploying scheduler exec service update for release5.11 into ITHC only via image policy, Demo to have latest prod image

### Testing done
release is for testing

### Security Vulnerability Assessment ###


**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change


## 🤖AEP PR SUMMARY🤖


### apps/juror/juror-scheduler-execution/demo.yaml
- Updated the image version from \"pr-246-0ad76d5-20250716134840\" to \"prod-804c9ab-20250724132741\" for the Juror Scheduler Execution demo environment.

### apps/juror/juror-scheduler-execution/image-policy.yaml
- Updated the image tag pattern from '^pr-239-[a-f0-9]+-(?P<ts>[0-9]+)' to '^pr-248-[a-f0-9]+-(?P<ts>[0-9]+)' in the image policy for Juror Scheduler Execution.

### apps/juror/juror-scheduler-execution/ithc.yaml
- No changes.