### PR TITLE
Added UTC Timezone for mi-azure-functions

### DIFF
--- a/apps/mi/mi-azure-functions/ithc.yaml
+++ b/apps/mi/mi-azure-functions/ithc.yaml
@@ -14,6 +14,7 @@ spec:
       MI_METADATA_SERVER: mi-metadata-server-ithc.database.windows.net
       MI_METADATA_SERVER_DB: mi-metadata-db-ithc
       ADF_INTEGRATIONRUNTIMENAME: IR-Self-hosted,IR-Self-hosted-2
+      TZ: UTC
     environment: "ithc"
     resourceGroup: "mi-ithc-rg"
     subscriptionId: "ba71a911-e0d6-4776-a1a6-079af1df7139"

--- a/apps/mi/mi-azure-functions/prod.yaml
+++ b/apps/mi/mi-azure-functions/prod.yaml
@@ -18,6 +18,7 @@ spec:
       MI_METADATA_SERVER_DB: mi-metadata-db-prod
       OPTIC_TOKEN_URL: https://hmcts.icasework.com/token
       ADF_INTEGRATIONRUNTIMENAME: IR-Self-hosted,IR-Self-hosted-2
+      TZ: UTC
     resourceGroup: "mi-prod-rg"
     subscriptionId: "5ca62022-6aa2-4cee-aaa7-e7536c8d566c"
     managedIdentityClientId: "6ca63ebe-d898-42fb-b5bb-88d67433c78f"

--- a/apps/mi/mi-azure-functions/sbox.yaml
+++ b/apps/mi/mi-azure-functions/sbox.yaml
@@ -22,6 +22,7 @@ spec:
       MI_METADATA_SERVER: mi-metadata-server-sbox.database.windows.net
       MI_METADATA_SERVER_DB: mi-metadata-db-sbox
       ADF_INTEGRATIONRUNTIMENAME: IR-Self-hosted,IR-Self-hosted-2
+      TZ: UTC
     environment: "sbox"
     resourceGroup: "mi-sbox-rg"
     subscriptionId: "a8140a9e-f1b0-481f-a4de-09e2ee23f7ab"

--- a/apps/mi/mi-azure-functions/stg.yaml
+++ b/apps/mi/mi-azure-functions/stg.yaml
@@ -14,6 +14,7 @@ spec:
       MI_METADATA_SERVER: mi-metadata-server-stg.database.windows.net
       MI_METADATA_SERVER_DB: mi-metadata-db-stg
       ADF_INTEGRATIONRUNTIMENAME: IR-Self-hosted,IR-Self-hosted-2
+      TZ: UTC
     environment: "stg"
     resourceGroup: "mi-stg-rg"
     subscriptionId: "74dacd4f-a248-45bb-a2f0-af700dc4cf68"

--- a/apps/mi/mi-azure-functions/test.yaml
+++ b/apps/mi/mi-azure-functions/test.yaml
@@ -14,6 +14,7 @@ spec:
       MI_METADATA_SERVER: mi-metadata-server-test.database.windows.net
       MI_METADATA_SERVER_DB: mi-metadata-db-test
       ADF_INTEGRATIONRUNTIMENAME: IR-Self-hosted,IR-Self-hosted-2
+      TZ: UTC
     environment: "test"
     resourceGroup: "mi-test-rg"
     subscriptionId: "3eec5bde-7feb-4566-bfb6-805df6e10b90"


### PR DESCRIPTION
Fixes an issue with Oracle servers detecting invalid timezone by enforcing UTC on the azure-functions mi release.