### PR TITLE
S28-4403 Suspend prod correct capture job

### DIFF
--- a/apps/pre/pre-api-cron-capture-session-status-correction/prod.yaml
+++ b/apps/pre/pre-api-cron-capture-session-status-correction/prod.yaml
@@ -8,7 +8,7 @@ spec:
     global:
       jobKind: CronJob
     job:
-      suspend: false
+      suspend: true
       schedule: "45 11 * * *" # 11:45AM UTC
       image: sdshmctspublic.azurecr.io/pre/api:prod-e6df200-20260105091354 # {"$imagepolicy": "flux-system:pre-api"}
       environment:


### PR DESCRIPTION
### Jira link

S28-4403 - https://tools.hmcts.net/jira/browse/S28-4403

### Change description

Suspend the Correct capture sessions job in prod as the method that updates the capture session does not allow sessions associated with Pending Closure cases to be updated