### PR TITLE
DTSPO-31001 Add FederatedIdentityCredential with custom SA for LibraG…

### DIFF
--- a/apps/met/batch-jobs/batch-jobs-federated-identity-credential.yaml
+++ b/apps/met/batch-jobs/batch-jobs-federated-identity-credential.yaml
@@ -1,0 +1,12 @@
+apiVersion: managedidentity.azure.com/v1api20220131preview
+kind: FederatedIdentityCredential
+metadata:
+  name: libragob-batch-jobs-service-account-${WI_CLUSTER}-fic
+  namespace: met
+spec:
+  owner:
+    name: libragob-${WI_ENVIRONMENT}-mi
+  audiences:
+    - api://AzureADTokenExchange
+  issuer: ${ISSUER_URL}
+  subject: system:serviceaccount:met:libragob-batch-jobs-service-account

--- a/apps/met/test/base/kustomization.yaml
+++ b/apps/met/test/base/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - ../../../rbac/nonprod-role.yaml
   - ../../batch-jobs/batch-jobs-rbac.yaml
   - ../../batch-jobs/batch-jobs-service-account-test.yaml
+  - ../../batch-jobs/batch-jobs-federated-identity-credential.yaml
   - ../../batch-jobs/batch-jobs.yaml
   - ../../pod-delete-cron/pod-delete-cron-rbac.yaml
   - ../../pod-delete-cron/pod-delete-cron.yaml


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/DTSPO-31001

### Change description

Automates OIDC issuer URL updates during AKS upgrades to prevent batch job failures.
Previously this credential was manually managed in Azure

This is being tested in Test Env.

### Testing done

This PR only adds to test env will add to prod once confirmed ok on Test Env.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
