### PR TITLE
DTSPO-27574 - Add role and rolebinding for github auth to run DB quer…

### DIFF
--- a/apps/darts-modernisation/prod/base/kustomization.yaml
+++ b/apps/darts-modernisation/prod/base/kustomization.yaml
@@ -4,6 +4,7 @@ resources:
   - ../../base
   - ../../../base/slack-provider/prod
   - ./darts-api-function.enc.yaml
+  - ../../../rbac/db-query-job-role.yaml
 namespace: darts-modernisation
 patches:
   - path: ../../darts-api/prod.yaml

--- a/apps/hmi/prod/base/kustomization.yaml
+++ b/apps/hmi/prod/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ../../base
   - ../../../base/slack-provider/prod
+  - ../../../rbac/db-query-job-role.yaml
 namespace: hmi
 patches:
   - path: ../../hmi-rota-dtu/prod.yaml

--- a/apps/juror-digital/prod/base/kustomization.yaml
+++ b/apps/juror-digital/prod/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ../../base
   - ../../../base/slack-provider/prod
+  - ../../../rbac/db-query-job-role.yaml
 namespace: jd
 patches:
   - path: ../../identity/prod.yaml

--- a/apps/juror/prod/base/kustomization.yaml
+++ b/apps/juror/prod/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ../../base
   - ../../../base/slack-provider/prod
+  - ../../../rbac/db-query-job-role.yaml
 namespace: juror
 patches:
   - path: ../../juror-scheduler-api/prod.yaml

--- a/apps/mailrelay/prod/base/kustomization.yaml
+++ b/apps/mailrelay/prod/base/kustomization.yaml
@@ -4,6 +4,7 @@ namespace: mailrelay
 resources:
   - ../../base
   - ../../mailrelay/prod/mailrelay-values.enc.yaml
+  - ../../../rbac/db-query-job-role.yaml
 patches:
   - path: ../../mailrelay/prod/prod.yaml
   - path: ../../serviceaccount/prod.yaml

--- a/apps/mailrelay2/prod/base/kustomization.yaml
+++ b/apps/mailrelay2/prod/base/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - ../../base
   - ../../mailrelay2/prod/mailrelay-values.enc.yaml
+  - ../../../rbac/db-query-job-role.yaml
 namespace: mailrelay2
 patches:
   - path: ../../mailrelay2/prod/prod.yaml

--- a/apps/met/prod/base/kustomization.yaml
+++ b/apps/met/prod/base/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - ../../pod-delete-cron/pod-delete-cron-rbac.yaml
   - ../../pod-delete-cron/pod-delete-cron.yaml
   - ../../pod-delete-cron/pod-delete-service-account-prod.yaml
+  - ../../../rbac/db-query-job-role.yaml
 namespace: met
 patches:
   - path: ../../identity/prod.yaml

--- a/apps/mi/prod/base/kustomization.yaml
+++ b/apps/mi/prod/base/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - ../../base
   - mi-adf-auth-values.enc.yaml
   - ../../../base/slack-provider/prod
+  - ../../../rbac/db-query-job-role.yaml
 patches:
   - path: ../../mi-azure-functions/prod.yaml
   - path: ../../mi-adf-shir/prod.yaml

--- a/apps/pip/prod/base/kustomization.yaml
+++ b/apps/pip/prod/base/kustomization.yaml
@@ -13,6 +13,7 @@ resources:
   - ../../data-management/pip-data-management.yaml
   - ../../frontend/pip-frontend.yaml
   - ../../../base/slack-provider/prod
+  - ../../../rbac/db-query-job-role.yaml
 namespace: pip
 patches:
   - path: ../../identity/prod.yaml

--- a/apps/pre/prod/base/kustomization.yaml
+++ b/apps/pre/prod/base/kustomization.yaml
@@ -17,6 +17,7 @@ resources:
   - ../../pre-api-cron-cleanup-null-durations/pre-api-cron-cleanup-null-durations.yaml
   - ../../pre-api-cron-vodafone-mk-import/pre-api-cron-vodafone-mk-import.yaml
   - ../../../base/slack-provider/prod
+  - ../../../rbac/db-query-job-role.yaml
 namespace: pre
 patches:
   - path: ../../identity/prod.yaml

--- a/apps/rbac/db-query-job-role.yaml
+++ b/apps/rbac/db-query-job-role.yaml
@@ -1,0 +1,29 @@
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: db-query-job-role
+  namespace: ${NAMESPACE}
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["create", "get", "list", "update", "patch", "delete"]
+- apiGroups: ["batch"]
+  resources: ["jobs", "cronjobs"]
+  verbs: ["create", "get", "list", "update", "patch", "delete"]
+- apiGroups: ["helm.fluxcd.io", "helm.toolkit.fluxcd.io"]
+  resources: ["helmreleases"]
+  verbs: ["create", "get", "list", "update", "patch", "delete"]
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: db-query-job-rolebinding
+  namespace: ${NAMESPACE}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: db-query-job-role
+subjects:
+- kind: User
+  apiGroup: rbac.authorization.k8s.io
+  name: "ab2a5eb5-d42a-423f-b12e-3b5cca105868" # ObjectID for DTS Auto DB Query app registration

--- a/apps/toffee/prod/base/kustomization.yaml
+++ b/apps/toffee/prod/base/kustomization.yaml
@@ -2,6 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base
+  - ../../../rbac/db-query-job-role.yaml
 namespace: toffee
 patches:
   - path: ../../identity/prod.yaml


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-27574

### Change description

Adding role and rolebinding for github to authenticate with cluster to deploy helm release to run DB query jobs.
This only applies to aat and prod

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
