### PR TITLE
Decommision monitoring/cveinfo from ptl

### DIFF
--- a/apps/monitoring/ptl/base/kustomization.yaml
+++ b/apps/monitoring/ptl/base/kustomization.yaml
@@ -5,4 +5,3 @@ resources:
 - ../../base
 - prometheus-values.yaml
 - prometheus-values.enc.yaml
-- ../../cveinfo


### PR DESCRIPTION
### Change description

- Monitoring/cveinfo is an in-house scheduled job which stores info on cve's flagged on tickets in an internal security JIRA board to cosmos DB
- This was thought to be useful but since 'splunk security team' was superseeded the JIRA ticket format changed so this is no longer useful
- Decom from PTL (will clean cosmos db table manually)  


### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change