### PR TITLE
feat(pre-api): add Vodafone MK import CronJob for all environments

### DIFF
--- a/apps/pre/demo/base/kustomization.yaml
+++ b/apps/pre/demo/base/kustomization.yaml
@@ -17,6 +17,7 @@ resources:
   - ../../pre-api-cron-vodafone-etl-post-migration/pre-api-cron-vodafone-etl-post-migration.yaml
   - ../../pre-api-cron-vodafone-etl-process-full/pre-api-cron-vodafone-etl-process-full.yaml
   - ../../pre-api-cron-cleanup-null-durations/pre-api-cron-cleanup-null-durations.yaml
+  - ../../pre-api-cron-vodafone-mk-import/pre-api-cron-vodafone-mk-import.yaml
 namespace: pre
 patches:
   - path: ../../identity/demo.yaml
@@ -35,4 +36,5 @@ patches:
   - path: ../../pre-api-cron-vodafone-etl-process-full/demo.yaml
   - path: ../../pre-api-cron-cleanup-null-durations/demo.yaml
   - path: ../../pre-api-cron-process-capture-sessions/stg.yaml
+  - path: ../../pre-api-cron-vodafone-mk-import/demo.yaml
   - path: ../../serviceaccount/demo.yaml

--- a/apps/pre/pre-api-cron-vodafone-mk-import/demo.yaml
+++ b/apps/pre/pre-api-cron-vodafone-mk-import/demo.yaml
@@ -1,0 +1,21 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: pre-api-cron-vodafone-mk-import
+  namespace: pre
+spec:
+  values:
+    global:
+      jobKind: CronJob
+    job:
+      schedule: "0 18 27 8 *" # 6 PM 27th Aug UTC
+      suspend: true
+      memoryRequests: '1Gi'
+      memoryLimits: '2Gi'
+      image: sdshmctspublic.azurecr.io/pre/api:prod-2dc68c8-20250822112300 # {"$imagepolicy": "flux-system:pre-api"}
+      environment:
+        AZURE_SUBSCRIPTION_ID: c68a4bed-4c3d-4956-af51-4ae164c1957c
+        PLATFORM_ENV_TAG: Demo
+        MEDIA_SERVICE: MediaKind
+        ENABLE_NEW_EMAIL_SERVICE: true
+        PORTAL_URL: https://pre-portal.demo.platform.hmcts.net/

--- a/apps/pre/pre-api-cron-vodafone-mk-import/pre-api-cron-vodafone-mk-import.yaml
+++ b/apps/pre/pre-api-cron-vodafone-mk-import/pre-api-cron-vodafone-mk-import.yaml
@@ -1,0 +1,22 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: pre-api-cron-vodafone-mk-import
+  namespace: pre
+spec:
+  releaseName: pre-api-cron-vodafone-mk-import
+  values:
+    java:
+      enabled: false
+    job:
+      enabled: true
+      environment:
+        TASK_NAME: BatchImportMissingMkAssets
+  chart:
+    spec:
+      chart: ./stable/pre-api
+      sourceRef:
+        kind: GitRepository
+        name: hmcts-charts
+        namespace: flux-system
+      interval: 1m

--- a/apps/pre/pre-api-cron-vodafone-mk-import/prod.yaml
+++ b/apps/pre/pre-api-cron-vodafone-mk-import/prod.yaml
@@ -1,0 +1,19 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: pre-api-cron-vodafone-mk-import
+  namespace: pre
+spec:
+  values:
+    global:
+      jobKind: CronJob
+    job:
+      schedule: "0 18 27 8 *" # 6 PM 27th Aug UTC
+      suspend: true
+      memoryRequests: '1Gi'
+      memoryLimits: '2Gi'
+      image: sdshmctspublic.azurecr.io/pre/api:prod-2dc68c8-20250822112300 # {"$imagepolicy": "flux-system:pre-api"}
+      environment:
+        MEDIA_SERVICE: MediaKind
+        ENABLE_NEW_EMAIL_SERVICE: true
+        PORTAL_URL: https://portal.pre-recorded-evidence.justice.gov.uk/

--- a/apps/pre/pre-api-cron-vodafone-mk-import/stg.yaml
+++ b/apps/pre/pre-api-cron-vodafone-mk-import/stg.yaml
@@ -1,0 +1,20 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: pre-api-cron-vodafone-mk-import
+  namespace: pre
+spec:
+  values:
+    global:
+      jobKind: CronJob
+    job:
+      schedule: "0 18 27 8 *" # 6 PM 27th Aug UTC
+      suspend: true
+      memoryRequests: '1Gi'
+      memoryLimits: '2Gi'
+      image: sdshmctspublic.azurecr.io/pre/api:prod-2dc68c8-20250822112300 # {"$imagepolicy": "flux-system:pre-api"}
+      environment:
+        AZURE_SUBSCRIPTION_ID: 74dacd4f-a248-45bb-a2f0-af700dc4cf68
+        PLATFORM_ENV_TAG: Staging
+        MEDIA_SERVICE: MediaKind
+        ENABLE_NEW_EMAIL_SERVICE: true

--- a/apps/pre/pre-api-cron-vodafone-mk-import/test-image-policy.yaml
+++ b/apps/pre/pre-api-cron-vodafone-mk-import/test-image-policy.yaml
@@ -1,0 +1,14 @@
+apiVersion: image.toolkit.fluxcd.io/v1beta2
+kind: ImagePolicy
+metadata:
+  name: test-pre-api-cron-vodafone-mk-import
+  annotations:
+    hmcts.github.com/prod-automated: disabled
+spec:
+  filterTags:
+    pattern: 'pr\-1118'
+  policy:
+    alphabetical:
+      order: asc
+  imageRepositoryRef:
+    name: pre-api

--- a/apps/pre/pre-api-cron-vodafone-mk-import/test.yaml
+++ b/apps/pre/pre-api-cron-vodafone-mk-import/test.yaml
@@ -1,0 +1,20 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: pre-api-cron-vodafone-mk-import
+  namespace: pre
+spec:
+  values:
+    global:
+      jobKind: CronJob
+    job:
+      schedule: "0 18 27 8 *" # 6 PM 27th Aug UTC
+      memoryRequests: '1Gi'
+      memoryLimits: '2Gi'
+      suspend: true
+      image: sdshmctspublic.azurecr.io/pre/api:prod-2dc68c8-20250822112300 # {"$imagepolicy": "flux-system:pre-api"}
+      environment:
+        AZURE_SUBSCRIPTION_ID: 3eec5bde-7feb-4566-bfb6-805df6e10b90
+        PLATFORM_ENV_TAG: Testing
+        MEDIA_SERVICE: MediaKind
+        PORTAL_URL: https://pre-portal.test.platform.hmcts.net/

--- a/apps/pre/prod/base/kustomization.yaml
+++ b/apps/pre/prod/base/kustomization.yaml
@@ -15,6 +15,7 @@ resources:
   - ../../pre-api-cron-vodafone-etl-post-migration/pre-api-cron-vodafone-etl-post-migration.yaml
   - ../../pre-api-cron-vodafone-etl-process-full/pre-api-cron-vodafone-etl-process-full.yaml
   - ../../pre-api-cron-cleanup-null-durations/pre-api-cron-cleanup-null-durations.yaml
+  - ../../pre-api-cron-vodafone-mk-import/pre-api-cron-vodafone-mk-import.yaml
   - ../../../base/slack-provider/prod
 namespace: pre
 patches:
@@ -34,4 +35,5 @@ patches:
   - path: ../../pre-api-cron-vodafone-etl-post-migration/prod.yaml
   - path: ../../pre-api-cron-vodafone-etl-process-full/prod.yaml
   - path: ../../pre-api-cron-cleanup-null-durations/prod.yaml
+  - path: ../../pre-api-cron-vodafone-mk-import/prod.yaml
   - path: ../../serviceaccount/prod.yaml

--- a/apps/pre/stg/base/kustomization.yaml
+++ b/apps/pre/stg/base/kustomization.yaml
@@ -15,6 +15,7 @@ resources:
   - ../../pre-api-cron-vodafone-etl-post-migration/pre-api-cron-vodafone-etl-post-migration.yaml
   - ../../pre-api-cron-vodafone-etl-process-full/pre-api-cron-vodafone-etl-process-full.yaml
   - ../../pre-api-cron-cleanup-null-durations/pre-api-cron-cleanup-null-durations.yaml
+  - ../../pre-api-cron-vodafone-mk-import/pre-api-cron-vodafone-mk-import.yaml
   - ../../../rbac/nonprod-role.yaml
   - ../../../base/slack-provider/stg
 namespace: pre
@@ -35,4 +36,5 @@ patches:
   - path: ../../pre-api-cron-vodafone-etl-post-migration/stg.yaml
   - path: ../../pre-api-cron-vodafone-etl-process-full/stg.yaml
   - path: ../../pre-api-cron-cleanup-null-durations/stg.yaml
+  - path: ../../pre-api-cron-vodafone-mk-import/stg.yaml
   - path: ../../serviceaccount/stg.yaml

--- a/apps/pre/test/base/kustomization.yaml
+++ b/apps/pre/test/base/kustomization.yaml
@@ -15,6 +15,7 @@ resources:
   - ../../pre-api-cron-vodafone-etl-post-migration/pre-api-cron-vodafone-etl-post-migration.yaml
   - ../../pre-api-cron-vodafone-etl-process-full/pre-api-cron-vodafone-etl-process-full.yaml
   - ../../pre-api-cron-cleanup-null-durations/pre-api-cron-cleanup-null-durations.yaml
+  - ../../pre-api-cron-vodafone-mk-import/pre-api-cron-vodafone-mk-import.yaml
   - ../../../rbac/nonprod-role.yaml
   - ../../../base/slack-provider/test
 namespace: pre
@@ -35,4 +36,5 @@ patches:
   - path: ../../pre-api-cron-vodafone-etl-post-migration/prod.yaml
   - path: ../../pre-api-cron-vodafone-etl-process-full/prod.yaml
   - path: ../../pre-api-cron-cleanup-null-durations/test.yaml
+  - path: ../../pre-api-cron-vodafone-mk-import/test.yaml
   - path: ../../serviceaccount/test.yaml


### PR DESCRIPTION
### Change description
- Create migration cron for `BatchImportMissingMkAssets` task in pre-api - suspended in all envs