### PR TITLE
S28-4915 Update staging pods after staging-only deployments

### DIFF
--- a/apps/pre/pre-api-cron-capture-session-status-correction/stg.yaml
+++ b/apps/pre/pre-api-cron-capture-session-status-correction/stg.yaml
@@ -10,6 +10,6 @@ spec:
     job:
       suspend: false
       schedule: "45 11 * * *" # 11:45AM UTC
-      image: hmctsprod.azurecr.io/pre/api:prod-a438b1d-20260422144342 # {"$imagepolicy": "flux-system:pre-api"}
+      image: hmctsprod.azurecr.io/pre/api:staging-3828519-20260423130354 # {"$imagepolicy": "flux-system:stg-pre-api"}
       environment:
         PLATFORM_ENV_TAG: Staging

--- a/apps/pre/pre-api-cron-check-for-missing-recordings/stg.yaml
+++ b/apps/pre/pre-api-cron-check-for-missing-recordings/stg.yaml
@@ -9,6 +9,6 @@ spec:
       jobKind: CronJob
     job:
       schedule: "15 19 * * *" # 7:15 PM UTC
-      image: hmctsprod.azurecr.io/pre/api:prod-a438b1d-20260422144342 # {"$imagepolicy": "flux-system:pre-api"}
+      image: hmctsprod.azurecr.io/pre/api:staging-3828519-20260423130354 # {"$imagepolicy": "flux-system:stg-pre-api"}
       environment:
         PLATFORM_ENV_TAG: Staging

--- a/apps/pre/pre-api-cron-cleanup-b2c-alternative-emails/stg.yaml
+++ b/apps/pre/pre-api-cron-cleanup-b2c-alternative-emails/stg.yaml
@@ -10,6 +10,6 @@ spec:
     job:
       suspend: false
       schedule: "0 20 * * *"
-      image: hmctsprod.azurecr.io/pre/api:prod-a438b1d-20260422144342 # {"$imagepolicy": "flux-system:pre-api"}
+      image: hmctsprod.azurecr.io/pre/api:staging-3828519-20260423130354 # {"$imagepolicy": "flux-system:stg-pre-api"}
       environment:
         PLATFORM_ENV_TAG: Staging

--- a/apps/pre/pre-api-cron-cleanup-live-events/stg.yaml
+++ b/apps/pre/pre-api-cron-cleanup-live-events/stg.yaml
@@ -9,6 +9,6 @@ spec:
       jobKind: CronJob
     job:
       schedule: "0 18 * * *" # 6pm UTC
-      image: hmctsprod.azurecr.io/pre/api:prod-a438b1d-20260422144342 # {"$imagepolicy": "flux-system:pre-api"}
+      image: hmctsprod.azurecr.io/pre/api:staging-3828519-20260423130354 # {"$imagepolicy": "flux-system:stg-pre-api"}
       environment:
         PLATFORM_ENV_TAG: Staging

--- a/apps/pre/pre-api-cron-cleanup-null-durations/stg.yaml
+++ b/apps/pre/pre-api-cron-cleanup-null-durations/stg.yaml
@@ -10,7 +10,7 @@ spec:
     job:
       suspend: true
       schedule: "0 8 * * Fri"
-      image: hmctsprod.azurecr.io/pre/api:prod-a438b1d-20260422144342 # {"$imagepolicy": "flux-system:pre-api"}
+      image: hmctsprod.azurecr.io/pre/api:staging-3828519-20260423130354 # {"$imagepolicy": "flux-system:stg-pre-api"}
       environment:
         PLATFORM_ENV_TAG: Staging
         ENABLE_NULL_DURATION_UPSERT: true

--- a/apps/pre/pre-api-cron-cleanup-streaming-locators/stg.yaml
+++ b/apps/pre/pre-api-cron-cleanup-streaming-locators/stg.yaml
@@ -9,6 +9,6 @@ spec:
       jobKind: CronJob
     job:
       schedule: "10 18 * * *" # 6:10 PM UTC
-      image: hmctsprod.azurecr.io/pre/api:prod-a438b1d-20260422144342 # {"$imagepolicy": "flux-system:pre-api"}
+      image: hmctsprod.azurecr.io/pre/api:staging-3828519-20260423130354 # {"$imagepolicy": "flux-system:stg-pre-api"}
       environment:
         PLATFORM_ENV_TAG: Staging

--- a/apps/pre/pre-api-cron-close-pending-cases/stg.yaml
+++ b/apps/pre/pre-api-cron-close-pending-cases/stg.yaml
@@ -10,6 +10,6 @@ spec:
     job:
       suspend: false
       schedule: "0 8-19 * * 1-5"
-      image: hmctsprod.azurecr.io/pre/api:prod-a438b1d-20260422144342 # {"$imagepolicy": "flux-system:pre-api"}
+      image: hmctsprod.azurecr.io/pre/api:staging-3828519-20260423130354 # {"$imagepolicy": "flux-system:stg-pre-api"}
       environment:
         PLATFORM_ENV_TAG: Staging

--- a/apps/pre/pre-api-cron-get-scheduled-bookings/stg.yaml
+++ b/apps/pre/pre-api-cron-get-scheduled-bookings/stg.yaml
@@ -10,6 +10,6 @@ spec:
     job:
       suspend: true
       schedule: "*/5 9-18 * * *"
-      image: hmctsprod.azurecr.io/pre/api:prod-a438b1d-20260422144342 # {"$imagepolicy": "flux-system:pre-api"}
+      image: hmctsprod.azurecr.io/pre/api:staging-3828519-20260423130354 # {"$imagepolicy": "flux-system:stg-pre-api"}
       environment:
         PLATFORM_ENV_TAG: Staging

--- a/apps/pre/pre-api-cron-perform-edit-requests/stg.yaml
+++ b/apps/pre/pre-api-cron-perform-edit-requests/stg.yaml
@@ -10,7 +10,7 @@ spec:
     job:
       suspend: false
       schedule: "*/5 * * * *" # every 5 mins
-      image: hmctsprod.azurecr.io/pre/api:prod-a438b1d-20260422144342 # {"$imagepolicy": "flux-system:pre-api"}
+      image: hmctsprod.azurecr.io/pre/api:staging-3828519-20260423130354 # {"$imagepolicy": "flux-system:stg-pre-api"}
       environment:
         PLATFORM_ENV_TAG: Staging
         ENABLE_NEW_EMAIL_SERVICE: true

--- a/apps/pre/pre-api-cron-process-capture-sessions/stg.yaml
+++ b/apps/pre/pre-api-cron-process-capture-sessions/stg.yaml
@@ -10,7 +10,7 @@ spec:
     job:
       suspend: false
       schedule: "* * * * *" # every min to speed up testing efforts
-      image: hmctsprod.azurecr.io/pre/api:prod-a438b1d-20260422144342 # {"$imagepolicy": "flux-system:pre-api"}
+      image: hmctsprod.azurecr.io/pre/api:staging-3828519-20260423130354 # {"$imagepolicy": "flux-system:stg-pre-api"}
       environment:
         PLATFORM_ENV_TAG: Staging
         ENABLE_ENHANCED_PROCESSING: true

--- a/apps/pre/pre-api-cron-start-live-events/stg.yaml
+++ b/apps/pre/pre-api-cron-start-live-events/stg.yaml
@@ -10,6 +10,6 @@ spec:
     job:
       suspend: false
       schedule: "30 7 * * *"
-      image: hmctsprod.azurecr.io/pre/api:prod-a438b1d-20260422144342 # {"$imagepolicy": "flux-system:pre-api"}
+      image: hmctsprod.azurecr.io/pre/api:staging-3828519-20260423130354 # {"$imagepolicy": "flux-system:stg-pre-api"}
       environment:
         PLATFORM_ENV_TAG: Staging

--- a/apps/pre/pre-api-cron-update-alt-email-field/stg.yaml
+++ b/apps/pre/pre-api-cron-update-alt-email-field/stg.yaml
@@ -12,7 +12,7 @@ spec:
       suspend: false
       memoryRequests: "1Gi"
       memoryLimits: "2Gi"
-      image: hmctsprod.azurecr.io/pre/api:prod-a438b1d-20260422144342 # {"$imagepolicy": "flux-system:pre-api"}
+      image: hmctsprod.azurecr.io/pre/api:staging-3828519-20260423130354 # {"$imagepolicy": "flux-system:stg-pre-api"}
       environment:
         PLATFORM_ENV_TAG: Staging
         ENABLE_NEW_EMAIL_SERVICE: true

--- a/apps/pre/pre-api-cron-vodafone-etl-fetch-data/stg.yaml
+++ b/apps/pre/pre-api-cron-vodafone-etl-fetch-data/stg.yaml
@@ -12,7 +12,7 @@ spec:
       suspend: false
       memoryRequests: '1Gi'
       memoryLimits: '2Gi'
-      image: hmctsprod.azurecr.io/pre/api:prod-a438b1d-20260422144342 # {"$imagepolicy": "flux-system:pre-api"}
+      image: hmctsprod.azurecr.io/pre/api:staging-3828519-20260423130354 # {"$imagepolicy": "flux-system:stg-pre-api"}
       environment:
         PLATFORM_ENV_TAG: Staging
         ENABLE_NEW_EMAIL_SERVICE: true

--- a/apps/pre/pre-api-cron-vodafone-etl-migrate-resolved/stg.yaml
+++ b/apps/pre/pre-api-cron-vodafone-etl-migrate-resolved/stg.yaml
@@ -12,7 +12,7 @@ spec:
       suspend: true
       memoryRequests: '1Gi'
       memoryLimits: '2Gi'
-      image: hmctsprod.azurecr.io/pre/api:prod-a438b1d-20260422144342 # {"$imagepolicy": "flux-system:pre-api"}
+      image: hmctsprod.azurecr.io/pre/api:staging-3828519-20260423130354 # {"$imagepolicy": "flux-system:stg-pre-api"}
       environment:
         PLATFORM_ENV_TAG: Staging
         ENABLE_NEW_EMAIL_SERVICE: true

--- a/apps/pre/pre-api-cron-vodafone-etl-post-migration/stg.yaml
+++ b/apps/pre/pre-api-cron-vodafone-etl-post-migration/stg.yaml
@@ -12,7 +12,7 @@ spec:
       suspend: false
       memoryRequests: '1Gi'
       memoryLimits: '2Gi'
-      image: hmctsprod.azurecr.io/pre/api:prod-a438b1d-20260422144342 # {"$imagepolicy": "flux-system:pre-api"}
+      image: hmctsprod.azurecr.io/pre/api:staging-3828519-20260423130354 # {"$imagepolicy": "flux-system:stg-pre-api"}
       environment:
         PLATFORM_ENV_TAG: Staging
         ENABLE_NEW_EMAIL_SERVICE: true

--- a/apps/pre/pre-api-cron-vodafone-etl-process-full/stg.yaml
+++ b/apps/pre/pre-api-cron-vodafone-etl-process-full/stg.yaml
@@ -12,7 +12,7 @@ spec:
       suspend: false
       memoryRequests: '1Gi'
       memoryLimits: '2Gi'
-      image: hmctsprod.azurecr.io/pre/api:prod-a438b1d-20260422144342 # {"$imagepolicy": "flux-system:pre-api"}
+      image: hmctsprod.azurecr.io/pre/api:staging-3828519-20260423130354 # {"$imagepolicy": "flux-system:stg-pre-api"}
       environment:
         PLATFORM_ENV_TAG: Staging
         ENABLE_NEW_EMAIL_SERVICE: true

--- a/apps/pre/pre-api-cron-vodafone-mk-import/stg.yaml
+++ b/apps/pre/pre-api-cron-vodafone-mk-import/stg.yaml
@@ -12,7 +12,7 @@ spec:
       suspend: false
       memoryRequests: '1Gi'
       memoryLimits: '2Gi'
-      image: hmctsprod.azurecr.io/pre/api:prod-a438b1d-20260422144342 # {"$imagepolicy": "flux-system:pre-api"}
+      image: hmctsprod.azurecr.io/pre/api:staging-3828519-20260423130354 # {"$imagepolicy": "flux-system:stg-pre-api"}
       environment:
         PLATFORM_ENV_TAG: Staging
         ENABLE_NEW_EMAIL_SERVICE: true

--- a/apps/pre/pre-api/stg-image-policy.yaml
+++ b/apps/pre/pre-api/stg-image-policy.yaml
@@ -1,0 +1,13 @@
+apiVersion: image.toolkit.fluxcd.io/v1
+kind: ImagePolicy
+metadata:
+  name: stg-pre-api
+spec:
+  filterTags:
+    pattern: "^staging-[a-f0-9]+-(?P<ts>[0-9]+)"
+    extract: "$ts"
+  policy:
+    alphabetical:
+      order: asc
+  imageRepositoryRef:
+    name: pre-api

--- a/apps/pre/pre-api/stg.yaml
+++ b/apps/pre/pre-api/stg.yaml
@@ -10,6 +10,7 @@ spec:
       ingressHost: pre-api.staging.platform.hmcts.net
       memoryRequests: '3Gi'
       memoryLimits: '3Gi'
+      image: hmctsprod.azurecr.io/pre/api:staging-3828519-20260423130354 # {"$imagepolicy": "flux-system:stg-pre-api"}
       environment:
         AZURE_RESOURCE_GROUP: pre-stg
         PLATFORM_ENV_TAG: Staging


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/S28-4915

### Change description
Follow-on from https://github.com/hmcts/pre-api/pull/1409

For the updated master pipeline which can now deploy to staging and prod/demo separately, the staging pods are not actually updated when the deployment is to staging only. This PR addresses that so that the pods now update.

All `stg.yamls` should now use the same image:

`image: hmctsprod.azurecr.io/pre/api:staging-3828519-20260423130354 # {"$imagepolicy": "flux-system:stg-pre-api"}`