### PR TITLE
S28-0000 Revert process capture sessions job to run at 6:15pm every day

### DIFF
--- a/apps/pre/pre-api-cron-process-capture-sessions/prod.yaml
+++ b/apps/pre/pre-api-cron-process-capture-sessions/prod.yaml
@@ -8,9 +8,8 @@ spec:
     global:
       jobKind: CronJob
     job:
-      suspend: true
       disableActiveClusterCheck: true
-      schedule: "*/5 * * * *"
+      schedule: "15 18 * * *" # 6.15pm every day
       image: sdshmctspublic.azurecr.io/pre/api:prod-1f6faaa-20251217164440 # {"$imagepolicy": "flux-system:pre-api"}
       environment:
         MEDIA_SERVICE: MediaKind


### PR DESCRIPTION
As part of reverting the enhanced processing (https://github.com/hmcts/sds-flux-config/pull/7719), also revert the process capture sessions job so that it runs at 6:15pm every day again instead of every 5 minutes.

Basically a revert of this one: https://github.com/hmcts/sds-flux-config/pull/7702/files