### PR TITLE
S28-4944 Add dedicated re-encode edit request cron

### DIFF
--- a/apps/pre/demo/base/kustomization.yaml
+++ b/apps/pre/demo/base/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - ../../pre-api-cron-check-for-missing-recordings/pre-api-cron-check-for-missing-recordings.yaml
   - ../../pre-api-cron-get-scheduled-bookings/pre-api-cron-get-scheduled-bookings.yaml
   - ../../pre-api-cron-perform-edit-requests/pre-api-cron-perform-edit-requests.yaml
+  - ../../pre-api-cron-perform-re-encode-requests/pre-api-cron-perform-re-encode-requests.yaml
   - ../../pre-api-cron-process-capture-sessions/pre-api-cron-process-capture-sessions.yaml
   - ../../pre-api-cron-start-live-events/pre-api-cron-start-live-events.yaml
   - ../../pre-api-cron-vodafone-etl-fetch-data/pre-api-cron-vodafone-etl-fetch-data.yaml
@@ -34,6 +35,7 @@ patches:
   - path: ../../pre-api-cron-check-for-missing-recordings/demo.yaml
   - path: ../../pre-api-cron-get-scheduled-bookings/demo.yaml
   - path: ../../pre-api-cron-perform-edit-requests/demo.yaml
+  - path: ../../pre-api-cron-perform-re-encode-requests/demo.yaml
   - path: ../../pre-api-cron-start-live-events/demo.yaml
   - path: ../../pre-api-cron-vodafone-etl-fetch-data/demo.yaml
   - path: ../../pre-api-cron-vodafone-etl-migrate-resolved/demo.yaml

--- a/apps/pre/pre-api-cron-perform-re-encode-requests/demo.yaml
+++ b/apps/pre/pre-api-cron-perform-re-encode-requests/demo.yaml
@@ -1,0 +1,18 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: pre-api-cron-perform-re-encode-requests
+  namespace: pre
+spec:
+  values:
+    global:
+      jobKind: CronJob
+    job:
+      suspend: true
+      disableActiveClusterCheck: true
+      schedule: "*/5 11-18 * * *" # every 5 mins, noon to 7pm BST
+      image: hmctsprod.azurecr.io/pre/api:prod-fa53a33-20260511145238 # {"$imagepolicy": "flux-system:pre-api"}
+      environment:
+        PLATFORM_ENV_TAG: Demo
+        PORTAL_URL: https://pre-portal.demo.platform.hmcts.net/
+        ENABLE_NEW_EMAIL_SERVICE: true

--- a/apps/pre/pre-api-cron-perform-re-encode-requests/pre-api-cron-perform-re-encode-requests.yaml
+++ b/apps/pre/pre-api-cron-perform-re-encode-requests/pre-api-cron-perform-re-encode-requests.yaml
@@ -1,0 +1,25 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: pre-api-cron-perform-re-encode-requests
+  namespace: pre
+spec:
+  releaseName: pre-api-cron-perform-re-encode-requests
+  values:
+    java:
+      enabled: false
+    job:
+      enabled: true
+      memoryRequests: '7Gi'
+      memoryLimits: '7Gi'
+      environment:
+        TASK_NAME: PerformEditRequest
+        PERFORM_EDIT_REQUEST_REENCODE_ONLY: true
+  chart:
+    spec:
+      chart: ./stable/pre-api
+      sourceRef:
+        kind: GitRepository
+        name: hmcts-charts
+        namespace: flux-system
+      interval: 1m

--- a/apps/pre/pre-api-cron-perform-re-encode-requests/prod.yaml
+++ b/apps/pre/pre-api-cron-perform-re-encode-requests/prod.yaml
@@ -1,0 +1,18 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: pre-api-cron-perform-re-encode-requests
+  namespace: pre
+spec:
+  values:
+    global:
+      jobKind: CronJob
+    job:
+      suspend: true
+      disableActiveClusterCheck: true
+      schedule: "*/5 11-18 * * *" # every 5 mins, noon to 7pm BST
+      image: hmctsprod.azurecr.io/pre/api:prod-fa53a33-20260511145238 # {"$imagepolicy": "flux-system:pre-api"}
+      environment:
+        PLATFORM_ENV_TAG: Production
+        PORTAL_URL: https://portal.pre-recorded-evidence.justice.gov.uk/
+        ENABLE_NEW_EMAIL_SERVICE: true

--- a/apps/pre/pre-api-cron-perform-re-encode-requests/stg.yaml
+++ b/apps/pre/pre-api-cron-perform-re-encode-requests/stg.yaml
@@ -1,0 +1,16 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: pre-api-cron-perform-re-encode-requests
+  namespace: pre
+spec:
+  values:
+    global:
+      jobKind: CronJob
+    job:
+      suspend: false
+      schedule: "*/5 11-18 * * *" # every 5 mins, noon to 7pm BST
+      image: hmctsprod.azurecr.io/pre/api:staging-4d3957a-20260513090617 # {"$imagepolicy": "flux-system:stg-pre-api"}
+      environment:
+        PLATFORM_ENV_TAG: Staging
+        ENABLE_NEW_EMAIL_SERVICE: true

--- a/apps/pre/pre-api-cron-perform-re-encode-requests/test.yaml
+++ b/apps/pre/pre-api-cron-perform-re-encode-requests/test.yaml
@@ -1,0 +1,17 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: pre-api-cron-perform-re-encode-requests
+  namespace: pre
+spec:
+  values:
+    global:
+      jobKind: CronJob
+    job:
+      suspend: true
+      schedule: "*/5 11-18 * * *" # every 5 mins, noon to 7pm BST
+      image: hmctsprod.azurecr.io/pre/api:pr-1317
+      environment:
+        PLATFORM_ENV_TAG: Test
+        PORTAL_URL: https://pre-portal.test.platform.hmcts.net/
+        ENABLE_NEW_EMAIL_SERVICE: true

--- a/apps/pre/prod/base/kustomization.yaml
+++ b/apps/pre/prod/base/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - ../../pre-api-cron-check-for-missing-recordings/pre-api-cron-check-for-missing-recordings.yaml
   - ../../pre-api-cron-get-scheduled-bookings/pre-api-cron-get-scheduled-bookings.yaml
   - ../../pre-api-cron-perform-edit-requests/pre-api-cron-perform-edit-requests.yaml
+  - ../../pre-api-cron-perform-re-encode-requests/pre-api-cron-perform-re-encode-requests.yaml
   - ../../pre-api-cron-process-capture-sessions/pre-api-cron-process-capture-sessions.yaml
   - ../../pre-api-cron-start-live-events/pre-api-cron-start-live-events.yaml
   - ../../pre-api-cron-vodafone-etl-fetch-data/pre-api-cron-vodafone-etl-fetch-data.yaml
@@ -33,6 +34,7 @@ patches:
   - path: ../../pre-api-cron-check-for-missing-recordings/prod.yaml
   - path: ../../pre-api-cron-get-scheduled-bookings/prod.yaml
   - path: ../../pre-api-cron-perform-edit-requests/prod.yaml
+  - path: ../../pre-api-cron-perform-re-encode-requests/prod.yaml
   - path: ../../pre-api-cron-process-capture-sessions/prod.yaml
   - path: ../../pre-api-cron-start-live-events/prod.yaml
   - path: ../../pre-api-cron-vodafone-etl-fetch-data/prod.yaml

--- a/apps/pre/stg/base/kustomization.yaml
+++ b/apps/pre/stg/base/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - ../../pre-api-cron-check-for-missing-recordings/pre-api-cron-check-for-missing-recordings.yaml
   - ../../pre-api-cron-get-scheduled-bookings/pre-api-cron-get-scheduled-bookings.yaml
   - ../../pre-api-cron-perform-edit-requests/pre-api-cron-perform-edit-requests.yaml
+  - ../../pre-api-cron-perform-re-encode-requests/pre-api-cron-perform-re-encode-requests.yaml
   - ../../pre-api-cron-process-capture-sessions/pre-api-cron-process-capture-sessions.yaml
   - ../../pre-api-cron-start-live-events/pre-api-cron-start-live-events.yaml
   - ../../pre-api-cron-vodafone-etl-fetch-data/pre-api-cron-vodafone-etl-fetch-data.yaml
@@ -33,6 +34,7 @@ patches:
   - path: ../../pre-api-cron-check-for-missing-recordings/stg.yaml
   - path: ../../pre-api-cron-get-scheduled-bookings/stg.yaml
   - path: ../../pre-api-cron-perform-edit-requests/stg.yaml
+  - path: ../../pre-api-cron-perform-re-encode-requests/stg.yaml
   - path: ../../pre-api-cron-process-capture-sessions/stg.yaml
   - path: ../../pre-api-cron-start-live-events/stg.yaml
   - path: ../../pre-api-cron-vodafone-etl-fetch-data/stg.yaml

--- a/apps/pre/test/base/kustomization.yaml
+++ b/apps/pre/test/base/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - ../../pre-api-cron-check-for-missing-recordings/pre-api-cron-check-for-missing-recordings.yaml
   - ../../pre-api-cron-get-scheduled-bookings/pre-api-cron-get-scheduled-bookings.yaml
   - ../../pre-api-cron-perform-edit-requests/pre-api-cron-perform-edit-requests.yaml
+  - ../../pre-api-cron-perform-re-encode-requests/pre-api-cron-perform-re-encode-requests.yaml
   - ../../pre-api-cron-process-capture-sessions/pre-api-cron-process-capture-sessions.yaml
   - ../../pre-api-cron-start-live-events/pre-api-cron-start-live-events.yaml
   - ../../pre-api-cron-vodafone-etl-fetch-data/pre-api-cron-vodafone-etl-fetch-data.yaml
@@ -32,6 +33,7 @@ patches:
   - path: ../../pre-api-cron-check-for-missing-recordings/test.yaml
   - path: ../../pre-api-cron-get-scheduled-bookings/test.yaml
   - path: ../../pre-api-cron-perform-edit-requests/test.yaml
+  - path: ../../pre-api-cron-perform-re-encode-requests/test.yaml
   - path: ../../pre-api-cron-process-capture-sessions/test.yaml
   - path: ../../pre-api-cron-start-live-events/test.yaml
   - path: ../../pre-api-cron-vodafone-etl-fetch-data/prod.yaml


### PR DESCRIPTION
### Change description

- Add a dedicated PRE re-encode edit request processor cron using `TASK_NAME=PerformEditRequest`.
- Set `PERFORM_EDIT_REQUEST_REENCODE_ONLY=true` so it only processes force re-encode edit requests.
- Enable the cron in staging every 5 minutes from noon to 7pm BST, with prod/test/demo configured but suspended.

### Dependency

- Depends on https://github.com/hmcts/pre-api/pull/1444 being merged and deployed to staging first.
