### PR TITLE
DTSPO-34168 DTSPO-34169: explicitly clear persisted disabledMetricConfig

### DIFF
--- a/apps/jenkins/jenkins/ptlsbox/controller-prometheus.yaml
+++ b/apps/jenkins/jenkins/ptlsbox/controller-prometheus.yaml
@@ -43,3 +43,10 @@ spec:
                 appendParamLabel: false
                 appendStatusLabel: false
                 processingDisabledBuilds: false
+                # Must be declared EXPLICITLY EMPTY: JCasC does not reset
+                # attributes that are simply removed from the YAML, and the
+                # previous trim regex (default_jenkins_builds_.*) is persisted
+                # in the controller's config XML — without this block it stays
+                # active and keeps suppressing all builds_* metrics.
+                disabledMetricConfig:
+                  entries: []


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-34168

### Change description

PR #8840 removed the disabledMetricConfig block from the JCasC YAML, but JCasC does not reset attributes that are absent from the file — the previously applied trim regex (default_jenkins_builds_.*) is persisted in the controller's PrometheusConfiguration.xml and remains active (verified on jenkins-0: perBuildMetrics/count flags applied, but the regex entry survived). As a result all default_jenkins_builds_* families, including the per-run stage/pipeline duration metrics for DTSPO-34168/34169, are still suppressed.

Declaring disabledMetricConfig with an explicit empty entries list forces JCasC to overwrite the persisted value.


### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behaviour remains the same.
-->

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [ ] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [ ] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
