### PR TITLE
Revert "Update jenkins image tag - ptlsbox"

### DIFF
--- a/apps/jenkins/jenkins/ptlsbox/jenkins.yaml
+++ b/apps/jenkins/jenkins/ptlsbox/jenkins.yaml
@@ -16,7 +16,6 @@ spec:
       image:
         registry: hmctspublic.azurecr.io
         repository: jenkins/jenkins
-        tag: 2.527-1003
       ingress:
         hostName: sds-sandbox-build.hmcts.net
       secondaryingress:


### PR DESCRIPTION
Reverts hmcts/sds-flux-config#7195

SDS Jenkins is working again so this is no longer required