### PR TITLE
Fixes demo images not updated

### DIFF
--- a/apps/pdda/pdda-public-display-data-aggregator/demo-image-policy.yaml
+++ b/apps/pdda/pdda-public-display-data-aggregator/demo-image-policy.yaml
@@ -4,12 +4,12 @@ metadata:
   name: demo-pdda-public-display-data-aggregator
   annotations:
     hmcts.github.com/prod-automated: disabled
-  spec:
-    filterTags:
-      pattern: '^pr-741-[a-f0-9]+-(?P<ts>[0-9]+)'
-      extract: '$ts'
-    policy:
-      alphabetical:
-        order: asc
-    imageRepositoryRef:
-      name: pdda-public-display-data-aggregator
+spec:
+  filterTags:
+    pattern: '^pr-741-[a-f0-9]+-(?P<ts>[0-9]+)'
+    extract: '$ts'
+  policy:
+    alphabetical:
+      order: asc
+  imageRepositoryRef:
+    name: pdda-public-display-data-aggregator


### PR DESCRIPTION
Found by looking at image policy not being updated on aks
Reason for that is broken kustomization of flux-system

showed this error; 
```
 ImagePolicy/flux-system/demo-pdda-public-display-data-aggregator dry-run failed: failed to create typed patch object (flux-system/demo-pdda-public-display-data-aggregator; image.toolkit.fluxcd.io/v1, Kind=ImagePolicy): .metadata.spec: field not declared in schema
```