### PR TITLE
Restrict perform edit requests prod cron

### DIFF
--- a/apps/pre/pre-api-cron-perform-edit-requests/prod.yaml
+++ b/apps/pre/pre-api-cron-perform-edit-requests/prod.yaml
@@ -10,7 +10,7 @@ spec:
     job:
       suspend: false
       disableActiveClusterCheck: true
-      schedule: "*/5 * * * *" # every 5 mins
+      schedule: "*/5 * * * 0-4" # every 5 mins, Sunday to Thursday
       image: hmctsprod.azurecr.io/pre/api:prod-510db7f-20260617111051 # {"$imagepolicy": "flux-system:pre-api"}
       environment:
         PORTAL_URL: https://portal.pre-recorded-evidence.justice.gov.uk/


### PR DESCRIPTION
## Summary
- restrict the PRE perform edit requests production cron to Sunday through Thursday
- keep the existing every-5-minutes cadence on those days