### PR TITLE
Updating creds for hourlyusage reports

### DIFF
--- a/apps/monitoring/prod/00/hourlyusage.enc.yaml
+++ b/apps/monitoring/prod/00/hourlyusage.enc.yaml
@@ -1,19 +1,25 @@
 apiVersion: v1
 data:
-  access_key: ENC[AES256_GCM,data:vaw/zGWGMobKLJTxtymxrL8e1f/vuwQ8uIWWrKigEAl5VZqKk5KtkYaEv7WAmDxAGgU0vRTxgT8=,iv:xtCRGXRiGAxatuxiGddxl6PEK0vY9mPcm3k3oNbJOuo=,tag:OYLIEEIz6fvxtEBg4hCk4Q==,type:str]
+  access_key: ENC[AES256_GCM,data:oF8Mj3gH+he4yE7ht2bxgiHKxHPKppc1IcmAMra3mlnz6N5jPhT2Fn8CneSnyLZx4xWAfLxtnyH0+s2V+jjZK9Covbkuzwxfx/VgvZ/xJ+2PcTDWxUsTPXFXt3aeR1dhlKfY1tjfHpIlkUsC+sjarapCaOau6rIZ,iv:eZpUtSGqCDH4mx1MX7idOjsAs/yset+rFiE8aCXerNg=,tag:8Ppw5aKwNhYOTDue7rTXhA==,type:str]
 kind: Secret
 metadata:
+  creationTimestamp: null
   name: vm-hourlyusage
   namespace: monitoring
 type: Opaque
 sops:
+  kms: []
+  gcp_kms: []
   azure_kv:
     - vault_url: https://dtssharedservicesprodkv.vault.azure.net
       name: sops-key
       version: 883d8b431ad345d09b2697c3aaae2a0c
-      created_at: "2025-09-26T11:12:20Z"
-      enc: iJyImXa2pjuO6aLAxpUoLBraPx-B49gusJ7N5oKuFItMcQ6-snrHKY09FWd-TrchXwANiBJMGem5eqatmFSCy6f4vmCO0i7zyrhbD8vMEVQ1GFBXkUbgD89Cowi0_uAhOkfWbtNsL6PhYkz6dMlBNZTj8obGyeedOCt2hGcG5kUQXo7kibBKv3HwyNeTzy9GVgwuqxAEo-m-2DYJuxSOYHGGd1TeusgT7j6oF3baxPVIFEq7Gsbxvpe_0EWiRgkNRe8UnL4KkJ7-gAQ43sIQIBKz2HPlo42kHdFDV87rMPxYC296EV3Y_8BwoFi_hzYyOBHts6hQFi1zoY0rrzuWmg
-  lastmodified: "2025-09-26T11:12:23Z"
-  mac: ENC[AES256_GCM,data:mJUMkll0PVMUMPBAX4GHuEcZ4N2co9DMBBa3oqk69rvkNYQrQERN5Ss9dG4p5CTmI8w5G4ZfD2G4ItxJ61y5iXfaDFdKNyprA/UocjS+Tq/JN/vnf10PcOYWGnC5Hnp9AFxcc9LAL+hf+0tN02MeAzlj0XDUKkE1ApFooOcjxuU=,iv:tXzuVWSVjITcMNNVI+fdwbldbLfc675PPB4fJzYN7xY=,tag:cD8xzsA+7I2KFDL1cYJRFw==,type:str]
+      created_at: "2025-09-29T11:53:17Z"
+      enc: hXFMx6ayYky92W_oXwqSsR6r6DLqqv88zEu42ghwhHH4pP4343JoFJlwv74SjvBRM1L7Jgg0HEdYFBxWyzr4o_4D6Tv-ojPSr0LtJfd0Kv7BisbIgsdxZxr8oen3OkWgyCU94YuRr-rlZ-y7ovpK7APf9gyZg27sjBzgJqyhnGkz3Oyz7m1sxEKfnOQG_e3zcveUtLarCxV4e32DAcn51gCnhpNeNIVljCUpWIV9pKGzXD59_gV04sj6XT4dRoAwddEYlS822RMmXBcLu6J9v0peDsMqCuPd7ldUDs_Rh57igfrzaw68AKNQKZrTg85qxXXJSRyzF1Lrb1K-OXHU9Q
+  hc_vault: []
+  age: []
+  lastmodified: "2025-09-29T11:53:20Z"
+  mac: ENC[AES256_GCM,data:t1aVvfB/nk/wBOwyLrkTBoBR3gJuH5OqeC7gQfdMRSiSipSmstolY3/uVEUUqpCt36J/t1BQ9MmKhc/WPiEMr1xKAsqRKqdW/IJECHceJljT47DxtGjF/xHFXNpYunr91B3USwrbjGK0PTOra9aRpsdisUQjxQeZ9s5Y6qqUnjI=,iv:ZarDuKBHmtrUFxsKrSbKljKEeek8XsUx7VbtP/UjOao=,tag:GJhOpn7x/Rne3ZjVFYiFVg==,type:str]
+  pgp: []
   encrypted_regex: ^(data|stringData)$
-  version: 3.10.2
+  version: 3.9.1

--- a/apps/monitoring/prod/00/version-reporter.enc.yaml
+++ b/apps/monitoring/prod/00/version-reporter.enc.yaml
@@ -14,11 +14,11 @@ sops:
   kms: []
   gcp_kms: []
   azure_kv:
-      - vault_url: https://dtssharedservicesprodkv.vault.azure.net
-        name: sops-key
-        version: 883d8b431ad345d09b2697c3aaae2a0c
-        created_at: "2025-09-29T12:05:15Z"
-        enc: Z_yovv4pEFrd4AvCarSQWHr8zxcfV6RkK2ZQtSdbHLJih9gO710VOpc62RTtvhgWJUhpclXvg4K-llJ4t0A5TceHSxRjfRJ_wudoQfMMVm-VgR0TP_e6S6B8AaytyKUs5mjum5AvybO0igaZVC-B1bwEwDKCaST9ddOW2KWVQ1EypA-MlDfqM31aTOmv0U7HVyp8q0xoWZYriA1Tow1tZWqqXHU2ssov4PPL6SXhhKL3xdl9iHDpT7TwjTygNLNbSscR6d1MfLQz_oNc0OgMNM9TDnDfoJYzkS7V5hbwo6xjrU89h6Mw14FlaiWcLPENXO3DCGgpEpAJDrxiJ5jFjA
+    - vault_url: https://dtssharedservicesprodkv.vault.azure.net
+      name: sops-key
+      version: 883d8b431ad345d09b2697c3aaae2a0c
+      created_at: "2025-09-29T12:05:15Z"
+      enc: Z_yovv4pEFrd4AvCarSQWHr8zxcfV6RkK2ZQtSdbHLJih9gO710VOpc62RTtvhgWJUhpclXvg4K-llJ4t0A5TceHSxRjfRJ_wudoQfMMVm-VgR0TP_e6S6B8AaytyKUs5mjum5AvybO0igaZVC-B1bwEwDKCaST9ddOW2KWVQ1EypA-MlDfqM31aTOmv0U7HVyp8q0xoWZYriA1Tow1tZWqqXHU2ssov4PPL6SXhhKL3xdl9iHDpT7TwjTygNLNbSscR6d1MfLQz_oNc0OgMNM9TDnDfoJYzkS7V5hbwo6xjrU89h6Mw14FlaiWcLPENXO3DCGgpEpAJDrxiJ5jFjA
   hc_vault: []
   age: []
   lastmodified: "2025-09-29T12:05:25Z"

--- a/apps/monitoring/prod/00/version-reporter.enc.yaml
+++ b/apps/monitoring/prod/00/version-reporter.enc.yaml
@@ -1,28 +1,28 @@
 apiVersion: v1
 data:
-    client_id: ENC[AES256_GCM,data:kJZm6oYAl/ZQE44AjFj4v1xrvxyQ1j6sEe3glXLA3Q4F9zkX0DlZaBkzauTn2x3D,iv:ykU4IqYQbV0zJt1CzmAUnpjce7SbKIL4FpJShegsjHY=,tag:1hCCzzqp520eU19CRp/c2A==,type:str]
-    client_secret: ENC[AES256_GCM,data:X+HOZZ4ftkNuYxqb5fbEJpDMSr1adg6CosUz5ESPsnHJEUfcqInVQj8va4cmI4S/V8SWEs9+tDI=,iv:tzcntXQn5J52SYcl/Cql3qOlcr+LCSwJQA/OoAnwCZM=,tag:y183DTSgQ5wHShqIH0pb7g==,type:str]
-    cosmos_key: ENC[AES256_GCM,data:takYJcVXoe0MusPlktehvYSTdpF8H6F6xM2p34+evHqSFs4vmjKF+E0lz5Lkg9l76LxleB22wkpaBGODQeCCFJRMtgFPlTYShlKdsoNqO+ggMU+kpleCrze6cbatNRUZyuwl8+YcdhRISwzIke9Tr/+aMCh0lcmU,iv:NzXKSQkDVKO3Xaz4X8Yx4vStjxTYeIEkDIxgUYgagOs=,tag:GmgFXaFIqO6Jas+MsoGQVQ==,type:str]
-    tenant_id: ENC[AES256_GCM,data:tZCNwFV1EOd2GWiV2qcI54R5bOrEVHICCsiJDSjJkOcPDJdK2KLefnFZWnXp1vtR,iv:pUehwnJA/EOUTZdbG5gkw5gimBT1tGS3UY9Buhn3ZT0=,tag:NoAAYEFAv6Nbx19CRvyrkg==,type:str]
+  client_id: ENC[AES256_GCM,data:kJZm6oYAl/ZQE44AjFj4v1xrvxyQ1j6sEe3glXLA3Q4F9zkX0DlZaBkzauTn2x3D,iv:ykU4IqYQbV0zJt1CzmAUnpjce7SbKIL4FpJShegsjHY=,tag:1hCCzzqp520eU19CRp/c2A==,type:str]
+  client_secret: ENC[AES256_GCM,data:X+HOZZ4ftkNuYxqb5fbEJpDMSr1adg6CosUz5ESPsnHJEUfcqInVQj8va4cmI4S/V8SWEs9+tDI=,iv:tzcntXQn5J52SYcl/Cql3qOlcr+LCSwJQA/OoAnwCZM=,tag:y183DTSgQ5wHShqIH0pb7g==,type:str]
+  cosmos_key: ENC[AES256_GCM,data:takYJcVXoe0MusPlktehvYSTdpF8H6F6xM2p34+evHqSFs4vmjKF+E0lz5Lkg9l76LxleB22wkpaBGODQeCCFJRMtgFPlTYShlKdsoNqO+ggMU+kpleCrze6cbatNRUZyuwl8+YcdhRISwzIke9Tr/+aMCh0lcmU,iv:NzXKSQkDVKO3Xaz4X8Yx4vStjxTYeIEkDIxgUYgagOs=,tag:GmgFXaFIqO6Jas+MsoGQVQ==,type:str]
+  tenant_id: ENC[AES256_GCM,data:tZCNwFV1EOd2GWiV2qcI54R5bOrEVHICCsiJDSjJkOcPDJdK2KLefnFZWnXp1vtR,iv:pUehwnJA/EOUTZdbG5gkw5gimBT1tGS3UY9Buhn3ZT0=,tag:NoAAYEFAv6Nbx19CRvyrkg==,type:str]
 kind: Secret
 metadata:
-    creationTimestamp: null
-    name: version-reporter
-    namespace: monitoring
+  creationTimestamp: null
+  name: version-reporter
+  namespace: monitoring
 type: Opaque
 sops:
-    kms: []
-    gcp_kms: []
-    azure_kv:
-        - vault_url: https://dtssharedservicesprodkv.vault.azure.net
-          name: sops-key
-          version: 883d8b431ad345d09b2697c3aaae2a0c
-          created_at: "2025-09-29T12:05:15Z"
-          enc: Z_yovv4pEFrd4AvCarSQWHr8zxcfV6RkK2ZQtSdbHLJih9gO710VOpc62RTtvhgWJUhpclXvg4K-llJ4t0A5TceHSxRjfRJ_wudoQfMMVm-VgR0TP_e6S6B8AaytyKUs5mjum5AvybO0igaZVC-B1bwEwDKCaST9ddOW2KWVQ1EypA-MlDfqM31aTOmv0U7HVyp8q0xoWZYriA1Tow1tZWqqXHU2ssov4PPL6SXhhKL3xdl9iHDpT7TwjTygNLNbSscR6d1MfLQz_oNc0OgMNM9TDnDfoJYzkS7V5hbwo6xjrU89h6Mw14FlaiWcLPENXO3DCGgpEpAJDrxiJ5jFjA
-    hc_vault: []
-    age: []
-    lastmodified: "2025-09-29T12:05:25Z"
-    mac: ENC[AES256_GCM,data:jfkjV8K8hOqQF+wG4+kCyjxz9qOvUDLygYRdC0zfenD6jmYrClmbW/K6rE95Ht2AltJdWNMhXTGMjXClZ3cWZQUrnI2/Bj9BZhQxRH1UzRzCO3THGU3OrP91cEPYQ5+om+uhC5ult4N7ARI0e93P9I701jq+bBZQB4COIPrEVlQ=,iv:3ijSdwg4YkrOftaFGwsTiUpO6tkizAxpjnSZecwtptA=,tag:LmBkap2UkGvg9vvrBpru/A==,type:str]
-    pgp: []
-    encrypted_regex: ^(data|stringData)$
-    version: 3.9.1
+  kms: []
+  gcp_kms: []
+  azure_kv:
+      - vault_url: https://dtssharedservicesprodkv.vault.azure.net
+        name: sops-key
+        version: 883d8b431ad345d09b2697c3aaae2a0c
+        created_at: "2025-09-29T12:05:15Z"
+        enc: Z_yovv4pEFrd4AvCarSQWHr8zxcfV6RkK2ZQtSdbHLJih9gO710VOpc62RTtvhgWJUhpclXvg4K-llJ4t0A5TceHSxRjfRJ_wudoQfMMVm-VgR0TP_e6S6B8AaytyKUs5mjum5AvybO0igaZVC-B1bwEwDKCaST9ddOW2KWVQ1EypA-MlDfqM31aTOmv0U7HVyp8q0xoWZYriA1Tow1tZWqqXHU2ssov4PPL6SXhhKL3xdl9iHDpT7TwjTygNLNbSscR6d1MfLQz_oNc0OgMNM9TDnDfoJYzkS7V5hbwo6xjrU89h6Mw14FlaiWcLPENXO3DCGgpEpAJDrxiJ5jFjA
+  hc_vault: []
+  age: []
+  lastmodified: "2025-09-29T12:05:25Z"
+  mac: ENC[AES256_GCM,data:jfkjV8K8hOqQF+wG4+kCyjxz9qOvUDLygYRdC0zfenD6jmYrClmbW/K6rE95Ht2AltJdWNMhXTGMjXClZ3cWZQUrnI2/Bj9BZhQxRH1UzRzCO3THGU3OrP91cEPYQ5+om+uhC5ult4N7ARI0e93P9I701jq+bBZQB4COIPrEVlQ=,iv:3ijSdwg4YkrOftaFGwsTiUpO6tkizAxpjnSZecwtptA=,tag:LmBkap2UkGvg9vvrBpru/A==,type:str]
+  pgp: []
+  encrypted_regex: ^(data|stringData)$
+  version: 3.9.1

--- a/apps/monitoring/prod/00/version-reporter.enc.yaml
+++ b/apps/monitoring/prod/00/version-reporter.enc.yaml
@@ -1,26 +1,28 @@
 apiVersion: v1
 data:
-  client_id: ENC[AES256_GCM,data:3zzYJ7EUy/i+RMbEcJ6bphOjPZDYLDpvsDR70FyVLduhtPjwZm3i/HdIirT30u1u,iv:pYLEOpmeuglYyGL6knEG1SgNNrwV9YDtjPwsaiqUUjc=,tag:DO5vwjnQFCBWwPgMvu2zww==,type:str]
-  client_secret: ENC[AES256_GCM,data:OkHkbmqCCGaIiyP5h/kkBdhy+n/TgO7mUhNgAphWfZcI+XHFQdGoKDIWMN2nBYg+ICyoA7vEqQs=,iv:5aktkeBm4gL5oxzpzTUPwLyvwkrahOrxgdChmBXC7jw=,tag:wBQ2j+ZJlp9XtX0B68rImQ==,type:str]
-  cosmos_key: ENC[AES256_GCM,data:kEXGKYc9yRC8O4yFzAe0iQVgA20UIEp7EHT3WlpKNX4c6q93nQ9AxOrefrK6cd3Fu3psrkfTnbzGVbHMiFYXZj/uvQibt/Zr6tlp4lAjawqNONd5gFBGYT1W2LY8ZEHgBRq9fKRzEXfVUG4MoPmn5vN51Zprxo0l,iv:JV7HXJppv7aYSLUDCELPpdmHvuL3fdhtVaij4BbVfCc=,tag:4aiO/zgN/CIgUSNmU7PApA==,type:str]
-  tenant_id: ENC[AES256_GCM,data:cZRR4WhstxtMqcyapmL5CO4Tx02AXDflZVMQ3D6aB+e45GV9O6nBQBAMEXr7Uo9N,iv:bmoRGyOgHmjzTl9c+JffDC2jD2h9P01iSbq6ikyWALU=,tag:VjEExo8LQ4MLvtrx7ZFDFw==,type:str]
+    client_id: ENC[AES256_GCM,data:kJZm6oYAl/ZQE44AjFj4v1xrvxyQ1j6sEe3glXLA3Q4F9zkX0DlZaBkzauTn2x3D,iv:ykU4IqYQbV0zJt1CzmAUnpjce7SbKIL4FpJShegsjHY=,tag:1hCCzzqp520eU19CRp/c2A==,type:str]
+    client_secret: ENC[AES256_GCM,data:X+HOZZ4ftkNuYxqb5fbEJpDMSr1adg6CosUz5ESPsnHJEUfcqInVQj8va4cmI4S/V8SWEs9+tDI=,iv:tzcntXQn5J52SYcl/Cql3qOlcr+LCSwJQA/OoAnwCZM=,tag:y183DTSgQ5wHShqIH0pb7g==,type:str]
+    cosmos_key: ENC[AES256_GCM,data:takYJcVXoe0MusPlktehvYSTdpF8H6F6xM2p34+evHqSFs4vmjKF+E0lz5Lkg9l76LxleB22wkpaBGODQeCCFJRMtgFPlTYShlKdsoNqO+ggMU+kpleCrze6cbatNRUZyuwl8+YcdhRISwzIke9Tr/+aMCh0lcmU,iv:NzXKSQkDVKO3Xaz4X8Yx4vStjxTYeIEkDIxgUYgagOs=,tag:GmgFXaFIqO6Jas+MsoGQVQ==,type:str]
+    tenant_id: ENC[AES256_GCM,data:tZCNwFV1EOd2GWiV2qcI54R5bOrEVHICCsiJDSjJkOcPDJdK2KLefnFZWnXp1vtR,iv:pUehwnJA/EOUTZdbG5gkw5gimBT1tGS3UY9Buhn3ZT0=,tag:NoAAYEFAv6Nbx19CRvyrkg==,type:str]
 kind: Secret
 metadata:
-  name: version-reporter
-  namespace: monitoring
+    creationTimestamp: null
+    name: version-reporter
+    namespace: monitoring
+type: Opaque
 sops:
-  kms: []
-  gcp_kms: []
-  azure_kv:
-    - vault_url: https://dtssharedservicesprodkv.vault.azure.net
-      name: sops-key
-      version: 883d8b431ad345d09b2697c3aaae2a0c
-      created_at: "2023-11-29T13:49:32Z"
-      enc: g1k3n0ICeOs7cpKJGEPpAu_xmXgS4BgyZg8VQlQEdh4x6QFdVGERTHBjsDVrenoZsPVqH9TYGTLZ13TGd-r3thW6LPEzI_UgZSxy6hcBJvm2TUfKySHkH-Bku05a8_T5O0zp0g9vP_X7gqE59oZDh3ONqT1YZkACJsim5JJkXi_N2wq5h-BHeLnAk8dJHfUdU2qASAecakX2eDfJyvE9dRqR9DE0mAlAURKN5RgctztUrmA26YDostQBAXAITLE4QRO4d-ayNk5XHZthHZ8H5RYUGdu1-VcawiNS4JHKo9GY-agaRTG_uHssAufLJDPRRGbe7Yw4j9vI8Bm98TL5ew
-  hc_vault: []
-  age: []
-  lastmodified: "2023-11-29T13:49:32Z"
-  mac: ENC[AES256_GCM,data:ohywlBUj55oLmr6qQHY6FtMWV0SRszFc6kkYYjRaohvh1yozqEWR9GnzgA9V+RbZgGyNJ78Sn3Q27DDWXaHQlmud6Zg/iijJfGGJpM2UPylM8RBfic+hM+2H8jw1ZFiK+eNwviGEM1GF8v/HZs9F6jwKK9Y7v6mG/A+DHjbusqE=,iv:5JKYNoZRu1cvQiZPWDSr55B4tc9cRtNxZ3dW4I8eG88=,tag:YtjJSRbBNHnwAOj9CCwRLQ==,type:str]
-  pgp: []
-  encrypted_regex: ^(data|stringData)$
-  version: 3.7.3
+    kms: []
+    gcp_kms: []
+    azure_kv:
+        - vault_url: https://dtssharedservicesprodkv.vault.azure.net
+          name: sops-key
+          version: 883d8b431ad345d09b2697c3aaae2a0c
+          created_at: "2025-09-29T12:05:15Z"
+          enc: Z_yovv4pEFrd4AvCarSQWHr8zxcfV6RkK2ZQtSdbHLJih9gO710VOpc62RTtvhgWJUhpclXvg4K-llJ4t0A5TceHSxRjfRJ_wudoQfMMVm-VgR0TP_e6S6B8AaytyKUs5mjum5AvybO0igaZVC-B1bwEwDKCaST9ddOW2KWVQ1EypA-MlDfqM31aTOmv0U7HVyp8q0xoWZYriA1Tow1tZWqqXHU2ssov4PPL6SXhhKL3xdl9iHDpT7TwjTygNLNbSscR6d1MfLQz_oNc0OgMNM9TDnDfoJYzkS7V5hbwo6xjrU89h6Mw14FlaiWcLPENXO3DCGgpEpAJDrxiJ5jFjA
+    hc_vault: []
+    age: []
+    lastmodified: "2025-09-29T12:05:25Z"
+    mac: ENC[AES256_GCM,data:jfkjV8K8hOqQF+wG4+kCyjxz9qOvUDLygYRdC0zfenD6jmYrClmbW/K6rE95Ht2AltJdWNMhXTGMjXClZ3cWZQUrnI2/Bj9BZhQxRH1UzRzCO3THGU3OrP91cEPYQ5+om+uhC5ult4N7ARI0e93P9I701jq+bBZQB4COIPrEVlQ=,iv:3ijSdwg4YkrOftaFGwsTiUpO6tkizAxpjnSZecwtptA=,tag:LmBkap2UkGvg9vvrBpru/A==,type:str]
+    pgp: []
+    encrypted_regex: ^(data|stringData)$
+    version: 3.9.1


### PR DESCRIPTION
### Change description
Updated the credentials for the vm hourly report jobs. The jobs have been failing due to a change in the creds, reports is need by the finops team to enable RI calculations at the end of a period.
