### PR TITLE
DTSPO-27732 Fix Missing hmctssbox-ocirepo.yaml in flux-system/base ku…

### DIFF
--- a/apps/flux-system/base/kustomization.yaml
+++ b/apps/flux-system/base/kustomization.yaml
@@ -7,6 +7,7 @@ resources:
 - sds-helm-charts-gitrepo.yaml
 - hmctspublic-helmrepo.yaml
 - hmctspublic-ocirepo.yaml
+- hmctssbox-ocirepo.yaml
 - hmcts-stable-charts-gitrepo.yaml
 - exim-relay-gitrepo.yaml
 - toffee-recipe-receiver-gitrepo.yaml


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DTSPO-27732

Fix Missing hmctssbox-ocirepo.yaml in flux-system/base kustomization.yaml