### PR TITLE
Dynatrace - reduce apiThreshold to 7mins from default 15 for demo

### DIFF
--- a/apps/dynatrace/demo/base/dynakube/dynakube.yaml
+++ b/apps/dynatrace/demo/base/dynakube/dynakube.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: dynatrace
 spec:
   apiUrl: https://yrk32651.live.dynatrace.com/api
+  dynatraceApiRequestThreshold: 7
   oneAgent:
     cloudNativeFullStack:
       annotations:


### PR DESCRIPTION
### Change description

- Louise Churchouse has been working with Dynatrace support to solve false-flag problems in Dynatrace when a node is deleted from the cluster
- Operator performs node reconciliation every 15 minutes by default, this could cause a conflict between the operator and the Dynatrace cluster, which is a theory for now. 
- Dynatrace support has suggested if we can reduce the operator reconciliation time to 7 minutes
- Testing first in demo
- [docs](https://docs.dynatrace.com/docs/ingest-from/setup-on-k8s/reference/dynakube-parameters#api-versions--v1beta5)
### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
