### PR TITLE
Upgrade sandbox Traefik to 37.2.0 - add kustomization with updated CRDs and set sbox clusters to use this

### DIFF
--- a/apps/admin/traefik-crds-upgrade-v372/kustomization.yaml
+++ b/apps/admin/traefik-crds-upgrade-v372/kustomization.yaml
@@ -1,0 +1,13 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v37.2.0/traefik/crds/traefik.io_ingressroutetcps.yaml
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v37.2.0/traefik/crds/traefik.io_ingressroutes.yaml
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v37.2.0/traefik/crds/traefik.io_ingressrouteudps.yaml
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v37.2.0/traefik/crds/traefik.io_middlewares.yaml
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v37.2.0/traefik/crds/traefik.io_middlewaretcps.yaml
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v37.2.0/traefik/crds/traefik.io_serverstransports.yaml
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v37.2.0/traefik/crds/traefik.io_serverstransporttcps.yaml
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v37.2.0/traefik/crds/traefik.io_tlsoptions.yaml
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v37.2.0/traefik/crds/traefik.io_tlsstores.yaml
+  - https://raw.githubusercontent.com/traefik/traefik-helm-chart/v37.2.0/traefik/crds/traefik.io_traefikservices.yaml

--- a/apps/admin/traefik-crds-upgrade-v372/kustomize.yaml
+++ b/apps/admin/traefik-crds-upgrade-v372/kustomize.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: traefik-crd
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./apps/admin/traefik-crds-upgrade-v372

--- a/apps/admin/traefik2/sbox/00-traefik2.yaml
+++ b/apps/admin/traefik2/sbox/00-traefik2.yaml
@@ -4,6 +4,14 @@ metadata:
   name: traefik2
   namespace: admin
 spec:
+  chart:
+    spec:
+      chart: traefik
+      version: 37.2.0
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: admin
   values:
     ports:
       traefik:

--- a/apps/admin/traefik2/sbox/01-traefik2.yaml
+++ b/apps/admin/traefik2/sbox/01-traefik2.yaml
@@ -4,6 +4,14 @@ metadata:
   name: traefik2
   namespace: admin
 spec:
+  chart:
+    spec:
+      chart: traefik
+      version: 37.2.0
+      sourceRef:
+        kind: HelmRepository
+        name: traefik
+        namespace: admin
   values:
     ports:
       traefik:

--- a/clusters/sbox/base/kustomization.yaml
+++ b/clusters/sbox/base/kustomization.yaml
@@ -23,3 +23,4 @@ patches:
       annotationSelector: hmcts.github.com/kustomize-defaults != disabled
   - path: ../../../apps/toffee/sbox/base/kustomize.yaml
   - path: ../../../apps/admin/sbox/base/kustomize.yaml
+  - path: ../../../apps/admin/traefik-crds-upgrade-v372/kustomize.yaml


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DTSPO-27974

### Change description
Upgrade Traefik to 37.2.0 in Sandbox
- Add updated CRDs as a separate kustomization
- Set Sandbox clusters to use above kustomization

### Testing done
- No breaking changes mentioned in the [Traefik release notes](https://github.com/traefik/traefik-helm-chart/releases)
- Part of testing ahead of prod upgrade next week

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
