### PR TITLE
ARCPOC-1472 - added flux test env config

### DIFF
--- a/apps/appreg/appreg-api/test.yaml
+++ b/apps/appreg/appreg-api/test.yaml
@@ -1,0 +1,14 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: appreg-api
+  namespace: appreg
+spec:
+  releaseName: appreg-api
+  values:
+    java:
+      ingressHost: appreg-api.perftest.platform.hmcts.net
+      image: hmctsprod.azurecr.io/appreg/api:prod-42869ef-20260708153633 # {"$imagepolicy": "flux-system:appreg-api"}
+      environment:
+        ENV_NAME: "PERFTEST"
+        LOG_LEVEL: "DEBUG"

--- a/apps/appreg/appreg-frontend/test.yaml
+++ b/apps/appreg/appreg-frontend/test.yaml
@@ -1,0 +1,14 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: appreg-frontend
+  namespace: appreg
+spec:
+  releaseName: appreg-frontend
+  values:
+    nodejs:
+      ingressHost: appreg.test.apps.hmcts.net
+      image: hmctsprod.azurecr.io/appreg/frontend:prod-dee8814-20260709000922 # {"$imagepolicy": "flux-system:appreg-frontend"}
+      environment:
+        ENV_NAME: "PERFTEST"
+        LOG_LEVEL: "DEBUG"

--- a/apps/appreg/serviceaccount/test.yaml
+++ b/apps/appreg/serviceaccount/test.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ${NAMESPACE}
+  namespace: ${NAMESPACE}
+  annotations:
+    azure.workload.identity/client-id: "4a863f94-5813-4294-9fab-b2a0013373f6"

--- a/apps/appreg/test/base/kustomization.yaml
+++ b/apps/appreg/test/base/kustomization.yaml
@@ -4,3 +4,7 @@ resources:
   - ../../base
   - ../../../rbac/nonprod-role.yaml
 namespace: appreg
+patches:
+  - path: ../../serviceaccount/test.yaml
+  - path: ../../appreg-api/test.yaml
+  - path: ../../appreg-frontend/test.yaml


### PR DESCRIPTION
### Jira link

See [ARCPOC-1472](https://tools.hmcts.net/jira/browse/ARCPOC-1472)

### Change description
This change adds test environment support for the appreg namespace in Flux.
It creates test-specific overrides for appreg-api, appreg-frontend, and the namespace service account, then wires those patches into the apps/appreg/test/base kustomization.