### PR TITLE
Vodafone MK assets run in stg

### DIFF
--- a/apps/pre/pre-api-cron-vodafone-mk-import/stg.yaml
+++ b/apps/pre/pre-api-cron-vodafone-mk-import/stg.yaml
@@ -8,7 +8,7 @@ spec:
     global:
       jobKind: CronJob
     job:
-      schedule: "45 15 15 9 *" # 16:15pm (BST) - 15 Sept
+      schedule: "15 9 16 9 *" # 10.15pm (BST) - 16 Sept
       suspend: false
       memoryRequests: '1Gi'
       memoryLimits: '2Gi'


### PR DESCRIPTION
Runs 16th September 9.15 UTC (10.15 BST)