### PR TITLE
S28-4704 Add PRE re-encode recordings cron

### DIFF
--- a/apps/pre/demo/base/kustomization.yaml
+++ b/apps/pre/demo/base/kustomization.yaml
@@ -21,6 +21,7 @@ resources:
   - ../../pre-api-cron-vodafone-mk-import/pre-api-cron-vodafone-mk-import.yaml
   - ../../pre-api-cron-capture-session-status-correction/pre-api-cron-capture-session-status-correction.yaml
   - ../../pre-api-cron-update-alt-email-field/pre-api-cron-update-alt-email-field.yaml
+  - ../../pre-api-cron-re-encode-recordings/pre-api-cron-re-encode-recordings.yaml
 
 namespace: pre
 patches:
@@ -44,4 +45,5 @@ patches:
   - path: ../../pre-api-cron-vodafone-mk-import/demo.yaml
   - path: ../../pre-api-cron-capture-session-status-correction/demo.yaml
   - path: ../../pre-api-cron-update-alt-email-field/demo.yaml
+  - path: ../../pre-api-cron-re-encode-recordings/demo.yaml
   - path: ../../serviceaccount/demo.yaml

--- a/apps/pre/pre-api-cron-re-encode-recordings/demo.yaml
+++ b/apps/pre/pre-api-cron-re-encode-recordings/demo.yaml
@@ -1,0 +1,18 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: pre-api-cron-re-encode-recordings
+  namespace: pre
+spec:
+  values:
+    global:
+      jobKind: CronJob
+    job:
+      schedule: "0 13 12 5 *" # 2pm BST - 12 May
+      suspend: true
+      memoryRequests: "1Gi"
+      memoryLimits: "2Gi"
+      image: hmctsprod.azurecr.io/pre/api:prod-c9770fd-20260427140842 # {"$imagepolicy": "flux-system:pre-api"}
+      environment:
+        PLATFORM_ENV_TAG: Demo
+        REENCODE_RECORDINGS_FORCE: "false"

--- a/apps/pre/pre-api-cron-re-encode-recordings/pre-api-cron-re-encode-recordings.yaml
+++ b/apps/pre/pre-api-cron-re-encode-recordings/pre-api-cron-re-encode-recordings.yaml
@@ -1,0 +1,23 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: pre-api-cron-re-encode-recordings
+  namespace: pre
+spec:
+  releaseName: pre-api-cron-re-encode-recordings
+  values:
+    java:
+      enabled: false
+    job:
+      enabled: true
+      environment:
+        TASK_NAME: ReEncodeRecordingsFromCsv
+        REENCODE_RECORDINGS_CSV_PATH: classpath:re-encode-recordings.csv
+  chart:
+    spec:
+      chart: ./stable/pre-api
+      sourceRef:
+        kind: GitRepository
+        name: hmcts-charts
+        namespace: flux-system
+      interval: 1m

--- a/apps/pre/pre-api-cron-re-encode-recordings/prod.yaml
+++ b/apps/pre/pre-api-cron-re-encode-recordings/prod.yaml
@@ -1,0 +1,19 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: pre-api-cron-re-encode-recordings
+  namespace: pre
+spec:
+  values:
+    global:
+      jobKind: CronJob
+    job:
+      schedule: "0 13 12 5 *" # 2pm BST - 12 May
+      suspend: true
+      disableActiveClusterCheck: true
+      memoryRequests: "1Gi"
+      memoryLimits: "2Gi"
+      image: hmctsprod.azurecr.io/pre/api:prod-c9770fd-20260427140842 # {"$imagepolicy": "flux-system:pre-api"}
+      environment:
+        PLATFORM_ENV_TAG: Production
+        REENCODE_RECORDINGS_FORCE: "false"

--- a/apps/pre/pre-api-cron-re-encode-recordings/stg.yaml
+++ b/apps/pre/pre-api-cron-re-encode-recordings/stg.yaml
@@ -1,0 +1,18 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: pre-api-cron-re-encode-recordings
+  namespace: pre
+spec:
+  values:
+    global:
+      jobKind: CronJob
+    job:
+      schedule: "0 13 12 5 *" # 2pm BST - 12 May
+      suspend: false
+      memoryRequests: "1Gi"
+      memoryLimits: "2Gi"
+      image: hmctsprod.azurecr.io/pre/api:staging-fa53a33-20260511145238 # {"$imagepolicy": "flux-system:stg-pre-api"}
+      environment:
+        PLATFORM_ENV_TAG: Staging
+        REENCODE_RECORDINGS_FORCE: "false"

--- a/apps/pre/pre-api-cron-re-encode-recordings/test.yaml
+++ b/apps/pre/pre-api-cron-re-encode-recordings/test.yaml
@@ -1,0 +1,18 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: pre-api-cron-re-encode-recordings
+  namespace: pre
+spec:
+  values:
+    global:
+      jobKind: CronJob
+    job:
+      schedule: "0 13 12 5 *" # 2pm BST - 12 May
+      suspend: true
+      memoryRequests: "1Gi"
+      memoryLimits: "2Gi"
+      image: hmctsprod.azurecr.io/pre/api:prod-c9770fd-20260427140842 # {"$imagepolicy": "flux-system:pre-api"}
+      environment:
+        PLATFORM_ENV_TAG: Testing
+        REENCODE_RECORDINGS_FORCE: "false"

--- a/apps/pre/prod/base/kustomization.yaml
+++ b/apps/pre/prod/base/kustomization.yaml
@@ -19,6 +19,7 @@ resources:
   - ../../pre-api-cron-vodafone-mk-import/pre-api-cron-vodafone-mk-import.yaml
   - ../../pre-api-cron-update-alt-email-field/pre-api-cron-update-alt-email-field.yaml
   - ../../pre-api-cron-capture-session-status-correction/pre-api-cron-capture-session-status-correction.yaml
+  - ../../pre-api-cron-re-encode-recordings/pre-api-cron-re-encode-recordings.yaml
   - ../../../base/slack-provider/prod
   - ../../../rbac/db-query-job-role.yaml
 namespace: pre
@@ -43,4 +44,5 @@ patches:
   - path: ../../pre-api-cron-vodafone-mk-import/prod.yaml
   - path: ../../pre-api-cron-update-alt-email-field/prod.yaml
   - path: ../../pre-api-cron-capture-session-status-correction/prod.yaml
+  - path: ../../pre-api-cron-re-encode-recordings/prod.yaml
   - path: ../../serviceaccount/prod.yaml

--- a/apps/pre/stg/base/kustomization.yaml
+++ b/apps/pre/stg/base/kustomization.yaml
@@ -19,6 +19,7 @@ resources:
   - ../../pre-api-cron-vodafone-mk-import/pre-api-cron-vodafone-mk-import.yaml
   - ../../pre-api-cron-capture-session-status-correction/pre-api-cron-capture-session-status-correction.yaml
   - ../../pre-api-cron-update-alt-email-field/pre-api-cron-update-alt-email-field.yaml
+  - ../../pre-api-cron-re-encode-recordings/pre-api-cron-re-encode-recordings.yaml
   - ../../../rbac/nonprod-role.yaml
   - ../../../base/slack-provider/stg
 namespace: pre
@@ -43,4 +44,5 @@ patches:
   - path: ../../pre-api-cron-vodafone-mk-import/stg.yaml
   - path: ../../pre-api-cron-capture-session-status-correction/stg.yaml
   - path: ../../pre-api-cron-update-alt-email-field/stg.yaml
+  - path: ../../pre-api-cron-re-encode-recordings/stg.yaml
   - path: ../../serviceaccount/stg.yaml

--- a/apps/pre/test/base/kustomization.yaml
+++ b/apps/pre/test/base/kustomization.yaml
@@ -18,6 +18,7 @@ resources:
   - ../../pre-api-cron-cleanup-b2c-alternative-emails/pre-api-cron-cleanup-b2c-alternative-emails.yaml
   - ../../pre-api-cron-vodafone-mk-import/pre-api-cron-vodafone-mk-import.yaml
   - ../../pre-api-cron-update-alt-email-field/pre-api-cron-update-alt-email-field.yaml
+  - ../../pre-api-cron-re-encode-recordings/pre-api-cron-re-encode-recordings.yaml
   - ../../../rbac/nonprod-role.yaml
   - ../../../base/slack-provider/test
 namespace: pre
@@ -41,4 +42,5 @@ patches:
   - path: ../../pre-api-cron-cleanup-b2c-alternative-emails/test.yaml
   - path: ../../pre-api-cron-vodafone-mk-import/test.yaml
   - path: ../../pre-api-cron-update-alt-email-field/test.yaml
+  - path: ../../pre-api-cron-re-encode-recordings/test.yaml
   - path: ../../serviceaccount/test.yaml


### PR DESCRIPTION
### Change description

- Add PRE re-encode recordings cron HelmRelease configuration for prod, staging, test, and demo.
- Enable the cron only in staging and schedule it for 2pm BST on 12 May.
- Configure the job to run `ReEncodeRecordingsFromCsv` with `REENCODE_RECORDINGS_CSV_PATH=classpath:re-encode-recordings.csv` and duplicate protection left enabled.

### Notes

- This assumes hmcts/pre-api#1443 is merged and the staging pre-api image has been rebuilt with classpath CSV support before the cron runs.

### Validation

- `kubectl kustomize --load-restrictor LoadRestrictionsNone apps/pre/stg/base`
- `kubectl kustomize --load-restrictor LoadRestrictionsNone apps/pre/prod/base`
- `kubectl kustomize --load-restrictor LoadRestrictionsNone apps/pre/test/base`
- `kubectl kustomize --load-restrictor LoadRestrictionsNone apps/pre/demo/base`
