### PR TITLE
PRE prod re-encode requests cron schedule

### DIFF
--- a/apps/pre/pre-api-cron-perform-re-encode-requests/prod.yaml
+++ b/apps/pre/pre-api-cron-perform-re-encode-requests/prod.yaml
@@ -10,7 +10,7 @@ spec:
     job:
       suspend: false
       disableActiveClusterCheck: true
-      schedule: "2-59/5 * * * *" # every 5 mins, offset from regular edit processing
+      schedule: "2-59/5 0-4,18-23 * * *" # every 5 mins, offset by 2 minutes between 6pm UTC and 5am UTC
       image: hmctsprod.azurecr.io/pre/api:prod-33e6ead-20260610105225 # {"$imagepolicy": "flux-system:pre-api"}
       environment:
         PLATFORM_ENV_TAG: Production


### PR DESCRIPTION
Change prod re-encoding processing to run every 5 mins, offset by 2 minutes, between 6pm UTC and 5am UTC