### PR TITLE
Run BatchImportMissingMkAssets task in staging against 4 test recordings

### DIFF
--- a/apps/pre/pre-api-cron-vodafone-mk-import/stg.yaml
+++ b/apps/pre/pre-api-cron-vodafone-mk-import/stg.yaml
@@ -8,8 +8,8 @@ spec:
     global:
       jobKind: CronJob
     job:
-      schedule: "0 18 27 8 *" # 6 PM 27th Aug UTC
-      suspend: true
+      schedule: "30 14 12 9 *" # 15:30pm (BST) - 12 Sept
+      suspend: false
       memoryRequests: '1Gi'
       memoryLimits: '2Gi'
       image: sdshmctspublic.azurecr.io/pre/api:prod-a0b2dc7-20250911155645 # {"$imagepolicy": "flux-system:pre-api"}


### PR DESCRIPTION
Runs Friday on 12 Sept 14.30 UTC (15.30 BST)