### PR TITLE
Crime IDAM integration with CaTH

### DIFF
--- a/apps/pip/frontend/prod.yaml
+++ b/apps/pip/frontend/prod.yaml
@@ -21,3 +21,4 @@ spec:
         B2C_ADMIN_URL: https://staff.court-tribunal-hearings.service.gov.uk/court-tribunal-hearings.service.gov.uk
         CFT_IDAM_URL: https://hmcts-access.service.gov.uk
         RESTART_PROD: false
+        CRIME_IDAM_URL: https://login.cjscp.org.uk


### PR DESCRIPTION
### Change description

This PR will help in enabling Crime IDAM integration for CaTH on Production. We need to merge this ticket on Wednesday 1st October 2025.