### PR TITLE
S28-4944 Enable prod re-encode edit cron

### DIFF
--- a/apps/pre/pre-api-cron-perform-re-encode-requests/prod.yaml
+++ b/apps/pre/pre-api-cron-perform-re-encode-requests/prod.yaml
@@ -8,9 +8,9 @@ spec:
     global:
       jobKind: CronJob
     job:
-      suspend: true
+      suspend: false
       disableActiveClusterCheck: true
-      schedule: "*/5 11-18 * * *" # every 5 mins, noon to 7pm BST
+      schedule: "2-59/5 * * * *" # every 5 mins, offset from regular edit processing
       image: hmctsprod.azurecr.io/pre/api:prod-36d92e3-20260513131910 # {"$imagepolicy": "flux-system:pre-api"}
       environment:
         PLATFORM_ENV_TAG: Production


### PR DESCRIPTION
### Change description

- Enable the PRE re-encode edit request processor cron in production.
- Run it every 5 minutes using an offset schedule so it does not start at the same minute as the regular edit processor.
- Keep `PERFORM_EDIT_REQUEST_REENCODE_ONLY=true` so this cron only processes force re-encode edit requests.

### Context

- The regular edit processor runs on `*/5 * * * *`.
- This re-encode processor now runs on `2-59/5 * * * *`.

### Validation

- `kubectl kustomize --load-restrictor LoadRestrictionsNone apps/pre/prod/base`
