### PR TITLE
DTSPO-33801: Route palo Grafana frontend hostname to ptlsbox Prometheus

### DIFF
--- a/apps/monitoring/kube-prometheus-stack/ptlsbox/00.yaml
+++ b/apps/monitoring/kube-prometheus-stack/ptlsbox/00.yaml
@@ -10,9 +10,12 @@ spec:
       ingress:
         hosts:
           - sds-prometheus-00-ptl.sandbox.platform.hmcts.net
+          # DTSPO-33801: palo frontend for the aat Managed Grafana datasource
+          - firewall-nonprodi-palo-grafanasdsprom.uksouth.cloudapp.azure.com
         tls:
           - hosts:
               - sds-prometheus-00-ptl.sandbox.platform.hmcts.net
+              - firewall-nonprodi-palo-grafanasdsprom.uksouth.cloudapp.azure.com
     alertmanager:
       ingress:
         hosts:


### PR DESCRIPTION
## Jira
https://tools.hmcts.net/jira/browse/DTSPO-33801

## What
Adds `firewall-nonprodi-palo-grafanasdsprom.uksouth.cloudapp.azure.com` as an additional host (and TLS host) on the ptlsbox kube-prometheus-stack Prometheus ingress.

## Why
hmcts/hub-terraform-infra#304 (merged, applied — frontend resolves to 20.58.16.255) created a palo frontend so the **aat Azure Managed Grafana** can reach this Prometheus, replicating the existing Grafana→PostgreSQL pattern. Traffic arrives at traefik under the firewall's cloudapp hostname; traefik routes by Host, so the ingress must also answer on that name. (`sandbox.platform.hmcts.net` has no public DNS zone, so the same-hostname split-horizon approach isn't available here.)

Access via the frontend is restricted at the firewall to the aat Managed Grafana's two egress IPs.
