### PR TITLE
S28-4945 Align stg re-encode crons with prod

### DIFF
--- a/apps/pre/pre-api-cron-perform-re-encode-requests/stg.yaml
+++ b/apps/pre/pre-api-cron-perform-re-encode-requests/stg.yaml
@@ -9,7 +9,8 @@ spec:
       jobKind: CronJob
     job:
       suspend: false
-      schedule: "*/5 11-18 * * *" # every 5 mins, noon to 7pm BST
+      disableActiveClusterCheck: true
+      schedule: "2-59/5 * * * *" # every 5 mins, offset from regular edit processing
       image: hmctsprod.azurecr.io/pre/api:staging-e5db5b6-20260519123751 # {"$imagepolicy": "flux-system:stg-pre-api"}
       environment:
         PLATFORM_ENV_TAG: Staging

--- a/apps/pre/pre-api-cron-re-encode-recordings/stg.yaml
+++ b/apps/pre/pre-api-cron-re-encode-recordings/stg.yaml
@@ -8,7 +8,7 @@ spec:
     global:
       jobKind: CronJob
     job:
-      schedule: "30 10 14 5 *" # 11.30pm BST - 14 May
+      schedule: "30 * * * *" # Run hourly
       suspend: false
       disableActiveClusterCheck: false
       memoryRequests: "1Gi"


### PR DESCRIPTION
## Summary
- set the stg re-encode CSV cron to run hourly at :30, matching prod
- set the stg re-encode processor cron to run every five minutes all day with the same offset as prod
- enable the same active-cluster bypass setting for the stg re-encode processor as prod
