### PR TITLE
DTSPO-33733 - removing devops agents from Flux for DR testing

### DIFF
--- a/clusters/sbox/base/kustomization.yaml
+++ b/clusters/sbox/base/kustomization.yaml
@@ -3,7 +3,7 @@ kind: Kustomization
 resources:
   - ../../../apps/flux-system/sbox/base
   - ../../../apps/toffee/base/kustomize.yaml
-  - ../../../apps/azure-devops/base/kustomize.yaml
+  # - ../../../apps/azure-devops/base/kustomize.yaml
   # - ../../../apps/mi/base/kustomize.yaml
   - ../../../apps/monitoring/base/kustomize.yaml
   - ../../../apps/admin/base/kustomize.yaml


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-33733

### Change description

- Temporarily removing the CNP DevOps Agents from the `ptlsbox` cluster to verify they can be restored via Flux.
- It will be reverted shortly after with the Agent pods being recreated by Flux on revert.
- Testing the following runbook - https://turbo-lamp-2q21n6z.pages.github.io/domains/developer-enablement/devops-agent-recovery.html#devops-agents-recovery-cnp

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is not always complete, so a successful pull request build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behaviour remains the same.
-->

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
