### PR TITLE
DTSPO-33801: Fix sandbox Jenkins PR image tag (2.575, not 2.564)

### DIFF
--- a/apps/jenkins/jenkins/ptlsbox/controller-image-pin.yaml
+++ b/apps/jenkins/jenkins/ptlsbox/controller-image-pin.yaml
@@ -11,4 +11,4 @@ spec:
   values:
     controller:
       image:
-        tag: pr-1895-2.564-1777
+        tag: pr-1895-2.575-1777


### PR DESCRIPTION
## Jira
https://tools.hmcts.net/jira/browse/DTSPO-33801

## What
Fixes the image tag pinned in #8773: the CI on hmcts/cnp-jenkins-docker#1895 derives the version from the `FROM jenkins:` line in the Dockerfile on the branch (Jenkins **2.575**), not from the currently deployed controller (2.564). The correct tag is `pr-1895-2.575-1777` — verified present in hmctsprod ACR.

## Current state on ptlsbox
The wrong tag caused `Init:ImagePullBackOff` and Helm rolled back to `2.564-1098` — sandbox Jenkins is unaffected. Merging this triggers the upgrade again with the correct, existing image.