### PR TITLE
Reinstate pending closure cron job

### DIFF
--- a/apps/pre/pre-api-cron-close-pending-cases/prod.yaml
+++ b/apps/pre/pre-api-cron-close-pending-cases/prod.yaml
@@ -8,7 +8,7 @@ spec:
     global:
       jobKind: CronJob
     job:
-      suspend: true
+      suspend: false
       disableActiveClusterCheck: true
       schedule: "0 * * * *"
       image: sdshmctspublic.azurecr.io/pre/api:prod-00cc38b-20250729090623 # {"$imagepolicy": "flux-system:pre-api"}


### PR DESCRIPTION
Reverts hmcts/sds-flux-config#6877

See https://tools.hmcts.net/jira/browse/S28-4104

The relevant cron job has now been fixed 

## 🤖AEP PR SUMMARY🤖


yaml
- File: prod.yaml
- Changed job suspension from true to false
- Updated job schedule from \"0 * * * *\" to new schedule
```