### PR TITLE
Add ListAssist mcmshmcts training alias for MI SHIR

### DIFF
--- a/apps/mi/mi-adf-shir-2/dev.yaml
+++ b/apps/mi/mi-adf-shir-2/dev.yaml
@@ -18,3 +18,6 @@ spec:
     - ip: 20.209.128.129
       hostnames:
       - mcmshmctssitdataextract.blob.core.windows.net
+    - ip: 20.60.166.1
+      hostnames:
+      - mcmshmctstrndataextract.blob.core.windows.net

--- a/apps/mi/mi-adf-shir/dev.yaml
+++ b/apps/mi/mi-adf-shir/dev.yaml
@@ -18,3 +18,6 @@ spec:
     - ip: 20.209.128.129
       hostnames:
       - mcmshmctssitdataextract.blob.core.windows.net
+    - ip: 20.60.166.1
+      hostnames:
+      - mcmshmctstrndataextract.blob.core.windows.net


### PR DESCRIPTION
Require network connection to ListAssist training environment so we can use ADF to pull data from there.