### PR TITLE
DTSPO-33747 - test drift detection to resolve auto recreation of configmap

### DIFF
--- a/apps/jenkins/jenkins/ptlsbox/jenkins.yaml
+++ b/apps/jenkins/jenkins/ptlsbox/jenkins.yaml
@@ -5,6 +5,8 @@ metadata:
   name: jenkins
   namespace: jenkins
 spec:
+  driftDetection:
+    mode: enabled
   values:
     controller:
       # image version is managed in jenkins-controller-version.yaml


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-33747

### Change description
- An issue cropped up during the deletion stage of this DR test where I removed the jenkins-jenkins-config-azure-vm-agent ConfigMap from the AKS cluster.
- The issue was that when the ConfigMap was removed, it was not recreated automatically across two full HelmRelease reconcile intervals.
- Drift detection was not configured on the HelmRelease, so helm-controller found the release already at the desired chart version and took no action. The platform appeared completely healthy even though the ConfigMap was deleted.
- I had to manually reconcile the ConfigMap via - `flux reconcile helmrelease jenkins -n jenkins --force`
- This PR enables `driftDetection.mode: enabled` on the Jenkins HelmRelease, which should hopefully detect the ConfigMap missing from the live cluster vs. the chart's desired manifest and recreate it automatically on the next reconcile, so no manual `flux reconcile --force` is needed.

### Testing done

- Currently only adding `driftDetection` to the **ptlsbox** for now
- Plan to rerun the test by deleting the ConfigMap again and confirming that automatic recreation works, without a manual force-reconcile.

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
