### PR TITLE
feat(pre-api): enable cleanup null duration cron in demo

### DIFF
--- a/apps/pre/pre-api-cron-cleanup-null-durations/demo.yaml
+++ b/apps/pre/pre-api-cron-cleanup-null-durations/demo.yaml
@@ -8,9 +8,9 @@ spec:
     global:
       jobKind: CronJob
     job:
-      suspend: true
+      suspend: false
       disableActiveClusterCheck: true
-      schedule: "0 19 * * *"
+      schedule: "15 1 21 8 *" # 2:15 BST, 21st Aug
       image: sdshmctspublic.azurecr.io/pre/api:prod-94ee809-20250821083204 # {"$imagepolicy": "flux-system:pre-api"}
       environment:
         AZURE_SUBSCRIPTION_ID: c68a4bed-4c3d-4956-af51-4ae164c1957c


### PR DESCRIPTION
### Change description
- Enable cleanup null duration cron in demo env
    - Runs at 2:15 BST, today 21st August
