### PR TITLE
fix-toffee-frontend-sbox-2

### DIFF
--- a/apps/toffee/frontend/sbox.yaml
+++ b/apps/toffee/frontend/sbox.yaml
@@ -9,7 +9,7 @@ spec:
       image: sdshmctspublic.azurecr.io/toffee/frontend:prod-f8bc08c-20250225100311 #{"$imagepolicy": "flux-system:toffee-frontend-sbox"}
       ingressHost: toffee.sandbox.platform.hmcts.net
       environment:
-        RECIPE_BACKEND_URL: http://toffee-recipe-backend-wrong-service.sandbox.platform.hmcts.net  # BREAKING: Wrong backend service URL
+        RECIPE_BACKEND_URL: http://toffee-recipe-backend.sandbox.platform.hmcts.net  # FIXED: Correct backend service URL
       useWorkloadIdentity: true
       workloadClientID: ${INVALID_WORKLOAD_ID}  # BREAKING: Invalid workload identity
     global:


### PR DESCRIPTION
Fix: Correct RECIPE_BACKEND_URL for toffee-frontend in sbox environment