### PR TITLE
Revert "chore: test new dsl job with stricter org scanning"

### DIFF
--- a/apps/jenkins/jenkins/ptlsbox/jenkins.yaml
+++ b/apps/jenkins/jenkins/ptlsbox/jenkins.yaml
@@ -33,9 +33,6 @@ spec:
             tag: 1.30.9
       JCasC:
         configScripts:
-          jobs: |
-            jobs:
-              - url: https://raw.githubusercontent.com/hmcts/sds-jenkins-config/feat/DTSPO-30152-update-dsl-job/jobdsl/organisations-beta.groovy
           welcome-message: |
             jenkins:
               systemMessage: >-


### PR DESCRIPTION
Reverts hmcts/sds-flux-config#8505

- Testing completed so no longer required