### PR TITLE
update scheudle

### DIFF
--- a/apps/pre/pre-api-cron-vodafone-etl-process-full/stg.yaml
+++ b/apps/pre/pre-api-cron-vodafone-etl-process-full/stg.yaml
@@ -8,7 +8,7 @@ spec:
     global:
       jobKind: CronJob
     job:
-      schedule: "0 11 8 8 *" # 12pm (BST) - 8 Aug
+      schedule: "15 13 12 8 *" # 14.15pm (BST) - 12 Aug
       suspend: false
       memoryRequests: '1Gi'
       memoryLimits: '2Gi'


### PR DESCRIPTION
Runs Tuesday on 12 Aug 13.15pm UTC (14.15pm BST)


## 🤖AEP PR SUMMARY🤖



pre-api-cron-vodafone-etl-process-full/stg.yaml
- Updated the schedule for the CronJob from \"0 11 8 8 *\" to \"15 13 12 8 *\"
