### PR TITLE
Upgrade dev to fix-forward and unblock teams

### DIFF
--- a/apps/azureserviceoperator-system/dev/base/kustomization.yaml
+++ b/apps/azureserviceoperator-system/dev/base/kustomization.yaml
@@ -1,5 +1,6 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - ../../base
+  - ../../aso
+  - ../../cert-manager
   - aso-controller-settings.yaml


### PR DESCRIPTION
Downgrading caused CRD errors that we can't resolve `"failed to apply CRDs" err="failed to apply CRD`