### PR TITLE
Patch for stg to use helm3 defaults instead of helm4

### DIFF
--- a/apps/flux-system/base/patches/helm-controller-helm3-defaults-patch.yaml
+++ b/apps/flux-system/base/patches/helm-controller-helm3-defaults-patch.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: helm-controller
+  namespace: flux-system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        args:
+        - --events-addr=http://notification-controller.$(RUNTIME_NAMESPACE).svc.cluster.local./
+        - --watch-all-namespaces=true
+        - --log-level=info
+        - --log-encoding=json
+        - --enable-leader-election
+        - --feature-gates=UseHelm3Defaults=true

--- a/clusters/stg/00/kustomization.yaml
+++ b/clusters/stg/00/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
 
 patches:
   - path: ../../../apps/flux-system/stg/00/kustomize.yaml
+  - path: ../../../apps/flux-system/base/patches/helm-controller-helm3-defaults-patch.yaml


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-33272

### Change description

Patch flux fixes to use helm3 as default for aat.

### Testing done

This is already tested on sbox.

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
