### PR TITLE
Marianne azzopardi patch6

### DIFF
--- a/apps/pre/pre-api-cron-vodafone-etl-process-full/stg.yaml
+++ b/apps/pre/pre-api-cron-vodafone-etl-process-full/stg.yaml
@@ -8,7 +8,7 @@ spec:
     global:
       jobKind: CronJob
     job:
-      schedule: "0 13 6 8 *" # 2pm (BST) - 6 Aug
+      schedule: "20 13 6 8 *" # 2.15pm (BST) - 6 Aug
       suspend: false
       memoryRequests: '1Gi'
       memoryLimits: '2Gi'


### PR DESCRIPTION
Runs Wednesday on 6 Aug 13.20pm UTC (2.20pm BST)









## 🤖AEP PR SUMMARY🤖


- stg.yaml
- Updated the schedule from \"0 12 6 8 *\" to \"20 13 6 8 *\"
- Changed the cron job schedule for Vodafone ETL process full from the 6th of August at 12:00 to the 6th of August at 13:20.