### PR TITLE
DTSPO-33747 - add drift detection to sds ptl

### DIFF
--- a/apps/jenkins/jenkins/ptl/jenkins.yaml
+++ b/apps/jenkins/jenkins/ptl/jenkins.yaml
@@ -5,6 +5,8 @@ metadata:
   name: jenkins
   namespace: jenkins
 spec:
+  driftDetection:
+    mode: enabled
   values:
     controller:
       # image version is managed in jenkins-controller-version.yaml


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-33747

### Change description

- Follow on from the sandbox rollout
- Adding `driftDetection.mode: enabled` to SDS PTL
- Flux only reconciles when git changes so if a Helm-managed object is deleted or edited on the cluster, nothing reconciles it. 
- During DR testing I found that a deleted Jenkins agent ConfigMap stayed missing and needed a manual `flux reconcile --force` to recover.

### Testing done

- Tested on ptlsbox 
- Deleted the agent ConfigMap, recreated automatically in around 3 minutes with no manual reconcile. 
- Jenkins controller was not restarted.

### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [ ] Yes
  * [x] No

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
