### PR TITLE
feat(pre-api): configure ENABLE_MULTI_FFMPEG_COMMAND for environments

### DIFF
--- a/apps/pre/pre-api-cron-perform-edit-requests/demo.yaml
+++ b/apps/pre/pre-api-cron-perform-edit-requests/demo.yaml
@@ -18,3 +18,4 @@ spec:
         MEDIA_SERVICE: MediaKind
         PORTAL_URL: https://pre-portal.demo.platform.hmcts.net/
         ENABLE_NEW_EMAIL_SERVICE: true
+        ENABLE_MULTI_FFMPEG_COMMAND: false

--- a/apps/pre/pre-api-cron-perform-edit-requests/prod.yaml
+++ b/apps/pre/pre-api-cron-perform-edit-requests/prod.yaml
@@ -16,3 +16,4 @@ spec:
         MEDIA_SERVICE: MediaKind
         PORTAL_URL: https://portal.pre-recorded-evidence.justice.gov.uk/
         ENABLE_NEW_EMAIL_SERVICE: true
+        ENABLE_MULTI_FFMPEG_COMMAND: false

--- a/apps/pre/pre-api-cron-perform-edit-requests/stg.yaml
+++ b/apps/pre/pre-api-cron-perform-edit-requests/stg.yaml
@@ -16,3 +16,4 @@ spec:
         PLATFORM_ENV_TAG: Staging
         MEDIA_SERVICE: MediaKind
         ENABLE_NEW_EMAIL_SERVICE: true
+        ENABLE_MULTI_FFMPEG_COMMAND: true

--- a/apps/pre/pre-api-cron-perform-edit-requests/test.yaml
+++ b/apps/pre/pre-api-cron-perform-edit-requests/test.yaml
@@ -17,3 +17,4 @@ spec:
         MEDIA_SERVICE: MediaKind
         PORTAL_URL: https://pre-portal.test.platform.hmcts.net/
         ENABLE_NEW_EMAIL_SERVICE: true
+        ENABLE_MULTI_FFMPEG_COMMAND: false


### PR DESCRIPTION
### Jira link

<!-- 
Replace PROJ-XXXXXX with your Jira key
Remove this section if its not applicable, or replace it with another reference link
-->
See [S28-4152](https://tools.hmcts.net/jira/browse/S28-4152)

### Change description
- Enable ENABLE_MULTI_FFMPEG_COMMAND in staging, disabled everywhere else for perform-edit-requests cron




## 🤖AEP PR SUMMARY🤖


- Updated `demo.yaml`, `prod.yaml`, `stg.yaml`, and `test.yaml` in the `pre-api-cron-perform-edit-requests` directory
- Added `ENABLE_MULTI_FFMPEG_COMMAND: false` to `demo.yaml`, `prod.yaml`, and `test.yaml`
- Updated `ENABLE_MULTI_FFMPEG_COMMAND` to `true` in `stg.yaml`