### PR TITLE
ARCPOC-1472 - Configure AppReg Perf test environment

### DIFF
--- a/apps/appreg/appreg-api/test.yaml
+++ b/apps/appreg/appreg-api/test.yaml
@@ -7,7 +7,7 @@ spec:
   releaseName: appreg-api
   values:
     java:
-      ingressHost: appreg-api.perftest.platform.hmcts.net
+      ingressHost: appreg-api.test.platform.hmcts.net
       image: hmctsprod.azurecr.io/appreg/api:prod-ecfb387-20260716122438 # {"$imagepolicy": "flux-system:appreg-api"}
       environment:
         ENV_NAME: "PERFTEST"

--- a/apps/appreg/appreg-api/test.yaml
+++ b/apps/appreg/appreg-api/test.yaml
@@ -12,3 +12,30 @@ spec:
       environment:
         ENV_NAME: "PERFTEST"
         LOG_LEVEL: "DEBUG"
+      keyVaults:
+        appreg-kv:
+          secrets:
+            - name: AppInsightsInstrumentationKey
+              alias: APP_INSIGHTS_INSTRUMENTATION_KEY
+            - name: app-insights-connection-string
+              alias: app-insights-connection-string
+            - name: POSTGRES-USER
+              alias: POSTGRES_USER
+            - name: POSTGRES-PASS
+              alias: POSTGRES_PASS
+            - name: POSTGRES-HOST
+              alias: POSTGRES_HOST
+            - name: POSTGRES-PORT
+              alias: POSTGRES_PORT
+            - name: POSTGRES-DATABASE
+              alias: POSTGRES_DATABASE
+            - name: azure-tenant-id
+              alias: AZURE_TENANT_ID
+            - name: azure-client-secret
+              alias: azure-client-secret
+            - name: azure-app-id
+              alias: AZURE_AUDIENCE_ID
+            - name: CSDS-KEY-1
+              alias: CSDS_KEY_1
+            - name: CSDS-KEY-2
+              alias: CSDS_KEY_2

--- a/apps/appreg/appreg-api/test.yaml
+++ b/apps/appreg/appreg-api/test.yaml
@@ -11,7 +11,6 @@ spec:
       image: hmctsprod.azurecr.io/appreg/api:prod-ecfb387-20260716122438 # {"$imagepolicy": "flux-system:appreg-api"}
       environment:
         ENV_NAME: "PERFTEST"
-        LOG_LEVEL: "DEBUG"
       keyVaults:
         appreg-kv:
           secrets:

--- a/apps/appreg/appreg-frontend/test.yaml
+++ b/apps/appreg/appreg-frontend/test.yaml
@@ -11,7 +11,6 @@ spec:
       image: hmctsprod.azurecr.io/appreg/frontend:prod-e6304c1-20260716144458 # {"$imagepolicy": "flux-system:appreg-frontend"}
       environment:
         ENV_NAME: "PERFTEST"
-        LOG_LEVEL: "DEBUG"
       keyVaults:
         appreg-kv:
           secrets:

--- a/apps/appreg/appreg-frontend/test.yaml
+++ b/apps/appreg/appreg-frontend/test.yaml
@@ -12,3 +12,30 @@ spec:
       environment:
         ENV_NAME: "PERFTEST"
         LOG_LEVEL: "DEBUG"
+      keyVaults:
+        appreg-kv:
+          secrets:
+            - name: app-insights-connection-string
+              alias: app-insights-connection-string-fe
+            - name: azure-tenant-id
+              alias: azure-tenant-id-fe
+            - name: azure-client-secret
+              alias: azure-client-secret-fe
+            - name: azure-app-id
+              alias: azure-app-id-fe
+            - name: managed-redis-connection-string
+              alias: redis-connection-string
+            - name: test-user1-email
+              alias: TEST-USER1-EMAIL
+            - name: test-user2-email
+              alias: TEST-USER2-EMAIL
+            - name: test-user3-email
+              alias: TEST-USER3-EMAIL
+            - name: test-admin1-email
+              alias: TEST-ADMIN1-EMAIL
+            - name: test-admin2-email
+              alias: TEST-ADMIN2-EMAIL
+            - name: test-admin3-email
+              alias: TEST-ADMIN3-EMAIL
+            - name: test-users-password
+              alias: TEST-USERS-PASSWORD


### PR DESCRIPTION
### Jira link

See [ARCPOC-1472](https://tools.hmcts.net/jira/browse/ARCPOC-1472)

### Change description

Configured the test AppReg API and frontend Helm overlays to use the appreg-kv-test Key Vault.

Corrected the test API ingress host to appreg-api.test.platform.hmcts.net.