### PR TITLE
S28-5068 In prod - show the re-encoded recordings and trigger the soft deletion job

### DIFF
--- a/apps/pre/pre-api-cron-update-recordings-visibility/prod.yaml
+++ b/apps/pre/pre-api-cron-update-recordings-visibility/prod.yaml
@@ -9,5 +9,5 @@ spec:
       jobKind: CronJob
     job:
       suspend: false
-      schedule: "25 16 * * Tue"
+      schedule: "20 16 * * Tue"
       image: hmctsprod.azurecr.io/pre/api:prod-389cd73-20260722110012 # {"$imagepolicy": "flux-system:pre-api"}

--- a/apps/pre/pre-api-cron-update-recordings-visibility/prod.yaml
+++ b/apps/pre/pre-api-cron-update-recordings-visibility/prod.yaml
@@ -9,5 +9,5 @@ spec:
       jobKind: CronJob
     job:
       suspend: false
-      schedule: "30 16 * * Tue"
+      schedule: "25 16 * * Tue"
       image: hmctsprod.azurecr.io/pre/api:prod-389cd73-20260722110012 # {"$imagepolicy": "flux-system:pre-api"}

--- a/apps/pre/pre-api-cron-update-recordings-visibility/prod.yaml
+++ b/apps/pre/pre-api-cron-update-recordings-visibility/prod.yaml
@@ -8,6 +8,6 @@ spec:
     global:
       jobKind: CronJob
     job:
-      suspend: true
-      schedule: "0 19 * * *"
+      suspend: false
+      schedule: "30 16 * * Tue"
       image: hmctsprod.azurecr.io/pre/api:prod-389cd73-20260722110012 # {"$imagepolicy": "flux-system:pre-api"}

--- a/apps/pre/pre-api-cron-update-recordings-visibility/prod.yaml
+++ b/apps/pre/pre-api-cron-update-recordings-visibility/prod.yaml
@@ -9,5 +9,5 @@ spec:
       jobKind: CronJob
     job:
       suspend: false
-      schedule: "20 16 * * Tue"
+      schedule: "25 16 * * Tue"
       image: hmctsprod.azurecr.io/pre/api:prod-16e9428-20260723142346 # {"$imagepolicy": "flux-system:pre-api"}

--- a/apps/pre/pre-api/prod.yaml
+++ b/apps/pre/pre-api/prod.yaml
@@ -22,3 +22,4 @@ spec:
         MEDIA_KIND_STREAMING_ENDPOINT_ADVANCED_SETTINGS_NAME: ap-jitp-hmcts-disable-edge-buffer
         TRIGGER_RESTART: 1
         ENABLE_TERMS_AND_CONDITIONS: true
+        HIDE_REENCODED_RECORDINGS: false


### PR DESCRIPTION
### Jira link
https://tools.hmcts.net/jira/browse/S28-5068

### Change description
- Change HIDE_REENCODED_RECORDINGS to false, so that the re-encoded Vodafone recordings are visible and the original corrupted ones are hidden
- Trigger the soft deletion job to run at 16:30 UTC, which will delete the original corrupted recordings

Await green light before merging this one