### PR TITLE
S28-4945 Enforce active cluster check for re-encode cron

### DIFF
--- a/apps/pre/pre-api-cron-re-encode-recordings/demo.yaml
+++ b/apps/pre/pre-api-cron-re-encode-recordings/demo.yaml
@@ -10,6 +10,7 @@ spec:
     job:
       schedule: "0 13 12 5 *" # 2pm BST - 12 May
       suspend: true
+      disableActiveClusterCheck: false
       memoryRequests: "1Gi"
       memoryLimits: "2Gi"
       image: hmctsprod.azurecr.io/pre/api:prod-04b6ae7-20260518122109 # {"$imagepolicy": "flux-system:pre-api"}

--- a/apps/pre/pre-api-cron-re-encode-recordings/prod.yaml
+++ b/apps/pre/pre-api-cron-re-encode-recordings/prod.yaml
@@ -10,7 +10,7 @@ spec:
     job:
       schedule: "30 19-23 * * *" # Run hourly from 7pm to midnight
       suspend: false
-      disableActiveClusterCheck: true
+      disableActiveClusterCheck: false
       memoryRequests: "1Gi"
       memoryLimits: "2Gi"
       image: hmctsprod.azurecr.io/pre/api:prod-04b6ae7-20260518122109 # {"$imagepolicy": "flux-system:pre-api"}

--- a/apps/pre/pre-api-cron-re-encode-recordings/prod.yaml
+++ b/apps/pre/pre-api-cron-re-encode-recordings/prod.yaml
@@ -8,7 +8,7 @@ spec:
     global:
       jobKind: CronJob
     job:
-      schedule: "30 19-23 * * *" # Run hourly from 7pm to midnight
+      schedule: "30 * * * *" # Run hourly
       suspend: false
       disableActiveClusterCheck: false
       memoryRequests: "1Gi"

--- a/apps/pre/pre-api-cron-re-encode-recordings/stg.yaml
+++ b/apps/pre/pre-api-cron-re-encode-recordings/stg.yaml
@@ -10,6 +10,7 @@ spec:
     job:
       schedule: "30 10 14 5 *" # 11.30pm BST - 14 May
       suspend: false
+      disableActiveClusterCheck: false
       memoryRequests: "1Gi"
       memoryLimits: "2Gi"
       image: hmctsprod.azurecr.io/pre/api:staging-834b01b-20260518135319 # {"$imagepolicy": "flux-system:stg-pre-api"}

--- a/apps/pre/pre-api-cron-re-encode-recordings/test.yaml
+++ b/apps/pre/pre-api-cron-re-encode-recordings/test.yaml
@@ -10,6 +10,7 @@ spec:
     job:
       schedule: "0 13 12 5 *" # 2pm BST - 12 May
       suspend: true
+      disableActiveClusterCheck: false
       memoryRequests: "1Gi"
       memoryLimits: "2Gi"
       image: hmctsprod.azurecr.io/pre/api:prod-04b6ae7-20260518122109 # {"$imagepolicy": "flux-system:pre-api"}


### PR DESCRIPTION
## What changed
- Set disableActiveClusterCheck to false for the PRE re-encode recordings cron in demo, prod, stg, and test overlays.
- Prod previously bypassed the active cluster guard, allowing the cron to run in both prod clusters.

## Why
The re-encode submission cron should only run on the active cron cluster. Running it in more than one cluster can submit duplicate re-encode edit requests from the same CSV.

## Validation
- Parsed the updated YAML overlays successfully.
- Confirmed all re-encode recording cron overlays now set disableActiveClusterCheck: false.