### PR TITLE
Enable minimum poolSize and dynamicBuffer in jenkins agents

### DIFF
--- a/apps/jenkins/jenkins/ptl/jenkins-azure-vm-agent.yaml
+++ b/apps/jenkins/jenkins/ptl/jenkins-azure-vm-agent.yaml
@@ -209,8 +209,11 @@ spec:
                       templateDesc: "Jenkins build agents for SDS ptl environment"
                       labels: "ubuntu-ptl"
                       retentionStrategy:
-                        azureVMCloudRetentionStrategy:
-                          idleTerminationMinutes: 5
+                        azureVMCloudPool:
+                          dynamicBufferEnabled: true
+                          bufferPercentage: 10
+                          maximumBuffer: 5
+                          poolSize: 2
                       maxVirtualMachinesLimit: 10
                       usageMode: "EXCLUSIVE"
                       virtualMachineSize: "Standard_D4ds_v5"


### PR DESCRIPTION
### Change description

Setting `poolSize` to ensure a minimum number of agents in the ptl pool
Also setting a buffer to ensure there's always spare ready to go
Testing here as there are more builds before rolling out to cnp

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [x] README and other documentation has been updated / added (if needed)
- [x] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
